### PR TITLE
Early log level configuration

### DIFF
--- a/karapace/config.py
+++ b/karapace/config.py
@@ -5,12 +5,14 @@ Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
 from pathlib import Path
-from typing import Dict, IO, Union
+from typing import Dict, IO, List, Union
 
 import json
 import os
 import socket
 import ssl
+
+Config = Dict[str, Union[str, int, bool, List[str]]]
 
 DEFAULTS = {
     "advertised_hostname": socket.gethostname(),
@@ -65,7 +67,7 @@ def parse_env_value(value: str) -> Union[str, int, bool]:
     return value
 
 
-def set_config_defaults(config: Dict[str, Union[str, int, bool]]) -> Dict[str, Union[str, int, bool]]:
+def set_config_defaults(config: Config) -> Config:
     for k, v in DEFAULTS.items():
         if k.startswith("karapace"):
             env_name = k.upper()
@@ -81,11 +83,11 @@ def set_config_defaults(config: Dict[str, Union[str, int, bool]]) -> Dict[str, U
     return config
 
 
-def write_config(config_path: Path, custom_values: Dict[str, Union[str, int, bool]]):
+def write_config(config_path: Path, custom_values: Config) -> None:
     config_path.write_text(json.dumps(custom_values))
 
 
-def read_config(config_handler: IO) -> Dict[str, Union[str, int, bool]]:
+def read_config(config_handler: IO) -> Config:
     try:
         config = json.load(config_handler)
         config = set_config_defaults(config)
@@ -94,7 +96,7 @@ def read_config(config_handler: IO) -> Dict[str, Union[str, int, bool]]:
         raise InvalidConfiguration(ex)
 
 
-def create_ssl_context(config: Dict[str, Union[str, int, bool]]) -> ssl.SSLContext:
+def create_ssl_context(config: Config) -> ssl.SSLContext:
     # taken from conn.py, as it adds a lot more logic to the context configuration than the initial version
     ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)  # pylint: disable=no-member
     ssl_context.options |= ssl.OP_NO_SSLv2  # pylint: disable=no-member

--- a/karapace/kafka_rest_apis/__main__.py
+++ b/karapace/kafka_rest_apis/__main__.py
@@ -4,6 +4,7 @@ from karapace.config import read_config
 from karapace.kafka_rest_apis import KafkaRest
 
 import argparse
+import logging
 import sys
 
 
@@ -16,6 +17,7 @@ def main() -> int:
     with closing(arg.config_file):
         config = read_config(arg.config_file)
 
+    logging.getLogger().setLevel(config["log_level"])
     kc = KafkaRest(config_file_path=arg.config_file.name, config=config)
     try:
         kc.run(host=kc.config["host"], port=kc.config["port"])

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -40,7 +40,6 @@ class KarapaceBase(RestApp):
         self.log = logging.getLogger("Karapace")
         self.app.on_startup.append(self.create_http_client)
         self.master_lock = asyncio.Lock()
-        self._set_log_level()
         self.log.info("Karapace initialized")
 
     def _create_producer(self) -> KafkaProducer:
@@ -67,12 +66,6 @@ class KarapaceBase(RestApp):
             return
         self.producer.close()
         self.producer = None
-
-    def _set_log_level(self) -> None:
-        try:
-            logging.getLogger().setLevel(self.config["log_level"])
-        except ValueError:
-            self.log.exception("Problem with log_level: %r", self.config["log_level"])
 
     @staticmethod
     def r(body: Union[dict, list], content_type: str, status: HTTPStatus = HTTPStatus.OK) -> NoReturn:

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -46,6 +46,8 @@ def main() -> int:
 
     config_file_path = arg.config_file.name
 
+    logging.getLogger().setLevel(config["log_level"])
+
     kc: RestApp
     if config["karapace_rest"] and config["karapace_registry"]:
         info_str = "both services"

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -13,6 +13,7 @@ from karapace.utils import json_encode
 
 import argparse
 import asyncio
+import logging
 import sys
 import time
 
@@ -734,6 +735,7 @@ def main() -> int:
     with closing(arg.config_file):
         config = read_config(arg.config_file)
 
+    logging.getLogger().setLevel(config["log_level"])
     kc = KarapaceSchemaRegistry(config_file_path=arg.config_file.name, config=config)
     try:
         kc.run(host=kc.config["host"], port=kc.config["port"])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -177,11 +177,7 @@ async def fixture_rest_async(tmp_path: Path, kafka_servers: KafkaServers,
                              registry_async_client: Client) -> AsyncIterator[KafkaRest]:
     config_path = tmp_path / "karapace_config.json"
 
-    config = set_config_defaults({
-        "log_level": "WARNING",
-        "bootstrap_uri": kafka_servers.bootstrap_servers,
-        "admin_metadata_max_age": 0
-    })
+    config = set_config_defaults({"bootstrap_uri": kafka_servers.bootstrap_servers, "admin_metadata_max_age": 0})
     write_config(config_path, config)
     rest = KafkaRest(config_file_path=str(config_path), config=config)
 
@@ -221,7 +217,6 @@ def fixture_registry_async_pair(tmp_path: Path, kafka_servers: KafkaServers):
     group_id = new_random_name("schema_pairs")
     write_config(
         master_config_path, {
-            "log_level": "WARNING",
             "bootstrap_uri": kafka_servers.bootstrap_servers,
             "topic_name": topic_name,
             "group_id": group_id,
@@ -232,7 +227,6 @@ def fixture_registry_async_pair(tmp_path: Path, kafka_servers: KafkaServers):
     )
     write_config(
         slave_config_path, {
-            "log_level": "WARNING",
             "bootstrap_uri": kafka_servers.bootstrap_servers,
             "topic_name": topic_name,
             "group_id": group_id,
@@ -257,7 +251,6 @@ async def fixture_registry_async(tmp_path: Path, kafka_servers: KafkaServers) ->
     config_path = tmp_path / "karapace_config.json"
 
     config = set_config_defaults({
-        "log_level": "WARNING",
         "bootstrap_uri": kafka_servers.bootstrap_servers,
 
         # Using the default settings instead of random values, otherwise it


### PR DESCRIPTION


Configuring the logging in the base class constructor interferes with
the testing runner configuration, it effectively overwrites pytest's
configuration making the flag `--log-cli-level` unusable.

