### PR TITLE
schema_backup: do not treat empty files as an error

### DIFF
--- a/karapace/schema_backup.py
+++ b/karapace/schema_backup.py
@@ -184,8 +184,9 @@ class SchemaBackup:
         with open(self.backup_location, "r") as fp:
             raw_msg = fp.read()
             values = json.loads(raw_msg)
+
         if not values:
-            raise BackupError("Nothing to restore in %s" % self.backup_location)
+            return
 
         for item in values:
             key = encode_value(item[0])


### PR DESCRIPTION
It is possible to generate empty backup files, this should not be
treated as an error.