### PR TITLE
Schema registry APIs using enum for error codes

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -26,6 +26,21 @@ class CompatibilityModes(Enum):
     NONE = "NONE"
 
 
+@unique
+class SchemaErrorCodes(Enum):
+    HTTP_NOT_FOUND = 404
+    HTTP_CONFLICT = 409
+    HTTP_UNPROCESSABLE_ENTITY = 422
+    HTTP_INTERNAL_SERVER_ERROR = 500
+    SUBJECT_NOT_FOUND = 40401
+    VERSION_NOT_FOUND = 40402
+    SCHEMA_NOT_FOUND = 40403
+    INVALID_VERSION_ID = 42202
+    INVALID_COMPATIBILITY_LEVEL = 42203
+    INVALID_AVRO_SCHEMA = 44201
+    NO_MASTER_ERROR = 50003
+
+
 TRANSITIVE_MODES = {
     "BACKWARD_TRANSITIVE",
     "FORWARD_TRANSITIVE",
@@ -117,11 +132,25 @@ class KarapaceSchemaRegistry(KarapaceBase):
     def _subject_get(self, subject, content_type):
         subject_data = self.ksr.subjects.get(subject)
         if not subject_data:
-            self.r({"error_code": 40401, "message": "Subject not found."}, content_type, status=404)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
+                    "message": "Subject not found.",
+                },
+                content_type=content_type,
+                status=404,
+            )
 
         schemas = self.ksr.get_schemas(subject)
         if not schemas:
-            self.r({"error_code": 40401, "message": "Subject not found."}, content_type, status=404)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
+                    "message": "Subject not found.",
+                },
+                content_type=content_type,
+                status=404,
+            )
 
         subject_data["schemas"] = schemas
         return subject_data
@@ -136,12 +165,14 @@ class KarapaceSchemaRegistry(KarapaceBase):
                 return version
         self.r(
             body={
-                "error_code": 42202,
-                "message": "The specified version is not a valid version id. "
-                "Allowed values are between [1, 2^31-1] and the string \"latest\""
+                "error_code": SchemaErrorCodes.INVALID_VERSION_ID.value,
+                "message": (
+                    "The specified version is not a valid version id. "
+                    "Allowed values are between [1, 2^31-1] and the string \"latest\""
+                ),
             },
             content_type=content_type,
-            status=422
+            status=422,
         )
 
     def get_offset_from_queue(self, sent_offset):
@@ -210,13 +241,27 @@ class KarapaceSchemaRegistry(KarapaceBase):
             new = TypedSchema.parse(schema_type, body["schema"])
         except InvalidSchema:
             self.log.warning("Invalid schema: %r", body["schema"])
-            self.r(body={"error_code": 44201, "message": "Invalid Avro schema"}, content_type=content_type, status=422)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.INVALID_AVRO_SCHEMA.value,
+                    "message": "Invalid Avro schema",
+                },
+                content_type=content_type,
+                status=422,
+            )
         try:
             old_schema_type = SchemaType(old.get("schemaType", "AVRO"))
             old_schema = TypedSchema.parse(old_schema_type, old["schema"])
         except InvalidSchema:
             self.log.warning("Invalid existing schema: %r", old["schema"])
-            self.r(body={"error_code": 44201, "message": "Invalid Avro schema"}, content_type=content_type, status=422)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.INVALID_AVRO_SCHEMA.value,
+                    "message": "Invalid Avro schema",
+                },
+                content_type=content_type,
+                status=422,
+            )
 
         compat = Compatibility(
             source=old_schema, target=new, compatibility=old.get("compatibility", self.ksr.config["compatibility"])
@@ -232,12 +277,26 @@ class KarapaceSchemaRegistry(KarapaceBase):
         try:
             schema_id_int = int(schema_id)
         except ValueError:
-            self.r({"error_code": 404, "message": "HTTP 404 Not Found"}, content_type, status=404)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.HTTP_NOT_FOUND.value,
+                    "message": "HTTP 404 Not Found",
+                },
+                content_type=content_type,
+                status=404,
+            )
         with self.ksr.id_lock:
             schema = self.ksr.schemas.get(schema_id_int)
         if not schema:
             self.log.warning("Schema: %r that was requested, not found", int(schema_id))
-            self.r(body={"error_code": 40403, "message": "Schema not found"}, content_type=content_type, status=404)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.SCHEMA_NOT_FOUND.value,
+                    "message": "Schema not found",
+                },
+                content_type=content_type,
+                status=404,
+            )
         response_body = {"schema": schema.schema_str}
         if schema.schema_type is not SchemaType.AVRO:
             response_body["schemaType"] = schema.schema_type
@@ -254,11 +313,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         except (ValueError, KeyError):
             self.r(
                 body={
-                    "error_code": 42203,
-                    "message": "Invalid compatibility level. Valid values are none, backward, forward and full"
+                    "error_code": SchemaErrorCodes.INVALID_COMPATIBILITY_LEVEL.value,
+                    "message": "Invalid compatibility level. Valid values are none, backward, forward and full",
                 },
                 content_type=content_type,
-                status=422
+                status=422,
             )
 
         are_we_master, master_url = await self.get_master()
@@ -285,7 +344,14 @@ class KarapaceSchemaRegistry(KarapaceBase):
             if compatibility:
                 self.r({"compatibilityLevel": compatibility}, content_type)
 
-        self.r({"error_code": 40401, "message": "Subject not found."}, content_type, status=404)
+        self.r(
+            body={
+                "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
+                "message": "Subject not found.",
+            },
+            content_type=content_type,
+            status=404,
+        )
 
     async def config_subject_set(self, content_type, *, request, subject):
         try:
@@ -293,9 +359,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         except (ValueError, KeyError):
             self.r(
                 body={
-                    "error_code": 42203,
-                    "message": "Invalid compatibility level"
-                }, content_type=content_type, status=422
+                    "error_code": SchemaErrorCodes.INVALID_COMPATIBILITY_LEVEL.value,
+                    "message": "Invalid compatibility level",
+                },
+                content_type=content_type,
+                status=422,
             )
 
         are_we_master, master_url = await self.get_master()
@@ -341,9 +409,23 @@ class KarapaceSchemaRegistry(KarapaceBase):
         elif int(version) <= max_version:
             schema_data = subject_data["schemas"].get(int(version))
         else:
-            self.r({"error_code": 40402, "message": "Version not found."}, content_type, status=404)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.VERSION_NOT_FOUND.value,
+                    "message": "Version not found.",
+                },
+                content_type=content_type,
+                status=404,
+            )
         if not schema_data:
-            self.r({"error_code": 40402, "message": "Version not found."}, content_type, status=404)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.VERSION_NOT_FOUND.value,
+                    "message": "Version not found.",
+                },
+                content_type=content_type,
+                status=404,
+            )
         schema_id = schema_data["id"]
         schema = schema_data["schema"]
 
@@ -368,7 +450,14 @@ class KarapaceSchemaRegistry(KarapaceBase):
 
         subject_schema_data = subject_data["schemas"].get(version, None)
         if not subject_schema_data:
-            self.r({"error_code": 40402, "message": "Version not found."}, content_type, status=404)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.VERSION_NOT_FOUND.value,
+                    "message": "Version not found.",
+                },
+                content_type=content_type,
+                status=404,
+            )
         schema_id = subject_schema_data["id"]
         schema = subject_schema_data["schema"]
         are_we_master, master_url = await self.get_master()
@@ -391,7 +480,14 @@ class KarapaceSchemaRegistry(KarapaceBase):
         elif int(version) <= max_version:
             schema_data = subject_data["schemas"].get(int(version))
         else:
-            self.r({"error_code": 40402, "message": "Version not found."}, content_type, status=404)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.VERSION_NOT_FOUND.value,
+                    "message": "Version not found.",
+                },
+                content_type=content_type,
+                status=404,
+            )
         self.r(schema_data["schema"].schema_str, content_type)
 
     async def subject_versions_list(self, content_type, *, subject):
@@ -412,16 +508,23 @@ class KarapaceSchemaRegistry(KarapaceBase):
 
     def _validate_schema_request_body(self, content_type, body):
         if not isinstance(body, dict):
-            self.r({"error_code": 500, "message": "Internal Server Error"}, content_type, status=500)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.HTTP_INTERNAL_SERVER_ERROR.value,
+                    "message": "Internal Server Error",
+                },
+                content_type=content_type,
+                status=500,
+            )
         for field in body:
             if field not in {"schema", "schemaType"}:
                 self.r(
                     body={
-                        "error_code": 422,
+                        "error_code": SchemaErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,
                         "message": f"Unrecognized field: {field}",
                     },
                     content_type=content_type,
-                    status=422
+                    status=422,
                 )
 
     def _validate_schema_type(self, content_type, body):
@@ -429,11 +532,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         if schema_type not in {SchemaType.JSONSCHEMA, SchemaType.AVRO}:
             self.r(
                 body={
-                    "error_code": 422,
-                    "message": f"unrecognized schemaType: {schema_type}"
+                    "error_code": SchemaErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,
+                    "message": f"unrecognized schemaType: {schema_type}",
                 },
                 content_type=content_type,
-                status=422
+                status=422,
             )
 
     async def subjects_schema_post(self, content_type, *, subject, request):
@@ -442,19 +545,28 @@ class KarapaceSchemaRegistry(KarapaceBase):
         subject_data = self._subject_get(subject, content_type)
         new_schema = None
         if "schema" not in body:
-            self.r({"error_code": 500, "message": "Internal Server Error"}, content_type, status=500)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.HTTP_INTERNAL_SERVER_ERROR.value,
+                    "message": "Internal Server Error",
+                },
+                content_type=content_type,
+                status=500,
+            )
         schema_str = body["schema"]
         schema_type = SchemaType(body.get("schemaType", "AVRO"))
         try:
             new_schema = TypedSchema.parse(schema_type, schema_str)
         except InvalidSchema:
             self.log.exception("No proper parser found")
-            self.r({
-                "error_code": 500,
-                "message": f"Error while looking up schema under subject {subject}"
-            },
-                   content_type,
-                   status=500)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.HTTP_INTERNAL_SERVER_ERROR.value,
+                    "message": f"Error while looking up schema under subject {subject}",
+                },
+                content_type=content_type,
+                status=500,
+            )
         for schema in subject_data["schemas"].values():
             typed_schema = schema["schema"]
             if typed_schema == new_schema:
@@ -469,7 +581,14 @@ class KarapaceSchemaRegistry(KarapaceBase):
                 self.r(ret, content_type)
             else:
                 self.log.debug("Schema %r did not match %r", schema, typed_schema)
-        self.r({"error_code": 40403, "message": "Schema not found"}, content_type, status=404)
+        self.r(
+            body={
+                "error_code": SchemaErrorCodes.SCHEMA_NOT_FOUND.value,
+                "message": "Schema not found",
+            },
+            content_type=content_type,
+            status=404,
+        )
 
     async def subject_post(self, content_type, *, subject, request):
         body = request.json
@@ -477,7 +596,14 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self._validate_schema_request_body(content_type, body)
         self._validate_schema_type(content_type, body)
         if "schema" not in body:
-            self.r({"error_code": 500, "message": "Internal Server Error"}, content_type, status=500)
+            self.r(
+                body={
+                    "error_code": SchemaErrorCodes.HTTP_INTERNAL_SERVER_ERROR.value,
+                    "message": "Internal Server Error",
+                },
+                content_type=content_type,
+                status=500,
+            )
         are_we_master, master_url = await self.get_master()
         if are_we_master:
             self.write_new_schema_local(subject, body, content_type)
@@ -497,11 +623,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.log.warning("Invalid schema: %r", body["schema"], exc_info=True)
             self.r(
                 body={
-                    "error_code": 44201,
-                    "message": f"Invalid {schema_type} schema"
+                    "error_code": SchemaErrorCodes.INVALID_AVRO_SCHEMA.value,
+                    "message": f"Invalid {schema_type} schema",
                 },
                 content_type=content_type,
-                status=422
+                status=422,
             )
         if subject not in self.ksr.subjects or not self.ksr.subjects.get(subject)["schemas"]:
             schema_id = self.ksr.get_schema_id(new_schema)
@@ -558,11 +684,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
                     self.log.warning("Incompatible schema: %s", ex)
                     self.r(
                         body={
-                            "error_code": 409,
-                            "message": "Schema being registered is incompatible with an earlier schema"
+                            "error_code": SchemaErrorCodes.HTTP_CONFLICT.value,
+                            "message": "Schema being registered is incompatible with an earlier schema",
                         },
                         content_type=content_type,
-                        status=409
+                        status=409,
                     )
 
             # We didn't find an existing schema and the schema is compatible so go and create one
@@ -587,12 +713,14 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.r(body=response.body, content_type=content_type, status=response.status)
 
     def no_master_error(self, content_type):
-        self.r({
-            "error_code": 50003,
-            "message": "Error while forwarding the request to the master."
-        },
-               content_type,
-               status=500)
+        self.r(
+            body={
+                "error_code": SchemaErrorCodes.NO_MASTER_ERROR.value,
+                "message": "Error while forwarding the request to the master.",
+            },
+            content_type=content_type,
+            status=500,
+        )
 
 
 def main() -> int:


### PR DESCRIPTION
My idea here is to remove the magic constants that we have through out the code and give them a name, the end goal is to use these variables in the tests so that when a test fails the enum name gives a hint on what went wrong.

