### PR TITLE
karapace: fix return fields for schema check endpoint

### DIFF
--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -450,7 +450,13 @@ class Karapace(RestApp):
         new_schema_encoded = json_encode(new_schema.to_json(), compact=True)
         for schema in subject_data["schemas"].values():
             if schema["schema"] == new_schema_encoded:
-                self.r(schema, content_type)
+                ret = {
+                    "subject": subject,
+                    "version": schema["version"],
+                    "id": schema["id"],
+                    "schema": schema["schema"],
+                }
+                self.r(ret, content_type)
         self.r({"error_code": 40403, "message": "Schema not found"}, content_type, status=404)
 
     async def subject_post(self, content_type, *, subject, request):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -789,7 +789,7 @@ async def schema_checks(c):
         json={"schema": '{"type": "string"}'},
     )
     assert res.status == 200
-    assert res.json()["id"] == schema_id
+    assert res.json() == {"id": schema_id, "subject": subject, "schema": '"string"', "version": 1}
     # Invalid schema should return 500
     res = await c.post(
         f"subjects/{subject}",


### PR DESCRIPTION
The endpoint included an extra "deleted" field and was missing a "subject" field.