### PR TITLE
rapu: parse content-type charsets correctly

### DIFF
--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -145,3 +145,16 @@ class Client:
         elif self.server_uri:
             res = self.session.put(os.path.join(self.server_uri, path), headers=headers, json=json)
             return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
+
+    async def put_with_data(self, path, data, headers):
+        if self.client:
+            async with self.client.put(
+                path,
+                headers=headers,
+                data=data,
+            ) as res:
+                json_result = await res.json()
+                return Result(res.status, json_result, headers=res.headers)
+        elif self.server_uri:
+            res = self.session.put(os.path.join(self.server_uri, path), headers=headers, data=data)
+            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1017,6 +1017,26 @@ async def check_http_headers(c):
     assert res.status == 406
     assert res.json()["message"] == "HTTP 406 Not Acceptable"
 
+    # Parse Content-Type correctly
+    res = await c.put(
+        "config",
+        json={"compatibility": "NONE"},
+        headers={"Content-Type": "application/vnd.schemaregistry.v1+json; charset=utf-8"}
+    )
+    assert res.status == 200
+    assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
+    assert res.json()["compatibility"] == "NONE"
+
+    # Works with other than the default charset
+    res = await c.put_with_data(
+        "config",
+        data="{\"compatibility\": \"NONE\"}".encode("utf-16"),
+        headers={"Content-Type": "application/vnd.schemaregistry.v1+json; charset=utf-16"}
+    )
+    assert res.status == 200
+    assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
+    assert res.json()["compatibility"] == "NONE"
+
 
 async def check_schema_body_validation(c):
     subject = os.urandom(16).hex()


### PR DESCRIPTION
Previous implementation failed when charsets were defined and
additionally it forced to use UTF-8 only.