### PR TITLE
Add compatibility logic for jsonschema

### DIFF
--- a/karapace/compatibility.py
+++ b/karapace/compatibility.py
@@ -4,10 +4,15 @@ karapace - schema compatibility checking
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from avro.schema import Schema as AvroSchema
 from karapace.schema_reader import SchemaType, TypedSchema
+from math import inf
+from typing import Union
 
 import avro.schema
 import logging
+
+min_val, max_val = -1 * inf, inf
 
 
 class IncompatibleSchema(Exception):
@@ -19,7 +24,9 @@ class UnknownSchemaType(Exception):
 
 
 class Compatibility:
-    def __init__(self, source, target, compatibility):
+    def __init__(
+        self, source: Union[TypedSchema, AvroSchema, dict], target: Union[TypedSchema, AvroSchema, dict], compatibility: str
+    ):
         self.source = source
         self.target = target
         self.log = logging.getLogger("Compatibility")
@@ -39,12 +46,226 @@ class Compatibility:
         if self.source.schema_type is SchemaType.AVRO:
             return AvroCompatibility(self.source.schema, self.target.schema, self.compatibility).check()
         if self.source.schema_type is SchemaType.JSONSCHEMA:
-            return JsonSchemaCompatibility(self.source.schema, self.target.schema, self.compatibility).check()
+            return JsonSchemaCompatibility(
+                target=self.source.to_json(), source=self.target.to_json(), compatibility=self.compatibility
+            ).check()
 
 
 class JsonSchemaCompatibility(Compatibility):
-    def check_compatibility(self, source: TypedSchema, target: TypedSchema) -> bool:
-        raise NotImplementedError("write me")
+    @staticmethod
+    def are_same_type(source: Union[dict, str], target: Union[dict, str]) -> bool:
+        return JsonSchemaCompatibility.get_type_info(source) == JsonSchemaCompatibility.get_type_info(target)
+
+    @staticmethod
+    def get_type_info(source: Union[dict, str]) -> (bool, str):
+        """
+        :param source: a type object, either a string for primitives or a dict for all
+        :return: tuple representing weather the type is complex or base on the first element and the type name on the second
+        """
+        # objects and unions are considered complex types
+        if isinstance(source, str):
+            source = {"type": source}
+        is_base_type = source["type"] not in ["object", "array"] and not isinstance(source["type"], list)
+        type_name = source["type"] if not isinstance(source["type"], list) else "union"
+        # we'll pretend both number types are the same , and do the actual in the base type check method
+        return is_base_type, type_name if type_name != "integer" else "number"
+
+    def check_compatibility(self, source, target, checking_for=None) -> bool:
+        checking_for = checking_for or self._checking_for
+        self.log.debug("Checking %r against %r", source, target)
+        if not self.are_same_type(source, target):
+            self.log.debug("%r and %r are not the same", source, target)
+            raise IncompatibleSchema(f"Source {source} and target {target} have different types")
+
+        return self.check_same_type(source, target, checking_for)
+
+    @staticmethod
+    def can_read_base(source, target, field_type):
+        if field_type in {"number", "integer"}:
+            return JsonSchemaCompatibility.can_read_number(source, target)
+        if field_type == "string":
+            return JsonSchemaCompatibility.can_read_string(source, target)
+        if field_type in {"boolean", "null"}:
+            return True
+        raise UnknownSchemaType(f"Unknown field type {field_type}")
+
+    @staticmethod
+    def can_read_number(source: dict, target: dict) -> bool:
+        if isinstance(source, str):
+            source = {"type": source}
+        if isinstance(target, str):
+            target = {"type": target}
+        if source["type"] == "integer" and target["type"] != "integer":
+            raise IncompatibleSchema(f"{source} cannot read {target}")
+        source_multiple, target_multiple = source.get("multipleOf"), target.get("multipleOf")
+        if source_multiple and (
+            not target_multiple or target_multiple / source_multiple != int(target_multiple / source_multiple)
+        ):
+            raise IncompatibleSchema(
+                f"Source multiple key {source_multiple} is not an exact multiple of target multiple {target_multiple}"
+            )
+        for min_lim_key in ["minimum", "exclusiveMinimum"]:
+            source_lim, target_lim = source.get(min_lim_key, min_val), target.get(min_lim_key, min_val)
+            if source_lim > target_lim:
+                raise IncompatibleSchema(
+                    f"Source {min_lim_key} {source_lim} is larger that target {min_lim_key} {target_lim}"
+                )
+
+        for max_lim_key in ["maximum", "exclusiveMaximum"]:
+            source_lim, target_lim = source.get(max_lim_key, max_val), target.get(max_lim_key, max_val)
+            if source_lim < target_lim:
+                raise IncompatibleSchema(
+                    f"Source {max_lim_key} {source_lim} is smaller that target {max_lim_key} {target_lim}"
+                )
+        return True
+
+    @staticmethod
+    def can_read_string(source: Union[dict, str], target: Union[dict, str]) -> bool:
+        if isinstance(source, str):
+            source = {"type": source}
+        if isinstance(target, str):
+            target = {"type": target}
+        source_enum, target_enum = set(source.get("enum", [])), set(target.get("enum", []))
+        if len(target_enum.difference(source_enum)) > 0:
+            raise IncompatibleSchema(
+                f"Source enum values do {source_enum} do not fully include target enum values {target_enum}"
+            )
+        for format_key in ["pattern", "format"]:
+            source_pattern, target_pattern = source.get(format_key), target.get(format_key)
+            if source_pattern != target_pattern:
+                raise IncompatibleSchema(
+                    f"Source {format_key} {source_pattern} is different from target {format_key} {target_pattern}"
+                )
+        source_min_len, target_min_len = source.get("minLength", 0), target.get("minLength", 0)
+        if source_min_len > target_min_len:
+            raise IncompatibleSchema(f"Source min len {source_min_len} is not greater than target min len {target_min_len}")
+        source_max_len, target_max_len = source.get("maxLength", 0), target.get("maxLength", 0)
+        if source_max_len < target_max_len:
+            raise IncompatibleSchema(f"Source max len {source_max_len} is not greater than target max len {target_max_len}")
+        return True
+
+    def can_read_objects(self, source: dict, target: dict, checking_for: str) -> bool:
+        if source.get("propertyNames") != target.get("propertyNames"):
+            raise IncompatibleSchema(f"{source} and {target} have different values for propertyNames")
+        if source.get("minProperties", 0) > target.get("minProperties", 0):
+            raise IncompatibleSchema(f"{source} does not cover {target} on minProperties")
+        if source.get("maxProperties", 0) < target.get("maxProperties", 0):
+            raise IncompatibleSchema(f"{source} does not cover {target} on maxProperties")
+        source_additional_props = source.get("additionalProperties")
+        target_additional_props = target.get("additionalProperties")
+        if source_additional_props is False and target_additional_props is not False:
+            raise IncompatibleSchema(f"{source} does not cover {target} on additionalProperties")
+        if target_additional_props is True and source_additional_props is not True:
+            raise IncompatibleSchema(f"{source} does not cover {target} on additionalProperties")
+        if isinstance(source_additional_props, dict) and isinstance(target_additional_props, dict):
+            self.log.debug("Recursing for additional properties on %r and %r", source, target)
+            self.check_compatibility(source_additional_props, target_additional_props, checking_for)
+        return True
+        # no patternProperties, no dependencies
+
+    @staticmethod
+    def can_read_unions(source, target, checking_for: str):  # pylint: disable=unused-argument
+        return True
+
+    @staticmethod
+    def can_read_array(source: dict, target: dict, checking_for: str) -> bool:  # pylint: disable=unused-argument
+        if source.get("minItems", 0) > target.get("minItems", 0):
+            raise IncompatibleSchema(f"{source} does not cover {target} on minItems")
+        if source.get("maxItems", 0) < target.get("maxItems", 0):
+            raise IncompatibleSchema(f"{source} does not cover {target} on maxItems")
+        if source.get("uniqueItems") and not target.get("uniqueItems"):
+            raise IncompatibleSchema(f"{source} has unique items enabled while {target} does not")
+        return True
+
+    def can_read_complex(self, source, target, field_type, checking_for: str) -> bool:
+        validators = {"array": self.can_read_array, "object": self.can_read_objects, "union": self.can_read_unions}
+        can_read, can_be_read = True, True
+        # we change the order of the source and target and reverse the check_for param
+        # in case we encounter deeper properties
+        if checking_for in {"FULL", "BACKWARD"}:
+            recurse_check_for = "FULL" if checking_for == "FULL" else "FORWARD"
+            can_read = validators[field_type](source, target, recurse_check_for)
+        if checking_for in {"FULL", "FORWARD"}:
+            recurse_check_for = "FULL" if checking_for == "FULL" else "BACKWARD"
+            can_be_read = validators[field_type](target, source, recurse_check_for)
+        if not can_read and can_be_read:
+            raise IncompatibleSchema(f"Fields {source} and {target} contain incompatible properties")
+        return True
+
+    @staticmethod
+    def get_fields(source):
+        if source["type"] == "object":
+            props = source.get("properties", {})
+            return [(field, props[field]) for field in props]
+        if source["type"] == "array":
+            # how do we handle contains fields??
+            fields = source["items"] if isinstance(source["items"], list) else [source["items"]]
+            return [(None, item) for item in fields]
+        if isinstance(source["type"], list):
+            return [(None, field) for field in source["type"]]
+        raise UnknownSchemaType(f"Unknown complex type: {source}")
+
+    def check_same_type(self, source, target, checking_for: str) -> bool:
+        self.log.debug("Checking same type %r against %r", source, target)
+        is_base_type, type_name = self.get_type_info(source)
+        if is_base_type:
+            can_read, can_be_read = True, True
+            if checking_for in {"BACKWARD", "FULL"}:
+                can_read = self.can_read_base(source=source, target=target, field_type=type_name)
+            if checking_for in {"FORWARD", "FULL"}:
+                can_be_read = self.can_read_base(source=target, target=source, field_type=type_name)
+            return can_read and can_be_read
+        if not self.can_read_complex(source, target, type_name, checking_for):
+            raise IncompatibleSchema(f"{source} and {target} are not compatible")
+
+        if type_name == "union":
+            unhandled_source_indexes, unhandled_target_indexes = self.handle_union(checking_for, source, target)
+        else:
+            unhandled_source_indexes, unhandled_target_indexes = self.handle_array_or_object(checking_for, source, target)
+
+        if (checking_for in {"FULL", "FORWARD"} or type_name == "object") and len(unhandled_source_indexes) > 0:
+            self.log.debug("Fields %r are missing from %r  for %s compatibility", source, target, self._checking_for)
+            raise IncompatibleSchema(f"{source} incompatible with {target} with the compatibility {self._checking_for}")
+        if (checking_for in {"FULL", "BACKWARD"} or type_name == "object") and len(unhandled_target_indexes) > 0:
+            self.log.debug("Fields %r are missing from %r  for %s compatibility", target, source, self._checking_for)
+            raise IncompatibleSchema(f"{target} incompatible with {source} with the compatibility {self._checking_for}")
+        return True
+
+    def handle_union(self, checking_for, source, target):
+        source_fields = self.get_fields(source)
+        target_fields = self.get_fields(target)
+        unhandled_target_indexes = set(range(len(target_fields)))
+        unhandled_source_indexes = set(range(len(source_fields)))
+        for i, ((_, source_field), (_, target_field)) in enumerate(zip(source_fields, target_fields)):
+            if not self.are_same_type(source_field, target_field):
+                continue
+            self.check_compatibility(source_field, target_field, checking_for)
+            unhandled_source_indexes.remove(i)
+            unhandled_target_indexes.remove(i)
+        return unhandled_source_indexes, unhandled_target_indexes
+
+    def handle_array_or_object(self, checking_for, source, target):
+        source_fields = self.get_fields(source)
+        target_fields = self.get_fields(target)
+        unhandled_target_indexes = set(range(len(target_fields)))
+        unhandled_source_indexes = set(range(len(source_fields)))
+        for i, (source_name, source_field) in enumerate(source_fields):
+            if i not in unhandled_source_indexes:
+                continue
+            for j, (target_name, target_field) in enumerate(target_fields):
+                if j not in unhandled_target_indexes:
+                    continue
+                if source_name != target_name:
+                    # only applies to objects, other complex types have the name set to None
+                    continue
+                # unhandled fields for now
+                try:
+                    if self.check_compatibility(source_field, target_field, checking_for):
+                        unhandled_source_indexes.remove(i)
+                        unhandled_target_indexes.remove(j)
+                except (IncompatibleSchema, UnknownSchemaType):
+                    self.log.debug("Not equal: %r and %r", source_field, target_field, exc_info=True)
+        return unhandled_source_indexes, unhandled_target_indexes
 
     def check(self) -> bool:
         return self.check_compatibility(self.source, self.target)

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -497,6 +497,9 @@ class KarapaceSchemaRegistry(KarapaceBase):
                     version=version,
                     deleted=False,
                 )
+                self.send_schema_message(
+                    subject, new_schema.to_json(), new_schema.schema_type.value, schema_id, version, deleted=False
+                )
                 self.r({"id": schema_id}, content_type)
 
             schema_versions = sorted(list(schemas))

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -497,9 +497,6 @@ class KarapaceSchemaRegistry(KarapaceBase):
                     version=version,
                     deleted=False,
                 )
-                self.send_schema_message(
-                    subject, new_schema.to_json(), new_schema.schema_type.value, schema_id, version, deleted=False
-                )
                 self.r({"id": schema_id}, content_type)
 
             schema_versions = sorted(list(schemas))

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -1,0 +1,298 @@
+from jsonschema import Draft7Validator
+from karapace.compatibility import IncompatibleSchema, JsonSchemaCompatibility
+
+import copy
+import json as jsonlib
+import os
+import pytest
+
+
+async def check_jsonschema_succeeds(new: dict, old: dict, compatibility: str, client=None):
+    if not client:
+        for schema in [new, old]:
+            Draft7Validator.check_schema(schema)
+        JsonSchemaCompatibility(new, old, compatibility).check()
+    else:
+        subject = os.urandom(16).hex()
+        res = await client.put("config", json={"compatibility": compatibility})
+        assert res.status == 200
+        res = await client.post(
+            "subjects/{}/versions".format(subject),
+            json={
+                "schema": jsonlib.dumps(old),
+                "schemaType": "JSON"
+            },
+        )
+        assert res.status == 200
+        assert "id" in res.json()
+        schema_id = res.json()["id"]
+        res = await client.post(
+            "subjects/{}/versions".format(subject),
+            json={
+                "schema": jsonlib.dumps(new),
+                "schemaType": "JSON"
+            },
+        )
+        assert res.status == 200
+        assert "id" in res.json()
+        new_id = res.json()["id"]
+        assert new_id != schema_id
+        await client.delete("subjects/{}".format(subject))
+
+
+async def check_jsonschema_fails(new: dict, old: dict, compatibility: str, client=None):
+    if not client:
+        for schema in [new, old]:
+            Draft7Validator.check_schema(schema)
+        with pytest.raises(IncompatibleSchema):
+            JsonSchemaCompatibility(new, old, compatibility).check()
+    else:
+        subject = os.urandom(16).hex()
+        res = await client.put("config", json={"compatibility": compatibility})
+        assert res.status == 200
+        res = await client.post(
+            "subjects/{}/versions".format(subject),
+            json={
+                "schema": jsonlib.dumps(old),
+                "schemaType": "JSON"
+            },
+        )
+        assert res.status == 200
+        assert "id" in res.json()
+        res = await client.post(
+            "subjects/{}/versions".format(subject),
+            json={
+                "schema": jsonlib.dumps(new),
+                "schemaType": "JSON"
+            },
+        )
+        await client.delete("subjects/{}".format(subject))
+        assert res.status == 409
+
+
+async def test_jsonschema_compatibility():
+    # uncomment and delete the parameter / fixture to do compatibility updates
+    registry_async_client = None
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+    source = {"type": "object", "properties": {"foo": {"type": "number"}}}
+    target = {
+        "type": "object",
+        "properties": {
+            "foo": {
+                "type": "integer"
+            },
+        },
+    }
+    # some basic checks for required fields
+    await check_jsonschema_succeeds(source, target, "BACKWARD", registry_async_client)
+    # base data types in top level schema
+    await check_jsonschema_succeeds({"type": "string"}, {"type": "string"}, "NONE")
+    # Base
+    # Number types
+    # int to number promotion
+    await check_jsonschema_succeeds({"type": "number"}, {"type": "integer"}, "BACKWARD", registry_async_client)
+    # invalid type promotion
+    await check_jsonschema_fails({"type": "number"}, {"type": "integer"}, "FORWARD", registry_async_client)
+    # multiple promotion
+    await check_jsonschema_succeeds({
+        "type": "number",
+        "multipleOf": 2
+    }, {
+        "type": "number",
+        "multipleOf": 4
+    }, "BACKWARD", registry_async_client)
+    # invalid multiple promotion
+    await check_jsonschema_fails({
+        "type": "number",
+        "multipleOf": 2
+    }, {
+        "type": "number",
+        "multipleOf": 4
+    }, "FORWARD", registry_async_client)
+    # inclusive domain
+    await check_jsonschema_succeeds({
+        "type": "number",
+        "minimum": -10,
+        "maximum": 100
+    }, {
+        "type": "number",
+        "minimum": -9,
+        "maximum": 9
+    }, "BACKWARD", registry_async_client)
+    # overlapping but not inclusive
+    await check_jsonschema_fails({
+        "type": "number",
+        "minimum": -10,
+        "maximum": 100
+    }, {
+        "type": "number",
+        "minimum": -19,
+        "maximum": 9
+    }, "BACKWARD", registry_async_client)
+    # String
+    # min len
+    await check_jsonschema_succeeds({
+        "type": "string",
+        "minLength": 8
+    }, {
+        "type": "string",
+        "minLength": 9
+    }, "BACKWARD", registry_async_client)
+    await check_jsonschema_fails({
+        "type": "string",
+        "minLength": 10
+    }, {
+        "type": "string",
+        "minLength": 9
+    }, "BACKWARD", registry_async_client)
+    # max len
+    await check_jsonschema_succeeds({
+        "type": "string",
+        "maxLength": 18
+    }, {
+        "type": "string",
+        "maxLength": 10
+    }, "BACKWARD", registry_async_client)
+    await check_jsonschema_fails({
+        "type": "string",
+        "maxLength": 10
+    }, {
+        "type": "string",
+        "maxLength": 19
+    }, "BACKWARD", registry_async_client)
+    # format or pattern
+    # TODO -> check if format is supported by confluent
+    for k in ["pattern"]:
+        await check_jsonschema_fails({
+            "type": "string",
+            k: "foo"
+        }, {
+            "type": "string",
+            k: "bar"
+        }, "BACKWARD", registry_async_client)
+    # Complex
+    # Array
+    src = {"type": "array", "items": {"type": "number"}}
+    tgt = {"type": "array", "items": {"type": "integer"}}
+    await check_jsonschema_succeeds(src, tgt, "BACKWARD", registry_async_client)
+    await check_jsonschema_fails(src, tgt, "FORWARD", registry_async_client)
+    for minI, maxI, arr in [(10, 20, src), (11, 19, tgt)]:
+        arr["minItems"] = minI
+        arr["maxItems"] = maxI
+    await check_jsonschema_succeeds(src, tgt, "BACKWARD", registry_async_client)
+    for minI, maxI, arr in [(12, 18, src), (11, 19, tgt)]:
+        arr["minItems"] = minI
+        arr["maxItems"] = maxI
+    await check_jsonschema_fails(src, tgt, "BACKWARD", registry_async_client)
+    await check_jsonschema_succeeds({
+        "type": "array",
+        "items": {
+            "type": "integer"
+        }
+    }, {
+        "type": "array",
+        "items": {
+            "type": "integer"
+        },
+        "uniqueItems": True
+    }, "BACKWARD", registry_async_client)
+    # Object
+    src = {"type": "object", "properties": {"some_num": {"type": "number"}}}
+    tgt = {
+        "type": "object",
+        "properties": {
+            "some_num": {
+                "type": "integer"
+            }
+        },
+    }
+    base_src, base_tgt = copy.deepcopy(src), copy.deepcopy(tgt)
+    await check_jsonschema_succeeds(src, tgt, "BACKWARD", registry_async_client)
+    src["properties"]["some_str"] = {"type": "string"}
+    src["properties"]["some_num"]["type"] = "integer"
+    await check_jsonschema_fails(tgt, src, "FORWARD", registry_async_client)
+    tgt["additionalProperties"] = {"type": "integer"}
+    src["additionalProperties"] = {"type": "number"}
+    for minP, maxP, obj in [(7, 17, base_src), (8, 16, base_tgt)]:
+        obj["minProperties"] = minP
+        obj["maxProperties"] = maxP
+    await check_jsonschema_succeeds(base_src, base_tgt, "BACKWARD", registry_async_client)
+    for minP, maxP, obj in [(7, 17, base_src), (6, 16, base_tgt)]:
+        obj["minProperties"] = minP
+        obj["maxProperties"] = maxP
+    await check_jsonschema_fails(base_src, base_tgt, "BACKWARD", registry_async_client)
+    await check_jsonschema_fails(base_src, base_tgt, "FORWARD", registry_async_client)
+    src = {
+        "type": "object",
+        "properties": {
+            "some_obj_num": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "number"
+                    }
+                },
+                "required": ["foo"]
+            },
+            "some_str": {
+                "type": "string"
+            }
+        },
+        "required": ["some_obj_num", "some_str"]
+    }
+    tgt = {
+        "type": "object",
+        "properties": {
+            "some_obj_num": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "integer"
+                    }
+                },
+                "required": ["foo"]
+            },
+            "some_str": {
+                "type": "string"
+            }
+        },
+        "required": ["some_obj_num", "some_str"]
+    }
+    await check_jsonschema_succeeds(src, tgt, "BACKWARD", registry_async_client)
+    await check_jsonschema_fails(src, tgt, "FORWARD", registry_async_client)
+    # Union (apparently you cannot have complex types in unions, so ... yay?)
+    # mangled order does not work as expected :(
+    src = {"type": ["string", "integer"]}
+    tgt = {"type": ["string", "integer", "boolean"]}
+    await check_jsonschema_succeeds(src, tgt, "FORWARD", registry_async_client)
+    src = {"type": ["string", "integer"]}
+    tgt = {"type": ["string", "number"]}
+    await check_jsonschema_fails({"type": ["string", "integer"]}, {"type": ["integer", "string"]}, "BACKWARD",
+                                 registry_async_client)
+    await check_jsonschema_succeeds(src, tgt, "FORWARD", registry_async_client)
+    src = {
+        "type": "object",
+        "properties": {
+            "num": {
+                "type": "number"
+            },
+            "uni": {
+                "type": ["string", "number"]
+            }
+        },
+        "required": ["num", "uni"]
+    }
+    tgt = {
+        "type": "object",
+        "properties": {
+            "num": {
+                "type": "integer"
+            },
+            "uni": {
+                "type": ["string", "number"]
+            }
+        },
+        "required": ["num", "uni"]
+    }
+    await check_jsonschema_succeeds(src, tgt, "BACKWARD", registry_async_client)

--- a/tests/test_rest_consumer.py
+++ b/tests/test_rest_consumer.py
@@ -266,7 +266,7 @@ async def test_consume(rest_async_client, admin_client, producer, trail):
                 f" does not match {values[fmt][i]} for format {fmt}"
 
 
-@pytest.mark.parametrize("schema_type", ["avro"])
+@pytest.mark.parametrize("schema_type", ["avro", "json"])
 @pytest.mark.parametrize("trail", ["", "/"])
 async def test_publish_consume_avro(rest_async_client, admin_client, trail, schema_type):
     header = REST_HEADERS[schema_type]

--- a/tests/test_rest_consumer.py
+++ b/tests/test_rest_consumer.py
@@ -266,7 +266,7 @@ async def test_consume(rest_async_client, admin_client, producer, trail):
                 f" does not match {values[fmt][i]} for format {fmt}"
 
 
-@pytest.mark.parametrize("schema_type", ["avro", "json"])
+@pytest.mark.parametrize("schema_type", ["avro", "jsonschema"])
 @pytest.mark.parametrize("trail", ["", "/"])
 async def test_publish_consume_avro(rest_async_client, admin_client, trail, schema_type):
     header = REST_HEADERS[schema_type]


### PR DESCRIPTION
- Add base for backward / forward compatibility check for base and complex types
- Add more logging and basic validation rules for forwarding base types
- Validation for primitive types and most cases i could think of on the spot for complex types
- Unit tests for compatibility
- Extract check calls into separate functions, tested against confluent rest
- Update consumer tests to also test jsonschema serialization
- Default kafka port for fixtures running with pre existing kafka service

NOTE: This PR is open against a non master branch for diff viewing purposes. IT will be reopen against master when the changes on the base branch are added to it, and left as a draft until then 