### PR TITLE
README: remove travis build status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,5 @@
-Karapace |BuildStatus|_
-=======================
-
-.. |BuildStatus| image:: https://travis-ci.org/aiven/karapace.png?branch=master
-.. _BuildStatus: https://travis-ci.org/aiven/karapace
+Karapace
+========
 
 ``karapace`` Your Kafka essentials in one tool
 


### PR DESCRIPTION
The project has moved to using Github actions so the Travis build status
badge is no longer needed.