### PR TITLE
sr-compat: Error messages in config_set and in config_subject_get

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -39,6 +39,16 @@ class SchemaErrorCodes(Enum):
     NO_MASTER_ERROR = 50003
 
 
+@unique
+class SchemaErrorMessages(Enum):
+    SUBJECT_NOT_FOUND_FMT = "Subject '{subject}' not found."
+    INVALID_COMPATIBILITY_LEVEL = (
+        "Invalid compatibility level. Valid values are none, backward, "
+        "forward, full, backward_transitive, forward_transitive, and "
+        "full_transitive"
+    )
+
+
 class InvalidSchemaType(Exception):
     pass
 
@@ -140,7 +150,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
-                    "message": f"Subject '{subject}' not found.",
+                    "message": SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=subject),
                 },
                 content_type=content_type,
                 status=HTTPStatus.NOT_FOUND,
@@ -151,7 +161,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
-                    "message": f"Subject '{subject}' not found.",
+                    "message": SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=subject),
                 },
                 content_type=content_type,
                 status=HTTPStatus.NOT_FOUND,
@@ -381,7 +391,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.INVALID_COMPATIBILITY_LEVEL.value,
-                    "message": "Invalid compatibility level. Valid values are none, backward, forward and full",
+                    "message": SchemaErrorMessages.INVALID_COMPATIBILITY_LEVEL.value,
                 },
                 content_type=content_type,
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
@@ -419,7 +429,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.r(
             body={
                 "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
-                "message": "Subject not found.",
+                "message": SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=subject),
             },
             content_type=content_type,
             status=HTTPStatus.NOT_FOUND,

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -7,7 +7,7 @@ See LICENSE for details
 from http import HTTPStatus
 from kafka import KafkaProducer
 from karapace.rapu import is_success
-from karapace.schema_registry_apis import KarapaceSchemaRegistry
+from karapace.schema_registry_apis import KarapaceSchemaRegistry, SchemaErrorMessages
 from karapace.utils import Client
 from tests.utils import (
     create_field_name_factory, create_schema_name_factory, create_subject_name_factory, repeat_until_successful_request
@@ -1742,7 +1742,7 @@ async def test_config(registry_async_client: Client, trail: str) -> None:
     res = await registry_async_client.put(f"config{trail}", json={"compatibility": "nonexistentmode"})
     assert res.status_code == 422
     assert res.json()["error_code"] == 42203
-    assert res.json()["message"] == "Invalid compatibility level. Valid values are none, backward, forward and full"
+    assert res.json()["message"] == SchemaErrorMessages.INVALID_COMPATIBILITY_LEVEL.value
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
 
     # Create a new subject so we can try setting its config
@@ -1757,7 +1757,7 @@ async def test_config(registry_async_client: Client, trail: str) -> None:
     res = await registry_async_client.get(f"config/{subject_1}{trail}")
     assert res.status_code == 404
     assert res.json()["error_code"] == 40401
-    assert res.json()["message"] == "Subject not found."
+    assert res.json()["message"] == SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=subject_1)
 
     res = await registry_async_client.put(f"config/{subject_1}{trail}", json={"compatibility": "FULL"})
     assert res.status_code == 200


### PR DESCRIPTION
Making changes to Karapace Schema Registry for Schema Registy-compatibility.

```shell
docker-compose -f ./tests/integration/confluent-docker-compose.yml up -d
pytest -vv tests/ --registry-url=http://localhost:8081 --rest-url=http://localhost:8082 --kafka-bootstrap-servers=localhost:9092 -k test_config
```