### PR TITLE
logic: metadata requests to bootstrap nodes

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -9,7 +9,7 @@ from karapace.karapace import KarapaceBase
 from karapace.rapu import HTTPRequest
 from karapace.schema_reader import SchemaType
 from karapace.serialization import InvalidMessageSchema, InvalidPayload, SchemaRegistrySerializer, SchemaRetrievalError
-from karapace.utils import convert_to_int
+from karapace.utils import convert_to_int, KarapaceKafkaClient
 from threading import Lock
 from typing import List, Optional, Tuple
 
@@ -299,6 +299,7 @@ class KafkaRest(KarapaceBase):
                     api_version=(1, 0, 0),
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
                     connections_max_idle_ms=self.config["connections_max_idle_ms"],
+                    client_factory=KarapaceKafkaClient,
                 )
                 break
             except:  # pylint: disable=bare-except

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -9,6 +9,7 @@ from functools import partial
 from kafka import KafkaProducer
 from karapace.config import read_config
 from karapace.rapu import HTTPResponse, RestApp
+from karapace.utils import KarapaceKafkaClient
 
 import asyncio
 import logging
@@ -54,6 +55,7 @@ class KarapaceBase(RestApp):
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
                     max_block_ms=2000,  # missing topics will block unless we cache cluster metadata and pre-check
                     connections_max_idle_ms=self.config["connections_max_idle_ms"],  # helps through cluster upgrades ??
+                    client_factory=KarapaceKafkaClient,
                 )
             except:  # pylint: disable=bare-except
                 self.log.exception("Unable to create producer, retrying")

--- a/karapace/master_coordinator.py
+++ b/karapace/master_coordinator.py
@@ -5,11 +5,11 @@ Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
 from kafka import KafkaConsumer
-from kafka.client_async import KafkaClient
 from kafka.coordinator.base import BaseCoordinator
 from kafka.errors import NoBrokersAvailable, NodeNotReadyError
 from kafka.metrics import MetricConfig, Metrics
 from karapace import constants
+from karapace.utils import KarapaceKafkaClient
 from threading import Lock, Thread
 
 import json
@@ -123,7 +123,7 @@ class MasterCoordinator(Thread):
 
     def init_kafka_client(self):
         try:
-            self.kafka_client = KafkaClient(
+            self.kafka_client = KarapaceKafkaClient(
                 api_version_auto_timeout_ms=constants.API_VERSION_AUTO_TIMEOUT_MS,
                 bootstrap_servers=self.config["bootstrap_uri"],
                 client_id=self.config["client_id"],

--- a/karapace/schema_backup.py
+++ b/karapace/schema_backup.py
@@ -10,7 +10,7 @@ from kafka.errors import NoBrokersAvailable, NodeNotReadyError, TopicAlreadyExis
 from karapace import constants
 from karapace.karapace import KarapaceBase
 from karapace.schema_reader import KafkaSchemaReader
-from karapace.utils import json_encode
+from karapace.utils import json_encode, KarapaceKafkaClient
 
 import argparse
 import json
@@ -43,7 +43,6 @@ class SchemaBackup:
         self.consumer = KafkaConsumer(
             self.topic_name,
             enable_auto_commit=False,
-            api_version=(1, 0, 0),
             bootstrap_servers=self.config["bootstrap_uri"],
             client_id=self.config["client_id"],
             security_protocol=self.config["security_protocol"],
@@ -52,6 +51,7 @@ class SchemaBackup:
             ssl_keyfile=self.config["ssl_keyfile"],
             auto_offset_reset="earliest",
             metadata_max_age_ms=self.config["metadata_max_age_ms"],
+            client_factory=KarapaceKafkaClient,
         )
 
     def init_producer(self):
@@ -61,7 +61,7 @@ class SchemaBackup:
             ssl_cafile=self.config["ssl_cafile"],
             ssl_certfile=self.config["ssl_certfile"],
             ssl_keyfile=self.config["ssl_keyfile"],
-            api_version=(1, 0, 0),
+            client_factory=KarapaceKafkaClient,
         )
 
     def init_admin_client(self):
@@ -80,6 +80,7 @@ class SchemaBackup:
                     ssl_cafile=self.config["ssl_cafile"],
                     ssl_certfile=self.config["ssl_certfile"],
                     ssl_keyfile=self.config["ssl_keyfile"],
+                    client_factory=KarapaceKafkaClient,
                 )
                 break
             except (NodeNotReadyError, NoBrokersAvailable, AssertionError):

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -14,7 +14,7 @@ from kafka.admin import KafkaAdminClient, NewTopic
 from kafka.errors import NoBrokersAvailable, NodeNotReadyError, TopicAlreadyExistsError
 from karapace import constants
 from karapace.statsd import StatsClient
-from karapace.utils import json_encode
+from karapace.utils import json_encode, KarapaceKafkaClient
 from queue import Queue
 from threading import Lock, Thread
 from typing import Dict
@@ -125,6 +125,7 @@ class KafkaSchemaReader(Thread):
             auto_offset_reset="earliest",
             session_timeout_ms=session_timeout_ms,
             request_timeout_ms=request_timeout_ms,
+            client_factory=KarapaceKafkaClient,
         )
 
     def init_admin_client(self):

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -5,6 +5,7 @@ Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
 from functools import partial
+from kafka.client_async import KafkaClient, MetadataRequest
 from urllib.parse import urljoin
 
 import datetime
@@ -187,3 +188,60 @@ def convert_to_int(object_: dict, key: str, content_type: str):
     except ValueError:
         from karapace.rapu import http_error
         http_error(f"{key} is not a valid int: {object_[key]}", content_type, 500)
+
+
+class KarapaceKafkaClient(KafkaClient):
+    def _maybe_refresh_metadata(self, wakeup=False):
+        """
+            Lifted from the parent class with the caveat that the node id will always belong to the bootstrap node,
+            thus ensuring we do not end up in a stale metadata loop
+        """
+        ttl = self.cluster.ttl()
+        wait_for_in_progress_ms = self.config['request_timeout_ms'] if self._metadata_refresh_in_progress else 0
+        metadata_timeout = max(ttl, wait_for_in_progress_ms)
+
+        if metadata_timeout > 0:
+            return metadata_timeout
+        # pylint: disable=protected-access
+        bootstrap_nodes = list(self.cluster._bootstrap_brokers.values())
+        # pylint: enable=protected-access
+        if not bootstrap_nodes:
+            node_id = self.least_loaded_node()
+        else:
+            node_id = bootstrap_nodes[0].nodeId
+        if node_id is None:
+            log.debug("Give up sending metadata request since no node is available")
+            return self.config['reconnect_backoff_ms']
+
+        if self._can_send_request(node_id):
+            topics = list(self._topics)
+            if not topics and self.cluster.is_bootstrap(node_id):
+                topics = list(self.config['bootstrap_topics_filter'])
+
+            if self.cluster.need_all_topic_metadata or not topics:
+                topics = [] if self.config['api_version'] < (0, 10) else None
+            api_version = 0 if self.config['api_version'] < (0, 10) else 1
+            request = MetadataRequest[api_version](topics)
+            log.debug("Sending metadata request %s to node %s", request, node_id)
+            future = self.send(node_id, request, wakeup=wakeup)
+            future.add_callback(self.cluster.update_metadata)
+            future.add_errback(self.cluster.failed_update)
+
+            self._metadata_refresh_in_progress = True
+
+            # pylint: disable=unused-argument
+            def refresh_done(val_or_error):
+                self._metadata_refresh_in_progress = False
+
+            # pylint: enable=unused-argument
+
+            future.add_callback(refresh_done)
+            future.add_errback(refresh_done)
+            return self.config['request_timeout_ms']
+        if self._connecting:
+            return self.config['reconnect_backoff_ms']
+
+        if self.maybe_connect(node_id, wakeup=wakeup):
+            log.debug("Initializing connection to node %s for metadata request", node_id)
+            return self.config['reconnect_backoff_ms']
+        return float('inf')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 git+https://github.com/aiven/avro.git@skip-namespace-validation#subdirectory=lang/py3/
-kafka-python==2.0.1
+git+git://github.com/aiven/kafka-python.git@39a372538c6bdfbfcb7852c36bed5de61e34bad8
 aiohttp-socks==0.3.4
 pylint==2.4.4
 pytest==5.4.1


### PR DESCRIPTION
Patch the karapace kafka client to only make metadata calls to the
bootstrap node. This will fix a bug where metadata calls would end up
continuously being made to no longer valid connections, resulting in a
stale metadata, log spam and probably decreased performance