### PR TITLE
schema_registry: breaking change in an error message

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -697,7 +697,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.HTTP_INTERNAL_SERVER_ERROR.value,
-                    "message": "Internal Server Error",
+                    "message": f"Error while looking up schema under subject {subject}",
                 },
                 content_type=content_type,
                 status=HTTPStatus.INTERNAL_SERVER_ERROR,

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1270,7 +1270,7 @@ async def test_schema_subject_post_invalid(registry_async_client: Client) -> Non
     res = await registry_async_client.post(f"subjects/{subject_1}", json={})
     assert res.status == 500
     assert res.json()["error_code"] == 500
-    assert res.json()["message"] == "Internal Server Error"
+    assert res.json()["message"] == f"Error while looking up schema under subject {subject_1}"
 
     # Schema not included in the request body for subject that does not exist
     subject_3 = subject_name_factory()


### PR DESCRIPTION
The error message in POST to /subject/<subject> when schema is not specified in the request changed.

Fixes test_schema_subject_post_invalid to run in Karapace and against Schema Registry.
