### PR TITLE
rapu: support application/octet-stream for schema requests

### DIFF
--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -25,7 +25,13 @@ import time
 
 SERVER_NAME = "Karapace/{}".format(__version__)
 
-ACCEPTED_SCHEMA_CONTENT_TYPES = [
+SCHEMA_CONTENT_TYPES = [
+    "application/vnd.schemaregistry.v1+json",
+    "application/vnd.schemaregistry+json",
+    "application/json",
+    "application/octet-stream",
+]
+SCHEMA_ACCEPT_VALUES = [
     "application/vnd.schemaregistry.v1+json",
     "application/vnd.schemaregistry+json",
     "application/json",
@@ -107,7 +113,7 @@ class RestApp:
         headers = request.headers
 
         content_type = "application/vnd.schemaregistry.v1+json"
-        if method in {"POST", "PUT"} and headers["Content-Type"] not in ACCEPTED_SCHEMA_CONTENT_TYPES:
+        if method in {"POST", "PUT"} and headers["Content-Type"] not in SCHEMA_CONTENT_TYPES:
             raise HTTPResponse(
                 body=json_encode({
                     "error_code": 415,
@@ -120,7 +126,7 @@ class RestApp:
         if "Accept" in headers:
             if headers["Accept"] == "*/*" or headers["Accept"].startswith("*/"):
                 return "application/vnd.schemaregistry.v1+json"
-            content_type_match = get_best_match(headers["Accept"], ACCEPTED_SCHEMA_CONTENT_TYPES)
+            content_type_match = get_best_match(headers["Accept"], SCHEMA_ACCEPT_VALUES)
             if not content_type_match:
                 self.log.debug("Unexpected Accept value: %r", headers["Accept"])
                 raise HTTPResponse(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1009,6 +1009,14 @@ async def check_http_headers(c):
     assert res.status == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
 
+    # Octet-stream is supported as a Content-Type
+    res = await c.put("config", json={"compatibility": "FULL"}, headers={"Content-Type": "application/octet-stream"})
+    assert res.status == 200
+    assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
+    res = await c.get("subjects", headers={"Accept": "application/octet-stream"})
+    assert res.status == 406
+    assert res.json()["message"] == "HTTP 406 Not Acceptable"
+
 
 async def check_schema_body_validation(c):
     subject = os.urandom(16).hex()


### PR DESCRIPTION
Some older clients use application/octet-stream as the Content-Type
value. The content is interpreted to be JSON.