### PR TITLE
karapace: read configuration only once

### DIFF
--- a/karapace/config.py
+++ b/karapace/config.py
@@ -5,7 +5,7 @@ Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
 
-from typing import Dict, Union
+from typing import Dict, IO, Union
 
 import json
 import os
@@ -86,14 +86,13 @@ def write_config(config_path: str, custom_values: Dict[str, Union[str, int, bool
         fp.write(json.dumps(custom_values))
 
 
-def read_config(config_path: str) -> Dict[str, Union[str, int, bool]]:
-    with open(config_path, "r") as cf:
-        try:
-            config = json.loads(cf.read())
-            config = set_config_defaults(config)
-            return config
-        except Exception as ex:
-            raise InvalidConfiguration(ex)
+def read_config(config_handler: IO) -> Dict[str, Union[str, int, bool]]:
+    try:
+        config = json.load(config_handler)
+        config = set_config_defaults(config)
+        return config
+    except Exception as ex:
+        raise InvalidConfiguration(ex)
 
 
 def create_ssl_context(config: Dict[str, Union[str, int, bool]]) -> ssl.SSLContext:

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -35,13 +35,13 @@ class FormatError(Exception):
 
 class KafkaRest(KarapaceBase):
     # pylint: disable=attribute-defined-outside-init
-    def __init__(self, config_path: str) -> None:
-        super().__init__(config_path)
+    def __init__(self, config_file_path: str, config: dict) -> None:
+        super().__init__(config_file_path=config_file_path, config=config)
         self._add_routes()
-        self._init(config_path)
+        self._init(config=config)
 
-    def _init(self, config_path: str) -> None:
-        self.serializer = SchemaRegistrySerializer(config_path=config_path)
+    def _init(self, config: dict) -> None:
+        self.serializer = SchemaRegistrySerializer(config=config)
         self.log = logging.getLogger("KarapaceRest")
         self.loop = asyncio.get_event_loop()
         self._cluster_metadata = None
@@ -51,7 +51,7 @@ class KafkaRest(KarapaceBase):
         self.admin_lock = Lock()
         self.metadata_cache = None
         self.schemas_cache = {}
-        self.consumer_manager = ConsumerManager(config_path)
+        self.consumer_manager = ConsumerManager(config=config)
         self.init_admin_client()
         self.producer_refs = []
         self.producer_queue = asyncio.Queue()

--- a/karapace/kafka_rest_apis/__main__.py
+++ b/karapace/kafka_rest_apis/__main__.py
@@ -1,28 +1,30 @@
+from contextlib import closing
 from karapace import version as karapace_version
+from karapace.config import read_config
 from karapace.kafka_rest_apis import KafkaRest
 
 import argparse
-import os
 import sys
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(prog="karapace rest", description="Karapace: Your Kafka essentials in one tool")
     parser.add_argument("--version", action="version", help="show program version", version=karapace_version.__version__)
-    parser.add_argument("config_file", help="configuration file path")
+    parser.add_argument("config_file", help="configuration file path", type=argparse.FileType())
     arg = parser.parse_args()
 
-    if not os.path.exists(arg.config_file):
-        print("Config file: {} does not exist, exiting".format(arg.config_file))
-        return 1
+    with closing(arg.config_file):
+        config = read_config(arg.config_file)
 
-    kc = KafkaRest(arg.config_file)
+    kc = KafkaRest(config_file_path=arg.config_file.name, config=config)
     try:
-        return kc.run(host=kc.config["host"], port=kc.config["port"])
+        kc.run(host=kc.config["host"], port=kc.config["port"])
     except Exception:  # pylint: disable-broad-except
         if kc.raven_client:
             kc.raven_client.captureException(tags={"where": "karapace_rest"})
         raise
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -25,11 +25,11 @@ TypedConsumer = namedtuple("TypedConsumer", ["consumer", "serialization_format",
 
 
 class ConsumerManager:
-    def __init__(self, config_path: str):
-        self.config = KarapaceBase.read_config(config_path)
+    def __init__(self, config: dict) -> None:
+        self.config = config
         self.hostname = f"http://{self.config['advertised_hostname']}:{self.config['port']}"
         self.log = logging.getLogger("RestConsumerManager")
-        self.deserializer = SchemaRegistryDeserializer(config_path=config_path)
+        self.deserializer = SchemaRegistryDeserializer(config=config)
         self.consumers = {}
         self.consumer_locks = defaultdict(Lock)
 

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -7,7 +7,6 @@ See LICENSE for details
 
 from functools import partial
 from kafka import KafkaProducer
-from karapace.config import read_config
 from karapace.rapu import HTTPResponse, RestApp
 from karapace.utils import KarapaceKafkaClient
 
@@ -21,12 +20,12 @@ logging.basicConfig(level=logging.INFO, format=LOG_FORMAT_JOURNAL)
 
 
 class KarapaceBase(RestApp):
-    def __init__(self, config_path):
+    def __init__(self, config_file_path: str, config: dict) -> None:
         self.config = {}
         self.producer = None
         self.kafka_timeout = 10
-        self.config_path = config_path
-        self.config = self.read_config(self.config_path)
+        self.config_path = config_file_path
+        self.config = config
         self._sentry_config = self.config.get("sentry", {"dsn": None}).copy()
         if os.environ.get("SENTRY_DSN"):
             self._sentry_config["dsn"] = os.environ["SENTRY_DSN"]
@@ -66,10 +65,6 @@ class KarapaceBase(RestApp):
             return
         self.producer.close()
         self.producer = None
-
-    @staticmethod
-    def read_config(config_path):
-        return read_config(config_path)
 
     def _set_log_level(self):
         try:

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -1,22 +1,23 @@
+from contextlib import closing
 from karapace import version as karapace_version
-from karapace.config import InvalidConfiguration, read_config
+from karapace.config import read_config
 from karapace.kafka_rest_apis import KafkaRest
 from karapace.karapace import KarapaceBase
+from karapace.rapu import RestApp
 from karapace.schema_registry_apis import KarapaceSchemaRegistry
 
 import argparse
 import logging
-import os
 import sys
 
 
 class KarapaceAll(KafkaRest, KarapaceSchemaRegistry, KarapaceBase):
     # pylint: disable=super-init-not-called
-    def __init__(self, config):
-        KarapaceBase.__init__(self, config)
-        KafkaRest._init(self, config)
+    def __init__(self, config_file_path: str, config: dict) -> None:
+        KarapaceBase.__init__(self, config_file_path=config_file_path, config=config)
+        KafkaRest._init(self, config=config)
         KafkaRest._add_routes(self)
-        KarapaceSchemaRegistry._init(self)
+        KarapaceSchemaRegistry._init(self, config=config)
         KarapaceSchemaRegistry._add_routes(self)
         self.log = logging.getLogger("KarapaceAll")
         self.app.on_shutdown.append(self.close_by_app)
@@ -34,42 +35,40 @@ class KarapaceAll(KafkaRest, KarapaceSchemaRegistry, KarapaceBase):
             KafkaRest.close_producers(self)
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(prog="karapace", description="Karapace: Your Kafka essentials in one tool")
     parser.add_argument("--version", action="version", help="show program version", version=karapace_version.__version__)
-    parser.add_argument("config_file", help="configuration file path")
+    parser.add_argument("config_file", help="configuration file path", type=argparse.FileType())
     arg = parser.parse_args()
 
-    if not os.path.exists(arg.config_file):
-        print("Config file: {} does not exist, exiting".format(arg.config_file))
-        return 1
-    config = None
-    kc = None
-    info_str = ""
-    try:
+    with closing(arg.config_file):
         config = read_config(arg.config_file)
-    except InvalidConfiguration:
-        print("Config file: {} is invalid, exiting".format(arg.config_file))
-        return 1
+
+    config_file_path = arg.config_file.name
+
+    kc: RestApp
     if config["karapace_rest"] and config["karapace_registry"]:
         info_str = "both services"
-        kc = KarapaceAll(arg.config_file)
+        kc = KarapaceAll(config_file_path=config_file_path, config=config)
     elif config["karapace_rest"]:
         info_str = "karapace rest"
-        kc = KafkaRest(arg.config_file)
+        kc = KafkaRest(config_file_path=config_file_path, config=config)
     elif config["karapace_registry"]:
         info_str = "karapace schema registry"
-        kc = KarapaceSchemaRegistry(arg.config_file)
+        kc = KarapaceSchemaRegistry(config_file_path=config_file_path, config=config)
     else:
         print("Both rest and registry options are disabled, exiting")
         return 1
+
     print("=" * 100 + f"\nStarting {info_str}\n" + "=" * 100)
+
     try:
-        return kc.run(host=kc.config["host"], port=kc.config["port"])
+        kc.run(host=kc.config["host"], port=kc.config["port"])
     except Exception:  # pylint: disable-broad-except
         if kc.raven_client:
             kc.raven_client.captureException(tags={"where": "karapace"})
         raise
+    return 0
 
 
 if __name__ == "__main__":

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -1,7 +1,6 @@
 from avro.io import BinaryDecoder, BinaryEncoder, DatumReader, DatumWriter
 from json import load
 from jsonschema import ValidationError
-from karapace.config import read_config
 from karapace.schema_reader import InvalidSchema, SchemaType, TypedSchema
 from karapace.utils import Client, json_encode
 from typing import Dict, Optional
@@ -111,11 +110,11 @@ class SchemaRegistryClient:
 class SchemaRegistrySerializerDeserializer:
     def __init__(
         self,
-        config_path: str,
+        config: dict,
         name_strategy: str = "topic_name",
         **cfg,  # pylint: disable=unused-argument
     ) -> None:
-        self.config = read_config(config_path)
+        self.config = config
         self.state_lock = asyncio.Lock()
         registry_url = f"http://{self.config['registry_host']}:{self.config['registry_port']}"
         registry_client = SchemaRegistryClient(registry_url)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,3 +1,4 @@
+from karapace.config import read_config
 from karapace.schema_reader import SchemaType, TypedSchema
 from karapace.serialization import (
     HEADER_FORMAT, InvalidMessageHeader, InvalidMessageSchema, InvalidPayload, SchemaRegistryClient,
@@ -16,8 +17,10 @@ pytest_plugins = "aiohttp.pytest_plugin"
 
 
 async def make_ser_deser(config_path, mock_client):
-    serializer = SchemaRegistrySerializer(config_path=config_path)
-    deserializer = SchemaRegistryDeserializer(config_path=config_path)
+    with open(config_path) as handler:
+        config = read_config(handler)
+    serializer = SchemaRegistrySerializer(config_path=config_path, config=config)
+    deserializer = SchemaRegistryDeserializer(config_path=config_path, config=config)
     await serializer.registry_client.close()
     await deserializer.registry_client.close()
     serializer.registry_client = mock_client


### PR DESCRIPTION
This change the code so that the configuration file is read only once at the `main`. I'm doing this for a few reasons:

- I want to eventually add validation for the configuration and make it a dataclass. This will make it possible to have type checking and auto completion for the config, have faster errors on improper configuration, and make it easier to document all the available options. (some of that, but not all, is done by the [`set_config_defaults`](https://github.com/aiven/karapace/blob/master/karapace/config.py#L68-L81))
- This should also make testing easier, since files won't be necessary any longer. ATM I couldn't remove the file path because the fixtures are piggybacking into the class state and getting the path.
- This also makes sure the config is consistent, in the unlikely event of the file changing while the servers are starting up.