### PR TITLE
compatibility: config msg offsets while not ready

### DIFF
--- a/tests/test_master_coordinator.py
+++ b/tests/test_master_coordinator.py
@@ -7,6 +7,10 @@ See LICENSE for details
 from karapace.config import set_config_defaults
 from karapace.master_coordinator import MasterCoordinator
 
+import asyncio
+import json
+import os
+import requests
 import time
 
 
@@ -50,3 +54,101 @@ def test_master_selection(kafka_server):
         break
     mc_aa.close()
     mc_bb.close()
+
+
+async def test_schema_request_forwarding(registry_async_pair):
+    master_url, slave_url = registry_async_pair
+    max_tries, counter = 5, 0
+    wait_time = 0.5
+    subject = os.urandom(16).hex()
+    schema = {"type": "string"}
+    other_schema = {"type": "int"}
+    # Config updates
+    for subj_path in [None, subject]:
+        if subj_path:
+            path = f"config/{subject}"
+        else:
+            path = "config"
+        for compat in ["FULL", "BACKWARD", "FORWARD", "NONE"]:
+            resp = requests.put(f"{slave_url}/{path}", json={"compatibility": compat})
+            assert resp.ok
+            while True:
+                if counter >= max_tries:
+                    raise Exception("Compat update not propagated")
+                resp = requests.get(f"{master_url}/{path}")
+                if not resp.ok:
+                    print(f"Invalid http status code: {resp.status_code}")
+                    continue
+                data = resp.json()
+                if "compatibilityLevel" not in data:
+                    print(f"Invalid response: {data}")
+                    counter += 1
+                    await asyncio.sleep(wait_time)
+                    continue
+                if data["compatibilityLevel"] != compat:
+                    print(f"Bad compatibility: {data}")
+                    counter += 1
+                    await asyncio.sleep(wait_time)
+                    continue
+                break
+
+    # New schema updates, last compatibility is None
+    for s in [schema, other_schema]:
+        resp = requests.post(f"{slave_url}/subjects/{subject}/versions", json={"schema": json.dumps(s)})
+    assert resp.ok
+    data = resp.json()
+    assert "id" in data, data
+    counter = 0
+    while True:
+        if counter >= max_tries:
+            raise Exception("Subject schema data not propagated yet")
+        resp = requests.get(f"{master_url}/subjects/{subject}/versions")
+        if not resp.ok:
+            print(f"Invalid http status code: {resp.status_code}")
+            counter += 1
+            continue
+        data = resp.json()
+        if not data:
+            print(f"No versions registered for subject {subject} yet")
+            counter += 1
+            continue
+        assert len(data) == 2, data
+        assert data[0] == 1, data
+        print("Subject schema data propagated")
+        break
+
+    # Schema deletions
+    resp = requests.delete(f"{slave_url}/subjects/{subject}/versions/1")
+    assert resp.ok
+    counter = 0
+    while True:
+        if counter >= max_tries:
+            raise Exception("Subject version deletion not propagated yet")
+        resp = requests.get(f"{master_url}/subjects/{subject}/versions/1")
+        if resp.ok:
+            print(f"Subject {subject} still has version 1 on master")
+            counter += 1
+            continue
+        assert resp.status_code == 404
+        print(f"Subject {subject} no longer has version 1")
+        break
+
+    # Subject deletion
+    resp = requests.get(f"{master_url}/subjects/")
+    assert resp.ok
+    data = resp.json()
+    assert subject in data
+    resp = requests.delete(f"{slave_url}/subjects/{subject}")
+    assert resp.ok
+    counter = 0
+    while True:
+        if counter >= max_tries:
+            raise Exception("Subject deletion not propagated yet")
+        resp = requests.get(f"{master_url}/subjects/")
+        if not resp.ok:
+            print("Could not retrieve subject list on master")
+            counter += 1
+            continue
+        data = resp.json()
+        assert subject not in data
+        break


### PR DESCRIPTION
Allow storing message offsets for config type messages no matter the
node state, since all node types will accept config type requests
and send relevant messages on the kafka topic, thus in certain scenarios
(single node not ready, but server is up) causing writes to
succeed but offsets to be lost, and thus requests to hang indefinitely