### PR TITLE
client: more aggresive idle conn recycling

### DIFF
--- a/karapace/config.py
+++ b/karapace/config.py
@@ -13,6 +13,7 @@ DEFAULTS = {
     "bootstrap_uri": "127.0.0.1:9092",
     "client_id": "sr-1",
     "compatibility": "BACKWARD",
+    "connections_max_idle_ms": 15000,
     "consumer_enable_auto_commit": True,
     "consumer_request_timeout_ms": 11000,
     "consumer_request_max_bytes": 67108864,

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -185,6 +185,7 @@ class KafkaRest(KarapaceBase):
                     acks=acks,
                     compression_type=self.config["producer_compression_type"],
                     linger_ms=self.config["producer_linger_ms"],
+                    connections_max_idle_ms=self.config["connections_max_idle_ms"],
                 )
                 await p.start()
                 return p
@@ -297,6 +298,7 @@ class KafkaRest(KarapaceBase):
                     ssl_keyfile=self.config["ssl_keyfile"],
                     api_version=(1, 0, 0),
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
+                    connections_max_idle_ms=self.config["connections_max_idle_ms"],
                 )
                 break
             except:  # pylint: disable=bare-except

--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -53,7 +53,7 @@ class KafkaRestAdminClient(KafkaAdminClient):
         with self.client_lock:
             node_id = self._client.least_loaded_node()
             # normal admin code will call poll on client not ready which will sometime block indefinitely on select
-            if not self.first_boot or not self._client.ready(node_id):
+            if not node_id or not self.first_boot or not self._client.ready(node_id):
                 #  pylint: disable=protected-access
                 node_id = list(self._client.cluster._bootstrap_brokers.keys())[0]
                 self.first_boot = False

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -180,7 +180,8 @@ class ConsumerManager:
                     fetch_max_bytes=self.config["consumer_request_max_bytes"],
                     request_timeout_ms=request_data["consumer.request.timeout.ms"],
                     enable_auto_commit=request_data["auto.commit.enable"],
-                    auto_offset_reset=request_data["auto.offset.reset"]
+                    auto_offset_reset=request_data["auto.offset.reset"],
+                    connections_max_idle_ms=self.config["connections_max_idle_ms"],
                 )
                 return c
             except:  # pylint: disable=bare-except

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -52,7 +52,8 @@ class KarapaceBase(RestApp):
                     ssl_keyfile=self.config["ssl_keyfile"],
                     api_version=(1, 0, 0),
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
-                    max_block_ms=2000  # missing topics will block unless we cache cluster metadata and pre-check
+                    max_block_ms=2000,  # missing topics will block unless we cache cluster metadata and pre-check
+                    connections_max_idle_ms=self.config["connections_max_idle_ms"],  # helps through cluster upgrades ??
                 )
             except:  # pylint: disable=bare-except
                 self.log.exception("Unable to create producer, retrying")


### PR DESCRIPTION
The default 9 minute idle connection closing is too lenient for
scenarios like maintaining a valid connection pool through a cluster
update.

Injecting a configurable lower value "should" lower the
possibility of clients with a connection pool where the majority of
connections are broken