### PR TITLE
logic: block ns failed connections

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -126,6 +126,7 @@ class KafkaSchemaReader(Thread):
             session_timeout_ms=session_timeout_ms,
             request_timeout_ms=request_timeout_ms,
             client_factory=KarapaceKafkaClient,
+            metadata_max_age_ms=self.config["metadata_max_age_ms"],
         )
 
     def init_admin_client(self):


### PR DESCRIPTION
Metadata updates will ensure we have access to an up to date broker list
for sending requests, but the client connection list can still hold
stale connections.
- Make sure we blackout requests failing with DNS errors
- If we encounter any such connections, close them and then force a
  metadata update
- Actually pass the metadata_max_age parameter to the SR consumer, as
  previously only the producer would make use of it