### PR TITLE
Added typing to the SchemaCompatibilityResult class

### DIFF
--- a/karapace/compatibility.py
+++ b/karapace/compatibility.py
@@ -4,6 +4,7 @@ karapace - schema compatibility checking
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from enum import Enum, unique
 from karapace.avro_compatibility import (
     ReaderWriterCompatibilityChecker as AvroChecker, SchemaCompatibilityType, SchemaIncompatibilityType
 )
@@ -12,6 +13,25 @@ from karapace.schema_reader import SchemaType, TypedSchema
 import logging
 
 LOG = logging.getLogger(__name__)
+
+
+@unique
+class CompatibilityModes(Enum):
+    BACKWARD = "BACKWARD"
+    BACKWARD_TRANSITIVE = "BACKWARD_TRANSITIVE"
+    FORWARD = "FORWARD"
+    FORWARD_TRANSITIVE = "FORWARD_TRANSITIVE"
+    FULL = "FULL"
+    FULL_TRANSITIVE = "FULL_TRANSITIVE"
+    NONE = "NONE"
+
+    def is_transitive(self) -> bool:
+        TRANSITIVE_MODES = {
+            "BACKWARD_TRANSITIVE",
+            "FORWARD_TRANSITIVE",
+            "FULL_TRANSITIVE",
+        }
+        return self.value in TRANSITIVE_MODES
 
 
 class IncompatibleSchema(Exception):
@@ -27,22 +47,22 @@ def check_avro_compatibility(reader_schema, writer_schema) -> None:
         raise IncompatibleSchema(str(result.compatibility))
 
 
-def check_compatibility(source: TypedSchema, target: TypedSchema, compatibility: str) -> None:
+def check_compatibility(source: TypedSchema, target: TypedSchema, compatibility_mode: CompatibilityModes) -> None:
     if source.schema_type is not target.schema_type:
         raise IncompatibleSchema(f"Comparing different schema types: {source.schema_type} with {target.schema_type}")
 
-    # Compatibility only checks between two versions, so we can drop the possible _TRANSITIVE
-    checking_for = compatibility.split("_")[0]
-    if checking_for == "NONE":
+    if compatibility_mode is CompatibilityModes.NONE:
         LOG.info("Compatibility level set to NONE, no schema compatibility checks performed")
         return
 
     if source.schema_type is SchemaType.AVRO:
-        if checking_for == "BACKWARD":
+        if compatibility_mode in {CompatibilityModes.BACKWARD, CompatibilityModes.BACKWARD_TRANSITIVE}:
             check_avro_compatibility(writer_schema=source.schema, reader_schema=target.schema)
-        elif checking_for == "FORWARD":
+
+        elif compatibility_mode in {CompatibilityModes.FORWARD, CompatibilityModes.FORWARD_TRANSITIVE}:
             check_avro_compatibility(writer_schema=target.schema, reader_schema=source.schema)
-        elif checking_for == "FULL":
+
+        elif compatibility_mode in {CompatibilityModes.FULL, CompatibilityModes.FULL_TRANSITIVE}:
             check_avro_compatibility(writer_schema=source.schema, reader_schema=target.schema)
             check_avro_compatibility(writer_schema=target.schema, reader_schema=source.schema)
 

--- a/karapace/compatibility.py
+++ b/karapace/compatibility.py
@@ -18,7 +18,16 @@ class IncompatibleSchema(Exception):
     pass
 
 
-def check_compatibility(source: TypedSchema, target: TypedSchema, compatibility: str) -> bool:
+def check_avro_compatibility(reader_schema, writer_schema) -> None:
+    result = AvroChecker().get_compatibility(reader=reader_schema, writer=writer_schema)
+    if (
+        result.compatibility is SchemaCompatibilityType.incompatible
+        and [SchemaIncompatibilityType.missing_enum_symbols] != result.incompatibilities
+    ):
+        raise IncompatibleSchema(str(result.compatibility))
+
+
+def check_compatibility(source: TypedSchema, target: TypedSchema, compatibility: str) -> None:
     if source.schema_type is not target.schema_type:
         raise IncompatibleSchema(f"Comparing different schema types: {source.schema_type} with {target.schema_type}")
 
@@ -26,22 +35,15 @@ def check_compatibility(source: TypedSchema, target: TypedSchema, compatibility:
     checking_for = compatibility.split("_")[0]
     if checking_for == "NONE":
         LOG.info("Compatibility level set to NONE, no schema compatibility checks performed")
-        return True
+        return
 
     if source.schema_type is SchemaType.AVRO:
-        if checking_for in {"BACKWARD", "FULL"}:
-            writer, reader = source.schema, target.schema
-            result = AvroChecker().get_compatibility(reader=reader, writer=writer)
-            if (
-                result.compatibility is SchemaCompatibilityType.incompatible
-                and [SchemaIncompatibilityType.missing_enum_symbols] != result.incompatibilities
-            ):
-                raise IncompatibleSchema(str(result.compatibility))
-        if checking_for in {"FORWARD", "FULL"}:
-            writer, reader = target.schema, source.schema
-            result = AvroChecker().get_compatibility(reader=reader, writer=writer)
-            if (
-                result.compatibility is SchemaCompatibilityType.incompatible
-                and [SchemaIncompatibilityType.missing_enum_symbols] != result.incompatibilities
-            ):
-                raise IncompatibleSchema(str(result.compatibility))
+        if checking_for == "BACKWARD":
+            check_avro_compatibility(writer_schema=source.schema, reader_schema=target.schema)
+        elif checking_for == "FORWARD":
+            check_avro_compatibility(writer_schema=target.schema, reader_schema=source.schema)
+        elif checking_for == "FULL":
+            check_avro_compatibility(writer_schema=source.schema, reader_schema=target.schema)
+            check_avro_compatibility(writer_schema=target.schema, reader_schema=source.schema)
+
+    LOG.info("Unknow schema_type %r", source.schema_type)


### PR DESCRIPTION
This does a few things

- Simplifies the code of `Compatibility`, it can be just a single function call
- Adds typing info and some docs to `SchemaCompatibilityResult`, I want to reuse this class with JSON schema

The goal was not to change any behavior just to document and simplify. I'm saying this because `check_compatibility` will need some refactoring. ATM this function is used only for the exceptions it raises, IOW, the return value is ignored by every caller. It makes a bit hard to reason if the callers are working as intended because `False` is returned is for unsupported formats (e.g. json schema and protobuf). I believe the code is behaving correctly because there are checks earlier in the code, but still, local reasoning is not great here.