### PR TITLE
Update kafka-python and fix api change.

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -299,7 +299,7 @@ class KafkaRest(KarapaceBase):
                     api_version=(1, 0, 0),
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
                     connections_max_idle_ms=self.config["connections_max_idle_ms"],
-                    client_factory=KarapaceKafkaClient,
+                    kafka_client=KarapaceKafkaClient,
                 )
                 break
             except:  # pylint: disable=bare-except

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -55,7 +55,7 @@ class KarapaceBase(RestApp):
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
                     max_block_ms=2000,  # missing topics will block unless we cache cluster metadata and pre-check
                     connections_max_idle_ms=self.config["connections_max_idle_ms"],  # helps through cluster upgrades ??
-                    client_factory=KarapaceKafkaClient,
+                    kafka_client=KarapaceKafkaClient,
                 )
             except:  # pylint: disable=bare-except
                 self.log.exception("Unable to create producer, retrying")

--- a/karapace/schema_backup.py
+++ b/karapace/schema_backup.py
@@ -51,7 +51,7 @@ class SchemaBackup:
             ssl_keyfile=self.config["ssl_keyfile"],
             auto_offset_reset="earliest",
             metadata_max_age_ms=self.config["metadata_max_age_ms"],
-            client_factory=KarapaceKafkaClient,
+            kafka_client=KarapaceKafkaClient,
         )
 
     def init_producer(self):
@@ -61,7 +61,7 @@ class SchemaBackup:
             ssl_cafile=self.config["ssl_cafile"],
             ssl_certfile=self.config["ssl_certfile"],
             ssl_keyfile=self.config["ssl_keyfile"],
-            client_factory=KarapaceKafkaClient,
+            kafka_client=KarapaceKafkaClient,
         )
 
     def init_admin_client(self):
@@ -80,7 +80,7 @@ class SchemaBackup:
                     ssl_cafile=self.config["ssl_cafile"],
                     ssl_certfile=self.config["ssl_certfile"],
                     ssl_keyfile=self.config["ssl_keyfile"],
-                    client_factory=KarapaceKafkaClient,
+                    kafka_client=KarapaceKafkaClient,
                 )
                 break
             except (NodeNotReadyError, NoBrokersAvailable, AssertionError):

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -128,7 +128,7 @@ class KafkaSchemaReader(Thread):
             auto_offset_reset="earliest",
             session_timeout_ms=session_timeout_ms,
             request_timeout_ms=request_timeout_ms,
-            client_factory=KarapaceKafkaClient,
+            kafka_client=KarapaceKafkaClient,
             metadata_max_age_ms=self.config["metadata_max_age_ms"],
         )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 git+https://github.com/aiven/avro.git@skip-namespace-validation#subdirectory=lang/py3/
-git+git://github.com/aiven/kafka-python.git@39a372538c6bdfbfcb7852c36bed5de61e34bad8
+git+git://github.com/aiven/kafka-python.git@346c01e4eec6bdcccc99ca613b79020f3be35eb7
 yapf==0.30.0
 aiohttp-socks==0.3.4
 pylint==2.4.4


### PR DESCRIPTION
`git+git://github.com/aiven/kafka-python.git@346c01e4eec6bdcccc99ca613b79020f3be35eb7` ~is the current commit for https://github.com/aiven/kafka-python/tree/aiven_patches , which is rebased on top of dpkp's master.~ `master` was updated instead, it is the same commit but now master points to it.

During the review fo https://github.com/dpkp/kafka-python/pull/2144 the configuration key changed name.