### PR TITLE
tests: increase test timeout

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 addopts = -ra -q --tb=short --showlocals --numprocesses auto
-timeout = 30
+timeout = 60


### PR DESCRIPTION
30 seconds is not sufficient is some cases to run zookeeper and kafka on
github workflows, this is causing flakiness:

Here is an example of a flakiness:

2021-03-24T09:18:02.7723927Z tests/integration/test_client.py::test_remote_client[pyloop]
2021-03-24T09:18:02.7743108Z filelock MainThread INFO Lock 140042435949008 acquired
2021-03-24T09:18:20.8720742Z filelock MainThread INFO Lock 140401743256016 released
...
2021-03-24T09:18:32.7708050Z Timeout

It took 18secs to start the servers, and the additional 12secs was not
sufficient for the two karapace servers started by `registry_async_pair`
to finish starting.