### PR TITLE
Added typing info to conftest.py

### DIFF
--- a/tests/test_master_coordinator.py
+++ b/tests/test_master_coordinator.py
@@ -6,6 +6,8 @@ See LICENSE for details
 """
 from karapace.config import set_config_defaults
 from karapace.master_coordinator import MasterCoordinator
+from tests.utils import KafkaConfig, REGISTRY_URI, REST_URI
+from typing import Optional
 
 import asyncio
 import json
@@ -26,17 +28,19 @@ def init_admin(config):
 
 
 @pytest.mark.parametrize("strategy", ["lowest", "highest"])
-def test_master_selection(kafka_server, strategy):
+def test_master_selection(kafka_server: Optional[KafkaConfig], strategy: str) -> None:
+    assert kafka_server, f"test_master_selection can not be used if the env variable `{REGISTRY_URI}` or `{REST_URI}` is set"
+
     config_aa = set_config_defaults({})
     config_aa["advertised_hostname"] = "127.0.0.1"
-    config_aa["bootstrap_uri"] = "127.0.0.1:{}".format(kafka_server["kafka_port"])
+    config_aa["bootstrap_uri"] = "127.0.0.1:{}".format(kafka_server.kafka_port)
     config_aa["client_id"] = "aa"
     config_aa["port"] = 1234
     config_aa["master_election_strategy"] = strategy
     mc_aa = init_admin(config_aa)
     config_bb = set_config_defaults({})
     config_bb["advertised_hostname"] = "127.0.0.1"
-    config_bb["bootstrap_uri"] = "127.0.0.1:{}".format(kafka_server["kafka_port"])
+    config_bb["bootstrap_uri"] = "127.0.0.1:{}".format(kafka_server.kafka_port)
     config_bb["client_id"] = "bb"
     config_bb["port"] = 5678
     config_bb["master_election_strategy"] = strategy

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from kafka.errors import TopicAlreadyExistsError
 from karapace.utils import Client
 from unittest.mock import MagicMock
@@ -97,6 +98,14 @@ REST_HEADERS = {
 }
 REST_URI = "REST_URI"
 REGISTRY_URI = "REGISTRY_URI"
+
+
+@dataclass
+class KafkaConfig:
+    datadir: str
+    kafka_keystore_password: str
+    kafka_port: int
+    zookeeper_port: int
 
 
 def get_broker_ip():


### PR DESCRIPTION
As the title says, this just adds type information to the conftest.

While adding the typing annotations I noticed some fixtures are conditional in respect to the env variables `REST_URI` and `REGISTRY_URI`. From the commit history it looks like these are just artifacts from how the tests used to be executed. I guess they should eventually be removed.