### PR TITLE
tests: ported avro compatibility tests

### DIFF
--- a/karapace/avro_compatibility.py
+++ b/karapace/avro_compatibility.py
@@ -1,10 +1,32 @@
 from avro.schema import (
     ARRAY, ArraySchema, BOOLEAN, BYTES, DOUBLE, ENUM, EnumSchema, Field, FIXED, FixedSchema, FLOAT, INT, LONG, MAP,
-    MapSchema, NamedSchema, NULL, RECORD, RecordSchema, Schema, STRING, UNION, UnionSchema
+    MapSchema, NamedSchema, Names, NULL, RECORD, RecordSchema, Schema, SchemaFromJSONData, STRING, UNION, UnionSchema
 )
 from copy import copy
 from enum import Enum
 from typing import Any, cast, Dict, List, Optional, Set
+
+import json
+
+
+def parse_json_ignore_trailing(s: str) -> Any:
+    """ Compatibility function with Avro which ignores trailing data in JSON
+    strings.
+
+    The Python stdlib `json` module doesn't allow to ignore trailing data. If
+    parsing fails because of it, the extra data can be removed and parsed
+    again.
+    """
+    try:
+        json_data = json.loads(s)
+    except json.JSONDecodeError as e:
+        if e.msg != 'Extra data':
+            raise
+
+        json_data = json.loads(s[:e.pos])
+
+    names = Names()
+    return SchemaFromJSONData(json_data, names)
 
 
 class SchemaCompatibilityType(Enum):

--- a/karapace/avro_compatibility.py
+++ b/karapace/avro_compatibility.py
@@ -4,7 +4,7 @@ from avro.schema import (
 )
 from copy import copy
 from enum import Enum
-from typing import cast, Dict, List, Optional, Set
+from typing import Any, cast, Dict, List, Optional, Set
 
 
 class SchemaCompatibilityType(Enum):
@@ -71,6 +71,15 @@ class SchemaCompatibilityResult:
             messages={message},
         )
         return ret
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, SchemaCompatibilityResult):
+            return False
+
+        return (
+            self.locations == other.locations and self.messages == other.messages
+            and self.compatibility == other.compatibility and self.incompatibilities == other.incompatibilities
+        )
 
     def __str__(self):
         return f"{self.compatibility}: {self.messages}"

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -4,7 +4,7 @@ karapace - Kafka schema reader
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
-from avro.schema import parse, Schema as AvroSchema, SchemaParseException
+from avro.schema import Schema as AvroSchema, SchemaParseException
 from enum import Enum, unique
 from json import JSONDecodeError, loads
 from jsonschema.exceptions import SchemaError
@@ -13,6 +13,7 @@ from kafka import KafkaConsumer
 from kafka.admin import KafkaAdminClient, NewTopic
 from kafka.errors import NoBrokersAvailable, NodeNotReadyError, TopicAlreadyExistsError
 from karapace import constants
+from karapace.avro_compatibility import parse_json_ignore_trailing
 from karapace.statsd import StatsClient
 from karapace.utils import json_encode, KarapaceKafkaClient
 from queue import Queue
@@ -56,7 +57,7 @@ class TypedSchema:
     @staticmethod
     def parse_avro(schema_str: str):  # pylint: disable=inconsistent-return-statements
         try:
-            ts = TypedSchema(parse(schema_str), SchemaType.AVRO, schema_str)
+            ts = TypedSchema(parse_json_ignore_trailing(schema_str), SchemaType.AVRO, schema_str)
             return ts
         except SchemaParseException as e:
             raise InvalidSchema from e

--- a/tests/test_avro_schema.py
+++ b/tests/test_avro_schema.py
@@ -96,25 +96,26 @@ def test_schemaregistry_basic_forwards_compatibility():
     schema.
     """
     msg = "adding a field is a forward compatible change"
-    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
     assert res == SchemaCompatibilityResult.compatible(), msg
 
-    # msg = "adding a field is a forward compatible change"
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
-    # assert res == SchemaCompatibilityResult.compatible(), msg
-
     msg = "adding a field is a forward compatible change"
-    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
     assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding a field is a forward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
     assert res == SchemaCompatibilityResult.compatible(), msg
 
-    msg = "removing a default is not a transitively compatible change"
-    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
+    msg = "adding a field is a forward compatible change"
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
     assert res == SchemaCompatibilityResult.compatible(), msg
-    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+
+    msg = "removing a default is not a transitively compatible change"
+    # Only schema 2 is checked!
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
+    # assert res != SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
     assert res == SchemaCompatibilityResult.compatible(), msg
 
 
@@ -124,24 +125,24 @@ def test_schemaregistry_basic_forwards_transitive_compatibility():
     in this schema.
     """
     # msg = "iteratively removing fields with defaults is a compatible change"
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema8)
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema1)
     # assert res == SchemaCompatibilityResult.compatible(), msg
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
     # assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding default to a field is a compatible change"
-    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
     assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a field with a default is a compatible change"
-    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
     assert res == SchemaCompatibilityResult.compatible(), msg
 
-    # msg = "removing a default is not a transitively compatible change"
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    # assert res == SchemaCompatibilityResult.compatible(), msg
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
-    # assert res != SchemaCompatibilityResult.compatible(), msg
+    msg = "removing a default is not a transitively compatible change"
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
+    assert res != SchemaCompatibilityResult.compatible(), msg
 
 
 def test_basic_full_compatibility():
@@ -149,18 +150,30 @@ def test_basic_full_compatibility():
     msg = "adding a field with default is a backward and a forward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
     assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
-    # msg = "transitively adding a field without a default is not a compatible change"
+    msg = "transitively adding a field without a default is not a compatible change"
+    # Only schema 2 is checked!
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
     # assert res != SchemaCompatibilityResult.compatible(), msg
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
-    # assert res == SchemaCompatibilityResult.compatible(), msg
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
+    # assert res != SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
-    # msg = "transitively removing a field without a default is not a compatible change"
+    msg = "transitively removing a field without a default is not a compatible change"
+    # Only schema 2 is checked!
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
     # assert res == SchemaCompatibilityResult.compatible(), msg
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
     # assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
 
 def test_basic_full_transitive_compatibility():
@@ -171,42 +184,66 @@ def test_basic_full_transitive_compatibility():
     # msg = "iteratively adding fields with defaults is a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema1)
     # assert res == SchemaCompatibilityResult.compatible(), msg
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema2)
-    # assert res == SchemaCompatibilityResult.compatible(), msg
-
-    # msg = "iteratively removing fields with defaults is a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema8)
     # assert res == SchemaCompatibilityResult.compatible(), msg
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema2)
     # assert res == SchemaCompatibilityResult.compatible(), msg
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema8)
+    # assert res == SchemaCompatibilityResult.compatible(), msg
+
+    msg = "iteratively removing fields with defaults is a compatible change"
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema8)
+    # assert res == SchemaCompatibilityResult.compatible(), msg
+    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema1)
+    # assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding default to a field is a compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
     assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a field with a default is a compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
     assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding a field with default is a compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
     assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a default from a field compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
     assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
-    # msg = "transitively adding a field without a default is not a compatible change"
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
-    # assert res == SchemaCompatibilityResult.compatible(), msg
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
-    # assert res != SchemaCompatibilityResult.compatible(), msg
+    msg = "transitively adding a field without a default is not a compatible change"
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
+    assert res != SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
-    # msg = "transitively removing a field without a default is not a compatible change"
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    # assert res == SchemaCompatibilityResult.compatible(), msg
-    # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
-    # assert res == SchemaCompatibilityResult.compatible(), msg
+    msg = "transitively removing a field without a default is not a compatible change"
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
+    assert res == SchemaCompatibilityResult.compatible(), msg
+    res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
+    assert res != SchemaCompatibilityResult.compatible(), msg
 
 
 def test_simple_schema_promotion():

--- a/tests/test_avro_schema.py
+++ b/tests/test_avro_schema.py
@@ -3,7 +3,7 @@
     and are here for debugging and speed, and as an initial sanity check
 """
 from avro.schema import ArraySchema, Field, MapSchema, parse, RecordSchema, Schema, UnionSchema
-from karapace.avro_compatibility import ReaderWriterCompatibilityChecker, SchemaCompatibilityType
+from karapace.avro_compatibility import ReaderWriterCompatibilityChecker, SchemaCompatibilityResult, SchemaCompatibilityType
 
 import json
 import pytest
@@ -37,31 +37,31 @@ def test_schemaregistry_basic_backwards_compatibility():
     """
     msg = "adding a field with default is a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding a field w/o default is NOT a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
-    assert res.compatibility is SchemaCompatibilityType.incompatible, msg
+    assert res != SchemaCompatibilityResult.compatible(), msg
 
     msg = "changing field name with alias is a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema4, schema1)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "evolving a field type to a union is a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema6, schema1)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a type from a union is NOT a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema6)
-    assert res.compatibility is SchemaCompatibilityType.incompatible, msg
+    assert res != SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding a new type in union is a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema7, schema6)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a type from a union is NOT a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema6, schema7)
-    assert res.compatibility is SchemaCompatibilityType.incompatible, msg
+    assert res != SchemaCompatibilityResult.compatible(), msg
 
 
 def test_schemaregistry_basic_backwards_transitive_compatibility():
@@ -71,23 +71,23 @@ def test_schemaregistry_basic_backwards_transitive_compatibility():
     """
     # msg = "iteratively adding fields with defaults is a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema1)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding a field with default is a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a default is a compatible change, but not transitively"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a default is not a transitively compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
-    assert res.compatibility is SchemaCompatibilityType.incompatible, msg
+    assert res != SchemaCompatibilityResult.compatible(), msg
 
 
 def test_schemaregistry_basic_forwards_compatibility():
@@ -97,25 +97,25 @@ def test_schemaregistry_basic_forwards_compatibility():
     """
     msg = "adding a field is a forward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     # msg = "adding a field is a forward compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding a field is a forward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding a field is a forward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a default is not a transitively compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
 
 def test_schemaregistry_basic_forwards_transitive_compatibility():
@@ -125,42 +125,42 @@ def test_schemaregistry_basic_forwards_transitive_compatibility():
     """
     # msg = "iteratively removing fields with defaults is a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema8)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding default to a field is a compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a field with a default is a compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     # msg = "removing a default is not a transitively compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
-    # assert res.compatibility is SchemaCompatibilityType.incompatible, msg
+    # assert res != SchemaCompatibilityResult.compatible(), msg
 
 
 def test_basic_full_compatibility():
     """Full compatibility: A new schema is fully compatible if it’s both backward and forward compatible."""
     msg = "adding a field with default is a backward and a forward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     # msg = "transitively adding a field without a default is not a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
-    # assert res.compatibility is SchemaCompatibilityType.incompatible, msg
+    # assert res != SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
 
     # msg = "transitively removing a field without a default is not a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
 
 
 def test_basic_full_transitive_compatibility():
@@ -170,43 +170,43 @@ def test_basic_full_transitive_compatibility():
     """
     # msg = "iteratively adding fields with defaults is a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema1)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema8, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
 
     # msg = "iteratively removing fields with defaults is a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema8)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding default to a field is a compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema3)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a field with a default is a compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "adding a field with default is a compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema2, schema1)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     msg = "removing a default from a field compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
-    assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
     # msg = "transitively adding a field without a default is not a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema3, schema1)
-    # assert res.compatibility is SchemaCompatibilityType.incompatible, msg
+    # assert res != SchemaCompatibilityResult.compatible(), msg
 
     # msg = "transitively removing a field without a default is not a compatible change"
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema2)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
     # res = ReaderWriterCompatibilityChecker().get_compatibility(schema1, schema3)
-    # assert res.compatibility is SchemaCompatibilityType.compatible, msg
+    # assert res == SchemaCompatibilityResult.compatible(), msg
 
 
 def test_simple_schema_promotion():
@@ -254,9 +254,9 @@ def test_simple_schema_promotion():
     assert res.compatibility is SchemaCompatibilityType.compatible, res.locations
 
     res = ReaderWriterCompatibilityChecker().get_compatibility(reader, writer)
-    assert res.compatibility is SchemaCompatibilityType.compatible, res
+    assert res == SchemaCompatibilityResult.compatible(), res
     res = ReaderWriterCompatibilityChecker().get_compatibility(writer, reader)
-    assert res.compatibility is SchemaCompatibilityType.incompatible, res
+    assert res != SchemaCompatibilityResult.compatible(), res
 
     writer = parse(
         json.dumps({
@@ -325,7 +325,7 @@ def test_simple_schema_promotion():
         })
     )
     res = ReaderWriterCompatibilityChecker().get_compatibility(writer=writer, reader=reader)
-    assert res.compatibility is SchemaCompatibilityType.compatible, res
+    assert res == SchemaCompatibilityResult.compatible(), res
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is the initial port of the tests, commented out tests are:

- Relying in the schema8, which is not parseable by the avro library (it looks like it is a sequence of items separated by a single `,`)
- Doing transitivity tests. These need to be reviewed in more detail to understand what is the proper behaviour. It is not clear which of the "legs" in the chain is breaking the schema compatibility
- There seems to be a few bugs with backwards and forwards compatibility that were commented out