### PR TITLE
JSON Schema pattern properties tests

### DIFF
--- a/karapace/compatibility/jsonschema/utils.py
+++ b/karapace/compatibility/jsonschema/utils.py
@@ -318,7 +318,7 @@ def schema_from_partially_open_content_model(schema: dict, target_property_name:
             return pattern_schema
 
     # additionalProperties is used when
-    # - the propety does not have a schema
+    # - the property does not have a schema
     # - none of the patternProperties matches the property_name
     # https://json-schema.org/draft/2020-12/json-schema-core.html#additionalProperties
     return schema.get(Keyword.ADDITIONAL_PROPERTIES.value)

--- a/tests/integration/schema_registry/test_jsonschema.py
+++ b/tests/integration/schema_registry/test_jsonschema.py
@@ -20,9 +20,9 @@ from tests.schemas.json_schemas import (
     MINIMUM_INCREASED_NUMBER_SCHEMA, MINIMUM_INTEGER_SCHEMA, MINIMUM_NUMBER_SCHEMA, NON_OBJECT_SCHEMAS, NOT_OF_EMPTY_SCHEMA,
     NOT_OF_TRUE_SCHEMA, NUMBER_SCHEMA, OBJECT_SCHEMA, OBJECT_SCHEMAS, ONEOF_ARRAY_A_DINT_B_NUM_SCHEMA,
     ONEOF_ARRAY_B_NUM_C_DINT_OPEN_SCHEMA, ONEOF_ARRAY_B_NUM_C_INT_SCHEMA, ONEOF_INT_SCHEMA, ONEOF_NUMBER_SCHEMA,
-    ONEOF_STRING_INT_SCHEMA, ONEOF_STRING_SCHEMA, PROPERTY_ASTAR_OBJECT_SCHEMA, STRING_SCHEMA, TRUE_SCHEMA,
-    TUPLE_OF_INT_INT_OPEN_SCHEMA, TUPLE_OF_INT_INT_SCHEMA, TUPLE_OF_INT_OPEN_SCHEMA, TUPLE_OF_INT_SCHEMA,
-    TUPLE_OF_INT_WITH_ADDITIONAL_INT_SCHEMA, TYPES_STRING_INT_SCHEMA, TYPES_STRING_SCHEMA
+    ONEOF_STRING_INT_SCHEMA, ONEOF_STRING_SCHEMA, PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA, PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+    STRING_SCHEMA, TRUE_SCHEMA, TUPLE_OF_INT_INT_OPEN_SCHEMA, TUPLE_OF_INT_INT_SCHEMA, TUPLE_OF_INT_OPEN_SCHEMA,
+    TUPLE_OF_INT_SCHEMA, TUPLE_OF_INT_WITH_ADDITIONAL_INT_SCHEMA, TYPES_STRING_INT_SCHEMA, TYPES_STRING_SCHEMA
 )
 from tests.utils import new_random_name
 
@@ -1019,20 +1019,21 @@ async def test_schemaregistry_schema_broadenning_attributes_is_compatible(regist
     )
 
 
-@pytest.mark.skip("not implemented yet")
-async def test_schemaregistry_property_name(registry_async_client: Client):
+async def test_schemaregistry_pattern_properties(registry_async_client: Client):
     await schemas_are_backward_compatible(
         reader=OBJECT_SCHEMA,
-        writer=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        writer=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
         client=registry_async_client,
     )
-    await not_schemas_are_backward_compatible(
-        reader=A_OBJECT_SCHEMA,
-        writer=PROPERTY_ASTAR_OBJECT_SCHEMA,
-        client=registry_async_client,
-    )
+    # In backward compatibility mode it is allowed to delete fields
     await schemas_are_backward_compatible(
-        reader=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        reader=A_OBJECT_SCHEMA,
+        writer=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+    # In backward compatibility mode it is allowed to add optional fields
+    await schemas_are_backward_compatible(
+        reader=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
         writer=A_OBJECT_SCHEMA,
         client=registry_async_client,
     )
@@ -1042,7 +1043,7 @@ async def test_schemaregistry_property_name(registry_async_client: Client):
     # invalid
     await not_schemas_are_backward_compatible(
         reader=A_INT_OBJECT_SCHEMA,
-        writer=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        writer=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
         client=registry_async_client,
     )
 
@@ -1050,7 +1051,43 @@ async def test_schemaregistry_property_name(registry_async_client: Client):
     # - newer only accepts properties with match regex `a*`
     await not_schemas_are_backward_compatible(
         reader=B_INT_OBJECT_SCHEMA,
-        writer=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        writer=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+
+
+@pytest.mark.skip("not implemented yet")
+async def test_schemaregistry_property_names(registry_async_client: Client):
+    await schemas_are_backward_compatible(
+        reader=OBJECT_SCHEMA,
+        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+    await not_schemas_are_backward_compatible(
+        reader=A_OBJECT_SCHEMA,
+        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+    await schemas_are_backward_compatible(
+        reader=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        writer=A_OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+
+    # - older accept any value for `a`
+    # - newer requires it to be an `int`, therefore the other values became
+    # invalid
+    await not_schemas_are_backward_compatible(
+        reader=A_INT_OBJECT_SCHEMA,
+        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+
+    # - older has property `b`
+    # - newer only accepts properties with match regex `a*`
+    await not_schemas_are_backward_compatible(
+        reader=B_INT_OBJECT_SCHEMA,
+        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
         client=registry_async_client,
     )
 

--- a/tests/schemas/json_schemas.py
+++ b/tests/schemas/json_schemas.py
@@ -131,7 +131,8 @@ B_NUM_C_INT_OPEN_OBJECT_SCHEMA = parse_jsonschema_definition(
 B_NUM_C_INT_OBJECT_SCHEMA = parse_jsonschema_definition(
     '{"type":"object","additionalProperties":false,"properties":{"b":{"type":"number"},"c":{"type":"integer"}}}'
 )
-PROPERTY_ASTAR_OBJECT_SCHEMA = parse_jsonschema_definition('{"type":"object","propertyNames":{"pattern":"a*"}}')
+PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA = parse_jsonschema_definition('{"type":"object","patternProperties":{"^a*": {}}}')
+PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA = parse_jsonschema_definition('{"type":"object","propertyNames":{"pattern":"a*"}}')
 ARRAY_OF_POSITIVE_INTEGER = parse_jsonschema_definition(
     '''
     {
@@ -181,7 +182,7 @@ OBJECT_SCHEMAS = (
     B_DINT_OPEN_OBJECT_SCHEMA, B_INT_OBJECT_SCHEMA, B_INT_OPEN_OBJECT_SCHEMA, B_NUM_C_DINT_OPEN_OBJECT_SCHEMA,
     B_NUM_C_INT_OBJECT_SCHEMA, B_NUM_C_INT_OPEN_OBJECT_SCHEMA, EMPTY_OBJECT_SCHEMA, EMPTY_SCHEMA, EVERY_TYPE_SCHEMA,
     MAX_PROPERTIES_SCHEMA, MAX_PROPERTIES_DECREASED_SCHEMA, MIN_PROPERTIES_SCHEMA, MIN_PROPERTIES_INCREASED_SCHEMA,
-    OBJECT_SCHEMA, PROPERTY_ASTAR_OBJECT_SCHEMA
+    OBJECT_SCHEMA, PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA, PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA
 )
 BOOLEAN_SCHEMAS = (TRUE_SCHEMA, FALSE_SCHEMA)
 NON_OBJECT_SCHEMAS = (

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -20,9 +20,9 @@ from tests.schemas.json_schemas import (
     NOT_BOOLEAN_SCHEMA, NOT_INT_SCHEMA, NOT_NUMBER_SCHEMA, NOT_OBJECT_SCHEMA, NOT_OF_EMPTY_SCHEMA, NOT_OF_TRUE_SCHEMA,
     NOT_STRING_SCHEMA, NUMBER_SCHEMA, OBJECT_SCHEMA, OBJECT_SCHEMAS, ONEOF_ARRAY_A_DINT_B_NUM_SCHEMA,
     ONEOF_ARRAY_B_NUM_C_DINT_OPEN_SCHEMA, ONEOF_ARRAY_B_NUM_C_INT_SCHEMA, ONEOF_INT_SCHEMA, ONEOF_NUMBER_SCHEMA,
-    ONEOF_STRING_INT_SCHEMA, ONEOF_STRING_SCHEMA, PROPERTY_ASTAR_OBJECT_SCHEMA, STRING_SCHEMA, TRUE_SCHEMA,
-    TUPLE_OF_INT_INT_OPEN_SCHEMA, TUPLE_OF_INT_INT_SCHEMA, TUPLE_OF_INT_OPEN_SCHEMA, TUPLE_OF_INT_SCHEMA,
-    TUPLE_OF_INT_WITH_ADDITIONAL_INT_SCHEMA, TYPES_STRING_INT_SCHEMA, TYPES_STRING_SCHEMA
+    ONEOF_STRING_INT_SCHEMA, ONEOF_STRING_SCHEMA, PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA, PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+    STRING_SCHEMA, TRUE_SCHEMA, TUPLE_OF_INT_INT_OPEN_SCHEMA, TUPLE_OF_INT_INT_SCHEMA, TUPLE_OF_INT_OPEN_SCHEMA,
+    TUPLE_OF_INT_SCHEMA, TUPLE_OF_INT_WITH_ADDITIONAL_INT_SCHEMA, TYPES_STRING_INT_SCHEMA, TYPES_STRING_SCHEMA
 )
 
 import pytest
@@ -1263,20 +1263,21 @@ def test_schema_broadenning_attributes_is_compatible() -> None:
     )
 
 
-@pytest.mark.skip("not implemented yet")
-def test_property_name():
+def test_pattern_properties():
     schemas_are_compatible(
         reader=OBJECT_SCHEMA,
-        writer=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        writer=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
         msg=COMPATIBLE_READER_IS_OPEN_AND_IGNORE_UNKNOWN_VALUES,
     )
-    not_schemas_are_compatible(
+    # In backward compatibility mode it is allowed to delete fields
+    schemas_are_compatible(
         reader=A_OBJECT_SCHEMA,
-        writer=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        writer=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
         msg=COMPATIBILIY,
     )
+    # In backward compatibility mode it is allowed to add optional fields
     schemas_are_compatible(
-        reader=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        reader=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
         writer=A_OBJECT_SCHEMA,
         msg=COMPATIBILIY,
     )
@@ -1286,14 +1287,50 @@ def test_property_name():
     # invalid
     not_schemas_are_compatible(
         reader=A_INT_OBJECT_SCHEMA,
-        writer=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        writer=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
         msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
     )
 
     # - writer has property `b`
     # - reader only accepts properties with match regex `a*`
     not_schemas_are_compatible(
-        reader=PROPERTY_ASTAR_OBJECT_SCHEMA,
+        reader=PATTERN_PROPERTY_ASTAR_OBJECT_SCHEMA,
+        writer=B_INT_OBJECT_SCHEMA,
+        msg=INCOMPATIBLE_READER_IS_CLOSED_AND_REMOVED_FIELD,
+    )
+
+
+@pytest.mark.skip("not implemented yet")
+def test_property_name():
+    schemas_are_compatible(
+        reader=OBJECT_SCHEMA,
+        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        msg=COMPATIBLE_READER_IS_OPEN_AND_IGNORE_UNKNOWN_VALUES,
+    )
+    not_schemas_are_compatible(
+        reader=A_OBJECT_SCHEMA,
+        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        msg=COMPATIBILIY,
+    )
+    schemas_are_compatible(
+        reader=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        writer=A_OBJECT_SCHEMA,
+        msg=COMPATIBILIY,
+    )
+
+    # - writer accept any value for `a`
+    # - reader requires it to be an `int`, therefore the other values became
+    # invalid
+    not_schemas_are_compatible(
+        reader=A_INT_OBJECT_SCHEMA,
+        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+
+    # - writer has property `b`
+    # - reader only accepts properties with match regex `a*`
+    not_schemas_are_compatible(
+        reader=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
         writer=B_INT_OBJECT_SCHEMA,
         msg=INCOMPATIBLE_READER_IS_CLOSED_AND_REMOVED_FIELD,
     )


### PR DESCRIPTION
# About this change: What it does, why it matters

Add separate `patternProperties` tests before implementing `propertyNames` compatibility and tests.  Also rename test schema objects for clarification.
