### PR TITLE
bugfix: fix infinite loop

### DIFF
--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -45,7 +45,7 @@ class KafkaRestAdminClient(KafkaAdminClient):
                 "Kafka Admin interface cannot determine the controller using MetadataRequest_v{}.".format(metadata_version)
             )
         request = MetadataRequest[1](topics=topics)
-        future = self._send_request_to_node(self._client.least_loaded_node(), request)
+        future = self._send_request_to_least_loaded_node(request)
         try:
             self._wait_for_futures([future])
         except Cancelled:
@@ -94,7 +94,7 @@ class KafkaRestAdminClient(KafkaAdminClient):
         else:
             request = OffsetRequest[2](-1, 1, list(six.iteritems({topic: [(partition_id, timestamp)]})))
 
-        future = self._send_request_to_node(self._client.least_loaded_node(), request)
+        future = self._send_request_to_least_loaded_node(request)
         return future
 
     def get_offsets(self, topic: str, partition_id: int) -> dict:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 git+https://github.com/aiven/avro.git@skip-namespace-validation#subdirectory=lang/py3/
-git+git://github.com/aiven/kafka-python.git@346c01e4eec6bdcccc99ca613b79020f3be35eb7
+git+git://github.com/aiven/kafka-python.git@b9f2f78377d56392f61cba8856dc6c02ae841b79
 yapf==0.30.0
 aiohttp-socks==0.5.5
 pylint==2.4.4


### PR DESCRIPTION
Upstream issue: https://github.com/dpkp/kafka-python/issues/2193

Note: This PR should not be merged before dependency `kafka-python` is updated, or we merge the patch to our repo https://github.com/aiven/kafka-python/pull/20

Calling `_send_request_to_node` with the result of `least_loaded_node`
results in an infinite loop if the metadata is out-dated and
`least_loaded_node` return the `node_id` of a broker that was removed
from the cluster. The method `_send_request_to_least_loaded_node`
handles this race and fixes the infinite loop.