### PR TITLE
Explicitly synchronize access to schema id container var

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -212,7 +212,8 @@ class KarapaceSchemaRegistry(KarapaceBase):
             schema_id_int = int(schema_id)
         except ValueError:
             self.r({"error_code": 404, "message": "HTTP 404 Not Found"}, content_type, status=404)
-        schema = self.ksr.schemas.get(schema_id_int)
+        with self.ksr.id_lock:
+            schema = self.ksr.schemas.get(schema_id_int)
         if not schema:
             self.log.warning("Schema: %r that was requested, not found", int(schema_id))
             self.r(body={"error_code": 40403, "message": "Schema not found"}, content_type=content_type, status=404)


### PR DESCRIPTION
and cached schemas dict to avoid any slim chances of ending up with generated invalid ids