### PR TITLE
updated aiohttp-socks

### DIFF
--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -67,8 +67,8 @@ NAME_STRATEGIES = {
 
 
 class SchemaRegistryClient:
-    def __init__(self, schema_registry_url: str = "http://localhost:8081", loop: asyncio.AbstractEventLoop = None):
-        self.client = Client(server_uri=schema_registry_url, client=aiohttp.ClientSession(loop=loop))
+    def __init__(self, schema_registry_url: str = "http://localhost:8081"):
+        self.client = Client(server_uri=schema_registry_url, client=aiohttp.ClientSession())
         self.base_url = schema_registry_url
 
     async def post_new_schema(self, subject: str, schema: TypedSchema) -> int:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 git+https://github.com/aiven/avro.git@skip-namespace-validation#subdirectory=lang/py3/
 git+git://github.com/aiven/kafka-python.git@39a372538c6bdfbfcb7852c36bed5de61e34bad8
 yapf==0.30.0
-aiohttp-socks==0.3.4
+aiohttp-socks==0.5.5
 pylint==2.4.4
 pytest==5.4.1
 requests==2.23.0


### PR DESCRIPTION
Update aiohttp-socks ~and fix code to work with `aiohttp>=3.6.0`~ The code does work with `aiohttp>=3.6`, the removal of the `loop` argument is only for `aiohttp>=4` which is still on alpha.