### PR TITLE
logic: update master election logic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -476,6 +476,10 @@ for the service to start
 
 Name strategy to use when storing schemas from the kafka rest proxy service
 
+``master_election_strategy`` (default ``lowest``)
+
+Decides on what basis the karapace cluster master is chosen (only relevant in a multi node setup)
+
 License
 =======
 

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -44,6 +44,7 @@ DEFAULTS = {
     "session_timeout_ms": 10000,
     "karapace_rest": False,
     "karapace_registry": False,
+    "master_election_strategy": "lowest"
 }
 
 
@@ -75,6 +76,8 @@ def set_config_defaults(config: Dict[str, Union[str, int, bool]]) -> Dict[str, U
             print(f"Populating config value {k} from env var {env_name} with {val} instead of config file")
             config[k] = parse_env_value(os.environ[env_name])
         config.setdefault(k, v)
+    strat = config["master_election_strategy"]
+    assert strat.lower() in {"highest", "lowest"}, f"Invalid master election strategy: {strat}"
     return config
 
 


### PR DESCRIPTION
Having the highest cluster node instead of the lowest one be the master
will in theory ensure that newer cluster members are immediately
eligible, thus preventing slaves pointing to dead / killed masters