### PR TITLE
tests: replaced pickle with json

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -107,6 +107,15 @@ class KafkaConfig:
     kafka_port: int
     zookeeper_port: int
 
+    @staticmethod
+    def from_dict(data: dict) -> "KafkaConfig":
+        return KafkaConfig(
+            data["datadir"],
+            data["kafka_keystore_password"],
+            data["kafka_port"],
+            data["zookeeper_port"],
+        )
+
 
 def get_broker_ip():
     if REST_URI in os.environ and REGISTRY_URI in os.environ:


### PR DESCRIPTION
- pickle encodes the object's absolute module location while encoding, and
  use it while decoding.
- pytest will change the top-level module depending on the arguments it
  is provided, breaking pickle decoding.

This changes to use json, since that does not depends on the above.