### PR TITLE
Fix flakiness of test_master_selection

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = -ra -q --tb=short --showlocals --numprocesses auto
+timeout = 30

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ yapf==0.30.0
 # testing
 pytest==6.2.2
 pytest-xdist[psutil]==2.2.1
+pytest-timeout==1.4.2
 
 # workflow
 pre-commit>=2.2.0


### PR DESCRIPTION
https://github.com/aiven/karapace/pull/161/commits/2070989380ff9cd99d47c719c65cbd0721f5d610 didn't fix the flakiness, https://github.com/aiven/karapace/pull/165 failed with the same test. I did a more thorough review and I think I found the cause of flakiness: 

The condition `if not (a or b)` is true only if both `a` and `b` are
false.

Truth table:

    a | b | a or b | not (a or b)
    f | f |   f    |       t
    t | f |   t    |       f *
    f | t |   t    |       f *
    t | t |   t    |       f

The cases with an asterisk above should cause flakiness in the test,
because setting the master flag and the url is not atomic. So the
condition can be partially satisfied.