### PR TITLE
compatibility: same type checks for union

### DIFF
--- a/karapace/compatibility.py
+++ b/karapace/compatibility.py
@@ -159,6 +159,8 @@ class AvroCompatibility(Compatibility):
         self.log.info("source: %s, target: %s", source, target)
 
         # Simple form presentation of values e.g. "int"
+        if isinstance(source, tuple):
+            return isinstance(target, tuple), False
         if isinstance(source.type, str):
             if source.type in self._NUMBER_TYPES and target.type in self._NUMBER_TYPES:
                 return True, True


### PR DESCRIPTION
check_same_type now accounts for multiple forms of union types, since we
can end up calling this method from multiple places