### PR TITLE
config: add session_timeout_ms config param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ start-kafka: fetch-kafka
 stop-kafka:
 	$(KAFKA_PATH)/bin/kafka-server-stop.sh 9 || true
 	$(KAFKA_PATH)/bin/zookeeper-server-stop.sh 9 || true
+	rm -rf /tmp/kafka-logs /tmp/zookeeper
 
 .PHONY: kafka
 kafka: start-kafka

--- a/karapace.config.json
+++ b/karapace.config.json
@@ -15,5 +15,6 @@
     "ssl_keyfile": null,
     "karapace_rest": true,
     "karapace_registry": true,
-    "topic_name": "_schemas"
+    "topic_name": "_schemas",
+    "session_timeout_ms": 10000
 }

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -41,6 +41,7 @@ DEFAULTS = {
     "producer_compression_type": None,
     "producer_count": 5,
     "producer_linger_ms": 0,
+    "session_timeout_ms": 10000,
     "karapace_rest": False,
     "karapace_registry": False,
 }

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -168,6 +168,11 @@ class ConsumerManager:
     async def create_kafka_consumer(self, fetch_min_bytes, group_name, internal_name, request_data):
         while True:
             try:
+                session_timeout_ms = self.config["session_timeout_ms"]
+                request_timeout_ms = max(
+                    session_timeout_ms, KafkaConsumer.DEFAULT_CONFIG["request_timeout_ms"],
+                    request_data["consumer.request.timeout.ms"]
+                )
                 c = KafkaConsumer(
                     bootstrap_servers=self.config["bootstrap_uri"],
                     client_id=internal_name,
@@ -178,10 +183,10 @@ class ConsumerManager:
                     group_id=group_name,
                     fetch_min_bytes=fetch_min_bytes,
                     fetch_max_bytes=self.config["consumer_request_max_bytes"],
-                    request_timeout_ms=request_data["consumer.request.timeout.ms"],
+                    request_timeout_ms=request_timeout_ms,
                     enable_auto_commit=request_data["auto.commit.enable"],
                     auto_offset_reset=request_data["auto.offset.reset"],
-                    connections_max_idle_ms=self.config["connections_max_idle_ms"],
+                    session_timeout_ms=session_timeout_ms,
                 )
                 return c
             except:  # pylint: disable=bare-except

--- a/karapace/master_coordinator.py
+++ b/karapace/master_coordinator.py
@@ -4,6 +4,7 @@ karapace - master coordinator
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from kafka import KafkaConsumer
 from kafka.client_async import KafkaClient
 from kafka.coordinator.base import BaseCoordinator
 from kafka.errors import NoBrokersAvailable, NodeNotReadyError
@@ -139,10 +140,13 @@ class MasterCoordinator(Thread):
         return False
 
     def init_schema_coordinator(self):
+        session_timeout_ms = self.config["session_timeout_ms"]
         self.sc = SchemaCoordinator(
             client=self.kafka_client,
             metrics=self._metrics,
             group_id=self.config["group_id"],
+            session_timeout_ms=session_timeout_ms,
+            request_timeout_ms=max(session_timeout_ms, KafkaConsumer.DEFAULT_CONFIG["request_timeout_ms"]),
         )
         self.sc.hostname = self.config["advertised_hostname"]
         self.sc.port = self.config["port"]

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -110,6 +110,8 @@ class KafkaSchemaReader(Thread):
 
     def init_consumer(self):
         # Group not set on purpose, all consumers read the same data
+        session_timeout_ms = self.config["session_timeout_ms"]
+        request_timeout_ms = max(session_timeout_ms, KafkaConsumer.DEFAULT_CONFIG["request_timeout_ms"])
         self.consumer = KafkaConsumer(
             self.config["topic_name"],
             enable_auto_commit=False,
@@ -121,6 +123,8 @@ class KafkaSchemaReader(Thread):
             ssl_certfile=self.config["ssl_certfile"],
             ssl_keyfile=self.config["ssl_keyfile"],
             auto_offset_reset="earliest",
+            session_timeout_ms=session_timeout_ms,
+            request_timeout_ms=request_timeout_ms,
         )
 
     def init_admin_client(self):


### PR DESCRIPTION
Having the kafka cluster configured with value for
group.min.session.timeout.ms exceeding the default session_timeout_ms
value (10s) will cause JoinGroup requests to fail. Making
session_timeout_ms, as well request_timeout_ms (which should always be
larger) configurable will allow one to work around that limitation

The stop-kafka make target did not previously cleanup the zk / kafka log
folders, which would cause subsequent cluster restarts to fail due to
preexisting data