### PR TITLE
Handle gracefully if no node is master eligible

### DIFF
--- a/karapace/master_coordinator.py
+++ b/karapace/master_coordinator.py
@@ -30,7 +30,8 @@ class SchemaCoordinator(BaseCoordinator):
     hostname = None
     port = None
     scheme = None
-    master = None
+    are_we_master = None
+    is_master_eligible = None
     master_url = None
     master_eligibility = True
     log = logging.getLogger("SchemaCoordinator")
@@ -49,16 +50,25 @@ class SchemaCoordinator(BaseCoordinator):
 
     def _perform_assignment(self, leader_id, protocol, members):
         self.log.info("Creating assignment: %r, protocol: %r, members: %r", leader_id, protocol, members)
-        self.master = None
+        self.are_we_master = None
         error = NO_ERROR
         urls = {}
+        fallback_urls = {}
         for member_id, member_data in members:
             member_identity = json.loads(member_data.decode("utf8"))
             if member_identity["master_eligibility"] is True:
                 urls[get_identity_url(member_identity["scheme"], member_identity["host"],
                                       member_identity["port"])] = (member_id, member_data)
-        self.master_url = sorted(urls, reverse=self.election_strategy.lower() == "highest")[0]
-        schema_master_id, member_data = urls[self.master_url]
+            else:
+                fallback_urls[get_identity_url(member_identity["scheme"], member_identity["host"],
+                                               member_identity["port"])] = (member_id, member_data)
+        if len(urls) > 0:
+            self.master_url = sorted(urls, reverse=self.election_strategy.lower() == "highest")[0]
+            schema_master_id, member_data = urls[self.master_url]
+        else:
+            # Protocol guarantees there is at least one member thus if urls is empty, fallback_urls cannot be
+            self.master_url = sorted(fallback_urls, reverse=self.election_strategy.lower() == "highest")[0]
+            schema_master_id, member_data = fallback_urls[self.master_url]
         member_identity = json.loads(member_data.decode("utf8"))
         identity = self.get_identity(
             host=member_identity["host"],
@@ -92,10 +102,12 @@ class SchemaCoordinator(BaseCoordinator):
         )
         if member_assignment["master"] == member_id:
             self.master_url = master_url
-            self.master = True
+            self.are_we_master = True
+            self.is_master_eligible = member_identity["master_eligibility"]
         else:
             self.master_url = master_url
-            self.master = False
+            self.are_we_master = False
+            self.is_master_eligible = member_identity["master_eligibility"]
         return super(SchemaCoordinator, self)._on_join_complete(generation, member_id, protocol, member_assignment_bytes)
 
     def _on_join_follower(self):
@@ -160,7 +172,7 @@ class MasterCoordinator(Thread):
     def get_master_info(self):
         """Return whether we're the master, and the actual master url that can be used if we're not"""
         with self.lock:
-            return self.sc.master, self.sc.master_url
+            return self.sc.are_we_master, self.sc.is_master_eligible, self.sc.master_url
 
     def close(self):
         self.log.info("Closing master_coordinator")
@@ -179,7 +191,10 @@ class MasterCoordinator(Thread):
 
                 self.sc.ensure_active_group()
                 self.sc.poll_heartbeat()
-                self.log.debug("We're master: %r: master_uri: %r", self.sc.master, self.sc.master_url)
+                self.log.debug(
+                    "We're master: %r (eligible master: %r): master_uri: %r", self.sc.are_we_master,
+                    self.sc.is_master_eligible, self.sc.master_url
+                )
                 time.sleep(min(_hb_interval, self.sc.time_to_next_heartbeat()))
             except:  # pylint: disable=bare-except
                 self.log.exception("Exception in master_coordinator")

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -239,11 +239,12 @@ class KafkaSchemaReader(Thread):
             self.ready = True
         add_offsets = False
         if self.master_coordinator is not None:
-            master, _ = self.master_coordinator.get_master_info()
-            # keep old behavior for True. When master is False, then we are a follower, so we should not accept direct
-            # writes anyway. When master is None, then this particular node is waiting for a stable value, so any
+            are_we_master, is_master_eligible, _ = self.master_coordinator.get_master_info()
+            # keep old behavior for True. When are_we_master is False, then we are a follower, so we should not accept direct
+            # writes anyway. When are_we_master is None, then this particular node is waiting for a stable value, so any
             # messages off the topic are writes performed by another node
-            if master is True:
+            # Also if master_elibility is disabled by configuration, disable writes too
+            if are_we_master is True and is_master_eligible is True:
                 add_offsets = True
 
         for _, msgs in raw_msgs.items():

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -239,12 +239,12 @@ class KafkaSchemaReader(Thread):
             self.ready = True
         add_offsets = False
         if self.master_coordinator is not None:
-            are_we_master, has_eligible_master, _ = self.master_coordinator.get_master_info()
+            are_we_master, _ = self.master_coordinator.get_master_info()
             # keep old behavior for True. When are_we_master is False, then we are a follower, so we should not accept direct
             # writes anyway. When are_we_master is None, then this particular node is waiting for a stable value, so any
             # messages off the topic are writes performed by another node
             # Also if master_elibility is disabled by configuration, disable writes too
-            if are_we_master is True and has_eligible_master is True:
+            if are_we_master is True:
                 add_offsets = True
 
         for _, msgs in raw_msgs.items():

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -239,12 +239,12 @@ class KafkaSchemaReader(Thread):
             self.ready = True
         add_offsets = False
         if self.master_coordinator is not None:
-            are_we_master, is_master_eligible, _ = self.master_coordinator.get_master_info()
+            are_we_master, has_eligible_master, _ = self.master_coordinator.get_master_info()
             # keep old behavior for True. When are_we_master is False, then we are a follower, so we should not accept direct
             # writes anyway. When are_we_master is None, then this particular node is waiting for a stable value, so any
             # messages off the topic are writes performed by another node
             # Also if master_elibility is disabled by configuration, disable writes too
-            if are_we_master is True and is_master_eligible is True:
+            if are_we_master is True and has_eligible_master is True:
                 add_offsets = True
 
         for _, msgs in raw_msgs.items():

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -397,10 +397,10 @@ class KarapaceSchemaRegistry(KarapaceBase):
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-        are_we_master, master_url = await self.get_master()
-        if are_we_master:
+        are_we_master, is_master_eligible, master_url = await self.get_master()
+        if are_we_master and is_master_eligible:
             self.send_config_message(compatibility_level=compatibility_level, subject=None)
-        elif are_we_master is None:
+        elif not is_master_eligible:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/config"
@@ -448,10 +448,10 @@ class KarapaceSchemaRegistry(KarapaceBase):
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-        are_we_master, master_url = await self.get_master()
-        if are_we_master:
+        are_we_master, is_master_eligible, master_url = await self.get_master()
+        if are_we_master and is_master_eligible:
             self.send_config_message(compatibility_level=compatibility_level, subject=subject)
-        elif are_we_master is None:
+        elif not is_master_eligible:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/config/{subject}"
@@ -494,11 +494,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
     async def subject_delete(self, content_type, *, subject, request: HTTPRequest):
         permanent = request.query.get("permanent", "false").lower() == "true"
 
-        are_we_master, master_url = await self.get_master()
-        if are_we_master:
+        are_we_master, is_master_eligible, master_url = await self.get_master()
+        if are_we_master and is_master_eligible:
             async with self.schema_lock:
                 await self._subject_delete_local(content_type, subject, permanent)
-        elif are_we_master is None:
+        elif not is_master_eligible:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}?permanent={permanent}"
@@ -598,11 +598,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         version = int(version)
         permanent = request.query.get("permanent", "false").lower() == "true"
 
-        are_we_master, master_url = await self.get_master()
-        if are_we_master:
+        are_we_master, is_master_eligible, master_url = await self.get_master()
+        if are_we_master and is_master_eligible:
             async with self.schema_lock:
                 await self._subject_version_delete_local(content_type, subject, version, permanent)
-        elif are_we_master is None:
+        elif not is_master_eligible:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}/versions/{version}?permanent={permanent}"
@@ -635,13 +635,13 @@ class KarapaceSchemaRegistry(KarapaceBase):
     async def get_master(self):
         async with self.master_lock:
             while True:
-                master, master_url = self.mc.get_master_info()
-                if master is None:
-                    self.log.info("No master set: %r, url: %r", master, master_url)
+                are_we_master, is_master_eligible, master_url = self.mc.get_master_info()
+                if are_we_master is None:
+                    self.log.info("No master set: %r, url: %r", are_we_master, master_url)
                 elif self.ksr.ready is False:
                     self.log.info("Schema reader isn't ready yet: %r", self.ksr.ready)
                 else:
-                    return master, master_url
+                    return are_we_master, is_master_eligible, master_url
                 await asyncio.sleep(1.0)
 
     def _validate_schema_request_body(self, content_type, body) -> None:
@@ -745,11 +745,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self._validate_schema_request_body(content_type, body)
         self._validate_schema_type(content_type, body)
         self._validate_schema_key(content_type, body)
-        are_we_master, master_url = await self.get_master()
-        if are_we_master:
+        are_we_master, is_master_eligible, master_url = await self.get_master()
+        if are_we_master and is_master_eligible:
             async with self.schema_lock:
                 await self.write_new_schema_local(subject, body, content_type)
-        elif are_we_master is None:
+        elif not is_master_eligible:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}/versions"

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -10,7 +10,7 @@ from karapace.master_coordinator import MasterCoordinator
 from karapace.rapu import HTTPRequest
 from karapace.schema_reader import InvalidSchema, KafkaSchemaReader, SchemaType, TypedSchema
 from karapace.utils import json_encode
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import argparse
 import asyncio
@@ -397,10 +397,10 @@ class KarapaceSchemaRegistry(KarapaceBase):
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-        are_we_master, has_eligible_master, master_url = await self.get_master()
-        if are_we_master and has_eligible_master:
+        are_we_master, master_url = await self.get_master()
+        if are_we_master:
             self.send_config_message(compatibility_level=compatibility_level, subject=None)
-        elif not has_eligible_master:
+        elif not master_url:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/config"
@@ -448,10 +448,10 @@ class KarapaceSchemaRegistry(KarapaceBase):
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-        are_we_master, has_eligible_master, master_url = await self.get_master()
-        if are_we_master and has_eligible_master:
+        are_we_master, master_url = await self.get_master()
+        if are_we_master:
             self.send_config_message(compatibility_level=compatibility_level, subject=subject)
-        elif not has_eligible_master:
+        elif not master_url:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/config/{subject}"
@@ -494,11 +494,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
     async def subject_delete(self, content_type, *, subject, request: HTTPRequest):
         permanent = request.query.get("permanent", "false").lower() == "true"
 
-        are_we_master, has_eligible_master, master_url = await self.get_master()
-        if are_we_master and has_eligible_master:
+        are_we_master, master_url = await self.get_master()
+        if are_we_master:
             async with self.schema_lock:
                 await self._subject_delete_local(content_type, subject, permanent)
-        elif not has_eligible_master:
+        elif not master_url:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}?permanent={permanent}"
@@ -598,11 +598,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         version = int(version)
         permanent = request.query.get("permanent", "false").lower() == "true"
 
-        are_we_master, has_eligible_master, master_url = await self.get_master()
-        if are_we_master and has_eligible_master:
+        are_we_master, master_url = await self.get_master()
+        if are_we_master:
             async with self.schema_lock:
                 await self._subject_version_delete_local(content_type, subject, version, permanent)
-        elif not has_eligible_master:
+        elif not master_url:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}/versions/{version}?permanent={permanent}"
@@ -632,16 +632,16 @@ class KarapaceSchemaRegistry(KarapaceBase):
         subject_data = self._subject_get(subject, content_type)
         self.r(list(subject_data["schemas"]), content_type, status=HTTPStatus.OK)
 
-    async def get_master(self):
+    async def get_master(self) -> Tuple[bool, Optional[str]]:
         async with self.master_lock:
             while True:
-                are_we_master, has_eligible_master, master_url = self.mc.get_master_info()
+                are_we_master, master_url = self.mc.get_master_info()
                 if are_we_master is None:
                     self.log.info("No master set: %r, url: %r", are_we_master, master_url)
                 elif self.ksr.ready is False:
                     self.log.info("Schema reader isn't ready yet: %r", self.ksr.ready)
                 else:
-                    return are_we_master, has_eligible_master, master_url
+                    return are_we_master, master_url
                 await asyncio.sleep(1.0)
 
     def _validate_schema_request_body(self, content_type, body) -> None:
@@ -745,11 +745,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self._validate_schema_request_body(content_type, body)
         self._validate_schema_type(content_type, body)
         self._validate_schema_key(content_type, body)
-        are_we_master, has_eligible_master, master_url = await self.get_master()
-        if are_we_master and has_eligible_master:
+        are_we_master, master_url = await self.get_master()
+        if are_we_master:
             async with self.schema_lock:
                 await self.write_new_schema_local(subject, body, content_type)
-        elif not has_eligible_master:
+        elif not master_url:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}/versions"

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -397,10 +397,10 @@ class KarapaceSchemaRegistry(KarapaceBase):
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-        are_we_master, is_master_eligible, master_url = await self.get_master()
-        if are_we_master and is_master_eligible:
+        are_we_master, has_eligible_master, master_url = await self.get_master()
+        if are_we_master and has_eligible_master:
             self.send_config_message(compatibility_level=compatibility_level, subject=None)
-        elif not is_master_eligible:
+        elif not has_eligible_master:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/config"
@@ -448,10 +448,10 @@ class KarapaceSchemaRegistry(KarapaceBase):
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-        are_we_master, is_master_eligible, master_url = await self.get_master()
-        if are_we_master and is_master_eligible:
+        are_we_master, has_eligible_master, master_url = await self.get_master()
+        if are_we_master and has_eligible_master:
             self.send_config_message(compatibility_level=compatibility_level, subject=subject)
-        elif not is_master_eligible:
+        elif not has_eligible_master:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/config/{subject}"
@@ -494,11 +494,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
     async def subject_delete(self, content_type, *, subject, request: HTTPRequest):
         permanent = request.query.get("permanent", "false").lower() == "true"
 
-        are_we_master, is_master_eligible, master_url = await self.get_master()
-        if are_we_master and is_master_eligible:
+        are_we_master, has_eligible_master, master_url = await self.get_master()
+        if are_we_master and has_eligible_master:
             async with self.schema_lock:
                 await self._subject_delete_local(content_type, subject, permanent)
-        elif not is_master_eligible:
+        elif not has_eligible_master:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}?permanent={permanent}"
@@ -598,11 +598,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         version = int(version)
         permanent = request.query.get("permanent", "false").lower() == "true"
 
-        are_we_master, is_master_eligible, master_url = await self.get_master()
-        if are_we_master and is_master_eligible:
+        are_we_master, has_eligible_master, master_url = await self.get_master()
+        if are_we_master and has_eligible_master:
             async with self.schema_lock:
                 await self._subject_version_delete_local(content_type, subject, version, permanent)
-        elif not is_master_eligible:
+        elif not has_eligible_master:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}/versions/{version}?permanent={permanent}"
@@ -635,13 +635,13 @@ class KarapaceSchemaRegistry(KarapaceBase):
     async def get_master(self):
         async with self.master_lock:
             while True:
-                are_we_master, is_master_eligible, master_url = self.mc.get_master_info()
+                are_we_master, has_eligible_master, master_url = self.mc.get_master_info()
                 if are_we_master is None:
                     self.log.info("No master set: %r, url: %r", are_we_master, master_url)
                 elif self.ksr.ready is False:
                     self.log.info("Schema reader isn't ready yet: %r", self.ksr.ready)
                 else:
-                    return are_we_master, is_master_eligible, master_url
+                    return are_we_master, has_eligible_master, master_url
                 await asyncio.sleep(1.0)
 
     def _validate_schema_request_body(self, content_type, body) -> None:
@@ -745,11 +745,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self._validate_schema_request_body(content_type, body)
         self._validate_schema_type(content_type, body)
         self._validate_schema_key(content_type, body)
-        are_we_master, is_master_eligible, master_url = await self.get_master()
-        if are_we_master and is_master_eligible:
+        are_we_master, has_eligible_master, master_url = await self.get_master()
+        if are_we_master and has_eligible_master:
             async with self.schema_lock:
                 await self.write_new_schema_local(subject, body, content_type)
-        elif not is_master_eligible:
+        elif not has_eligible_master:
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}/versions"

--- a/tests/integration/test_master_coordinator.py
+++ b/tests/integration/test_master_coordinator.py
@@ -110,10 +110,8 @@ def test_no_eligible_master(kafka_servers: KafkaServers) -> None:
             time.sleep(0.3)
 
         # Make sure the end configuration is as expected
-        master_url = f'http://{mc.config["host"]}:{mc.config["port"]}'
-        assert mc.sc.master_url == master_url
         assert mc.sc.are_we_master is False
-        assert mc.sc.has_eligible_master is False
+        assert mc.sc.master_url is None
 
 
 async def test_schema_request_forwarding(registry_async_pair):

--- a/tests/integration/test_master_coordinator.py
+++ b/tests/integration/test_master_coordinator.py
@@ -112,8 +112,8 @@ def test_no_eligible_master(kafka_servers: KafkaServers) -> None:
         # Make sure the end configuration is as expected
         master_url = f'http://{mc.config["host"]}:{mc.config["port"]}'
         assert mc.sc.master_url == master_url
-        assert mc.sc.are_we_master is True
-        assert mc.sc.is_master_eligible is False
+        assert mc.sc.are_we_master is False
+        assert mc.sc.has_eligible_master is False
 
 
 async def test_schema_request_forwarding(registry_async_pair):


### PR DESCRIPTION
# About this change: What it does, why it matters

Karapace configuration allows configuring node to not be eligible for master.  Handle gracefully ie. read-only mode if all nodes are configured non-eligible for master.
