### PR TITLE
Update kafka mirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ karapace/version.py: version.py
 	$(PYTHON) $^ $@
 
 $(KAFKA_TAR):
-	wget "http://www.nic.funet.fi/pub/mirrors/apache.org/kafka/$(KAFKA_VERSION)/$(KAFKA_PATH).tgz"
+	wget "https://archive.apache.org/dist/kafka/$(KAFKA_VERSION)/$(KAFKA_PATH).tgz"
 
 $(KAFKA_PATH): $(KAFKA_TAR)
 	tar zxf "$(KAFKA_TAR)"

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:30
-ARG APACHE_MIRROR=http://www.nic.funet.fi/pub/mirrors/apache.org
+ARG APACHE_MIRROR=https://archive.apache.org/dist
 ARG SCALA_VERSION=2.12
 ARG KAFKA_VERSION=2.4.1
 

--- a/karapace.spec
+++ b/karapace.spec
@@ -1,6 +1,7 @@
 Name:           karapace
 Version:        %{major_version}
 Release:        %{minor_version}%{?dist}
+Epoch:          1000
 Url:            http://github.com/aiven/karapace
 Summary:        Your Kafka essentials in one tool
 License:        ASL 2.0


### PR DESCRIPTION
The previous mirror is returning `404` causing the build to fail:

```
wget "http://www.nic.funet.fi/pub/mirrors/apache.org/kafka/2.4.1/kafka_2.12-2.4.1.tgz"
--2021-02-01 08:18:01--  http://www.nic.funet.fi/pub/mirrors/apache.org/kafka/2.4.1/kafka_2.12-2.4.1.tgz
Resolving www.nic.funet.fi (www.nic.funet.fi)... 193.166.3.3, 2001:708:10:8::3
Connecting to www.nic.funet.fi (www.nic.funet.fi)|193.166.3.3|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-02-01 08:18:02 ERROR 404: Not Found.

make: *** [kafka_2.12-2.4.1.tgz] Error 8
Makefile:41: recipe for target 'kafka_2.12-2.4.1.tgz' failed
Error: Process completed with exit code 2.
```