### PR TITLE
Handle missing and miscased content headers

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,8 @@
+from karapace.rapu import HTTPRequest
+
+
+async def test_header_get():
+    req = HTTPRequest(url="", query="", headers={}, path_for_stats="", method="GET")
+    assert "Content-Type" not in req.headers
+    for v in ["Content-Type", "content-type", "CONTENT-tYPE", "coNTENT-TYpe"]:
+        assert req.get_header(v) == "application/json"


### PR DESCRIPTION
Header search will try to ignore case. Missing Content-Type
headers will default in application/json.