### PR TITLE
tests: added test for accept header regex

### DIFF
--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -1,4 +1,4 @@
-from karapace.rapu import HTTPRequest, REST_ACCEPT_RE
+from karapace.rapu import HTTPRequest, REST_ACCEPT_RE, REST_CONTENT_TYPE_RE
 
 
 async def test_header_get():
@@ -72,6 +72,79 @@ def test_rest_accept_re():
         'general_format': None,
     }
     assert REST_ACCEPT_RE.match('application/vnd.kafka.v2+json').groupdict() == {
+        'embedded_format': None,
+        'api_version': 'v2',
+        'serialization_format': 'json',
+        'general_format': None,
+    }
+
+
+def test_content_type_re():
+    # incomplete headers
+    assert not REST_CONTENT_TYPE_RE.match('')
+    assert not REST_CONTENT_TYPE_RE.match('application/')
+    assert not REST_CONTENT_TYPE_RE.match('application/vnd.kafka')
+    assert not REST_CONTENT_TYPE_RE.match('application/vnd.kafka.json')
+    # Unsupported serialization formats
+    assert not REST_CONTENT_TYPE_RE.match('application/vnd.kafka+avro')
+    assert not REST_CONTENT_TYPE_RE.match('application/vnd.kafka+protobuf')
+    assert not REST_CONTENT_TYPE_RE.match('application/vnd.kafka+binary')
+    # Unspecified format
+    assert not REST_CONTENT_TYPE_RE.match('application/*')
+
+    assert REST_CONTENT_TYPE_RE.match('application/json').groupdict() == {
+        'embedded_format': None,
+        'api_version': None,
+        'serialization_format': None,
+        'general_format': 'json',
+    }
+    assert REST_CONTENT_TYPE_RE.match('application/octet-stream').groupdict() == {
+        'embedded_format': None,
+        'api_version': None,
+        'serialization_format': None,
+        'general_format': 'octet-stream',
+    }
+    assert REST_CONTENT_TYPE_RE.match('application/vnd.kafka+json').groupdict() == {
+        'embedded_format': None,
+        'api_version': None,
+        'serialization_format': 'json',
+        'general_format': None,
+    }
+
+    # Embdded format
+    assert REST_CONTENT_TYPE_RE.match('application/vnd.kafka.avro+json').groupdict() == {
+        'embedded_format': 'avro',
+        'api_version': None,
+        'serialization_format': 'json',
+        'general_format': None,
+    }
+    assert REST_CONTENT_TYPE_RE.match('application/vnd.kafka.json+json').groupdict() == {
+        'embedded_format': 'json',
+        'api_version': None,
+        'serialization_format': 'json',
+        'general_format': None,
+    }
+    assert REST_CONTENT_TYPE_RE.match('application/vnd.kafka.binary+json').groupdict() == {
+        'embedded_format': 'binary',
+        'api_version': None,
+        'serialization_format': 'json',
+        'general_format': None,
+    }
+    assert REST_CONTENT_TYPE_RE.match('application/vnd.kafka.jsonschema+json').groupdict() == {
+        'embedded_format': 'jsonschema',
+        'api_version': None,
+        'serialization_format': 'json',
+        'general_format': None,
+    }
+
+    # API version
+    assert REST_CONTENT_TYPE_RE.match('application/vnd.kafka.v1+json').groupdict() == {
+        'embedded_format': None,
+        'api_version': 'v1',
+        'serialization_format': 'json',
+        'general_format': None,
+    }
+    assert REST_CONTENT_TYPE_RE.match('application/vnd.kafka.v2+json').groupdict() == {
         'embedded_format': None,
         'api_version': 'v2',
         'serialization_format': 'json',


### PR DESCRIPTION
As the PR title says. The goal here is more to have examples of the matching strings to make it easier to understand what to expect from the regex groups 