### PR TITLE
tests: refactor schema tests

### DIFF
--- a/tests/test_schema_backup.py
+++ b/tests/test_schema_backup.py
@@ -5,7 +5,6 @@ Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
 from karapace.schema_backup import SchemaBackup
-from karapace.utils import Client
 
 import json as jsonlib
 import os
@@ -26,29 +25,22 @@ async def insert_data(c):
     return subject
 
 
-async def test_backup_get(karapace, aiohttp_client):
-    kc, datadir = karapace(topic_name="get_schemas")
-    client = await aiohttp_client(kc.app)
-    c = Client(client=client)
-
-    _ = await insert_data(c)
+async def test_backup_get(registry_async, registry_async_client):
+    _ = await insert_data(registry_async_client)
 
     # Get the backup
-    backup_location = os.path.join(datadir, "schemas.log")
-    sb = SchemaBackup(kc.config_path, backup_location)
+    backup_location = os.path.join(os.path.dirname(registry_async.config_path), "schemas.log")
+    sb = SchemaBackup(registry_async.config_path, backup_location)
     sb.request_backup()
 
     # The backup file has been created
     assert os.path.exists(backup_location)
 
 
-async def test_backup_restore(karapace, aiohttp_client):
-    kc, datadir = karapace(topic_name="restore_schemas")
-    client = await aiohttp_client(kc.app)
-    c = Client(client=client)
+async def test_backup_restore(registry_async, registry_async_client):
 
     subject = os.urandom(16).hex()
-    restore_location = os.path.join(datadir, "restore.log")
+    restore_location = os.path.join(os.path.dirname(registry_async.config_path), "restore.log")
     with open(restore_location, "w") as fp:
         jsonlib.dump([[
             {
@@ -66,19 +58,19 @@ async def test_backup_restore(karapace, aiohttp_client):
             },
         ]],
                      fp=fp)
-    sb = SchemaBackup(kc.config_path, restore_location)
+    sb = SchemaBackup(registry_async.config_path, restore_location)
     sb.restore_backup()
 
     # The restored karapace should have the previously created subject
     time.sleep(1.0)
-    res = await c.get("subjects")
+    res = await registry_async_client.get("subjects")
     assert res.status_code == 200
     data = res.json()
     assert subject in data
 
     # Test a few exotic scenarios
     subject = os.urandom(16).hex()
-    res = await c.put(f"config/{subject}", json={"compatibility": "NONE"})
+    res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "NONE"})
     assert res.status == 200
     assert res.json()["compatibility"] == "NONE"
 
@@ -98,19 +90,19 @@ async def test_backup_restore(karapace, aiohttp_client):
 ]
         """.format(subject_value=subject)
         )
-    res = await c.get(f"config/{subject}")
+    res = await registry_async_client.get(f"config/{subject}")
     assert res.status == 200
     sb.restore_backup()
     time.sleep(1.0)
-    res = await c.get(f"config/{subject}")
+    res = await registry_async_client.get(f"config/{subject}")
     assert res.status == 404
 
     # Restore a complete schema delete message
     subject = os.urandom(16).hex()
-    res = await c.put(f"config/{subject}", json={"compatibility": "NONE"})
-    res = await c.post(f"subjects/{subject}/versions", json={"schema": '{"type": "int"}'})
-    res = await c.post(f"subjects/{subject}/versions", json={"schema": '{"type": "float"}'})
-    res = await c.get(f"subjects/{subject}/versions")
+    res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "NONE"})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": '{"type": "int"}'})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": '{"type": "float"}'})
+    res = await registry_async_client.get(f"subjects/{subject}/versions")
     assert res.status == 200
     assert res.json() == [1, 2]
     with open(restore_location, "w") as fp:
@@ -131,13 +123,13 @@ async def test_backup_restore(karapace, aiohttp_client):
         )
     sb.restore_backup()
     time.sleep(1.0)
-    res = await c.get(f"subjects/{subject}/versions")
+    res = await registry_async_client.get(f"subjects/{subject}/versions")
     assert res.status == 200
     assert res.json() == [1]
 
     # Schema delete for a nonexistent subject version is ignored
     subject = os.urandom(16).hex()
-    res = await c.post(f"subjects/{subject}/versions", json={"schema": '{"type": "string"}'})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": '{"type": "string"}'})
     with open(restore_location, "w") as fp:
         fp.write(
             """
@@ -156,6 +148,6 @@ async def test_backup_restore(karapace, aiohttp_client):
         )
     sb.restore_backup()
     time.sleep(1.0)
-    res = await c.get(f"subjects/{subject}/versions")
+    res = await registry_async_client.get(f"subjects/{subject}/versions")
     assert res.status == 200
     assert res.json() == [1]


### PR DESCRIPTION
Use a separate unittest instead of a check function to better split the
tests. Remove unused fixtures

WARNING: Test run time is increased due to the registry fixture being
recreated for almost each test in the suite

Wait for kafka cluster using an admin client instead of a tcp check in
hope of catching broken kafka / zk fixtures earlier
