### PR TITLE
JSON Schema propertyNames compatibility

### DIFF
--- a/karapace/compatibility/jsonschema/utils.py
+++ b/karapace/compatibility/jsonschema/utils.py
@@ -147,18 +147,7 @@ def is_object_content_model_open(schema: Any) -> bool:
     does_not_restrict_properties_by_pattern = len(schema.get(Keyword.PATTERN_PROPERTIES.value, list())) == 0
     does_not_restrict_additional_properties = is_true_schema(schema.get(Keyword.ADDITIONAL_PROPERTIES.value, True))
 
-    # For propertyNames the type is implictly "string":
-    #
-    #   https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.2.4
-    #
-    property_names = schema.get(Keyword.PROPERTY_NAMES.value, {})
-    assert property_names.setdefault(Keyword.TYPE.value, Instance.STRING.value) == Instance.STRING.value
-    does_restrict_properties_names = is_string_and_constrained(property_names)
-
-    return (
-        does_not_restrict_properties_by_pattern and does_not_restrict_additional_properties
-        and not does_restrict_properties_names
-    )
+    return does_not_restrict_properties_by_pattern and does_not_restrict_additional_properties
 
 
 def is_true_schema(schema: Any) -> bool:
@@ -311,7 +300,7 @@ def introduced_constraint(reader: Optional[T], writer: Optional[T]) -> bool:
 
 def schema_from_partially_open_content_model(schema: dict, target_property_name: str) -> Any:
     """Returns the schema from patternProperties or additionalProperties that
-    valdiates `target_property_name`, if any.
+    validates `target_property_name`, if any.
     """
     for pattern, pattern_schema in schema.get(Keyword.PATTERN_PROPERTIES.value, dict()).items():
         if re.match(pattern, target_property_name):

--- a/tests/integration/schema_registry/test_jsonschema.py
+++ b/tests/integration/schema_registry/test_jsonschema.py
@@ -1109,9 +1109,9 @@ async def test_schemaregistry_property_names(registry_async_client: Client):
 
     # - older has property `b`
     # - newer only accepts properties with match regex `a*`
-    await not_schemas_are_backward_compatible(
-        reader=B_INT_OBJECT_SCHEMA,
-        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+    await schemas_are_backward_compatible(
+        reader=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        writer=B_INT_OBJECT_SCHEMA,
         client=registry_async_client,
     )
 

--- a/tests/integration/schema_registry/test_jsonschema.py
+++ b/tests/integration/schema_registry/test_jsonschema.py
@@ -1056,6 +1056,31 @@ async def test_schemaregistry_pattern_properties(registry_async_client: Client):
     )
 
 
+async def test_schemaregistry_object_properties(registry_async_client: Client):
+    await not_schemas_are_backward_compatible(
+        reader=A_OBJECT_SCHEMA,
+        writer=OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+    await schemas_are_backward_compatible(
+        reader=OBJECT_SCHEMA,
+        writer=A_OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+
+    await not_schemas_are_backward_compatible(
+        reader=A_INT_OBJECT_SCHEMA,
+        writer=OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+
+    await not_schemas_are_backward_compatible(
+        reader=B_INT_OBJECT_SCHEMA,
+        writer=OBJECT_SCHEMA,
+        client=registry_async_client,
+    )
+
+
 @pytest.mark.skip("not implemented yet")
 async def test_schemaregistry_property_names(registry_async_client: Client):
     await schemas_are_backward_compatible(

--- a/tests/integration/schema_registry/test_jsonschema.py
+++ b/tests/integration/schema_registry/test_jsonschema.py
@@ -1081,7 +1081,6 @@ async def test_schemaregistry_object_properties(registry_async_client: Client):
     )
 
 
-@pytest.mark.skip("not implemented yet")
 async def test_schemaregistry_property_names(registry_async_client: Client):
     await schemas_are_backward_compatible(
         reader=OBJECT_SCHEMA,

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -25,8 +25,6 @@ from tests.schemas.json_schemas import (
     TUPLE_OF_INT_SCHEMA, TUPLE_OF_INT_WITH_ADDITIONAL_INT_SCHEMA, TYPES_STRING_INT_SCHEMA, TYPES_STRING_SCHEMA
 )
 
-import pytest
-
 COMPATIBLE = SchemaCompatibilityResult.compatible()
 
 COMPATIBILIY = "compatibility with schema registry"
@@ -1323,7 +1321,6 @@ def test_object_properties():
     )
 
 
-@pytest.mark.skip("not implemented yet")
 def test_property_names():
     schemas_are_compatible(
         reader=OBJECT_SCHEMA,

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -1302,7 +1302,7 @@ def test_object_properties():
     not_schemas_are_compatible(
         reader=A_OBJECT_SCHEMA,
         writer=OBJECT_SCHEMA,
-        msg=COMPATIBILIY,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
     )
     schemas_are_compatible(
         reader=OBJECT_SCHEMA,
@@ -1317,7 +1317,7 @@ def test_object_properties():
     not_schemas_are_compatible(
         reader=B_INT_OBJECT_SCHEMA,
         writer=OBJECT_SCHEMA,
-        msg=INCOMPATIBLE_READER_IS_CLOSED_AND_REMOVED_FIELD,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
     )
 
 
@@ -1330,7 +1330,7 @@ def test_property_names():
     not_schemas_are_compatible(
         reader=A_OBJECT_SCHEMA,
         writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
-        msg=COMPATIBILIY,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
     )
     schemas_are_compatible(
         reader=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
@@ -1349,10 +1349,10 @@ def test_property_names():
 
     # - writer has property `b`
     # - reader only accepts properties with match regex `a*`
-    not_schemas_are_compatible(
-        reader=B_INT_OBJECT_SCHEMA,
-        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
-        msg=INCOMPATIBLE_READER_IS_CLOSED_AND_REMOVED_FIELD,
+    schemas_are_compatible(
+        reader=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
+        writer=B_INT_OBJECT_SCHEMA,
+        msg=COMPATIBILIY,
     )
 
 

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -1330,8 +1330,8 @@ def test_property_name():
     # - writer has property `b`
     # - reader only accepts properties with match regex `a*`
     not_schemas_are_compatible(
-        reader=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
-        writer=B_INT_OBJECT_SCHEMA,
+        reader=B_INT_OBJECT_SCHEMA,
+        writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,
         msg=INCOMPATIBLE_READER_IS_CLOSED_AND_REMOVED_FIELD,
     )
 

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -1300,8 +1300,31 @@ def test_pattern_properties():
     )
 
 
+def test_object_properties():
+    not_schemas_are_compatible(
+        reader=A_OBJECT_SCHEMA,
+        writer=OBJECT_SCHEMA,
+        msg=COMPATIBILIY,
+    )
+    schemas_are_compatible(
+        reader=OBJECT_SCHEMA,
+        writer=A_OBJECT_SCHEMA,
+        msg=COMPATIBILIY,
+    )
+    not_schemas_are_compatible(
+        reader=A_INT_OBJECT_SCHEMA,
+        writer=OBJECT_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    not_schemas_are_compatible(
+        reader=B_INT_OBJECT_SCHEMA,
+        writer=OBJECT_SCHEMA,
+        msg=INCOMPATIBLE_READER_IS_CLOSED_AND_REMOVED_FIELD,
+    )
+
+
 @pytest.mark.skip("not implemented yet")
-def test_property_name():
+def test_property_names():
     schemas_are_compatible(
         reader=OBJECT_SCHEMA,
         writer=PROPERTY_NAMES_ASTAR_OBJECT_SCHEMA,


### PR DESCRIPTION
# About this change: What it does, why it matters

Fix `propertyNames` support: An object with `propertyNames` setting constraints on property names is still open ie. there are no limitations on property values for those.

Add separate test for object properties without `propertyNames` and fix test to match existing integration test.