### PR TITLE
schema_registry: breaking change in subjects/{}/versions/{}

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -172,7 +172,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             body={
                 "error_code": SchemaErrorCodes.INVALID_VERSION_ID.value,
                 "message": (
-                    "The specified version is not a valid version id. "
+                    f"The specified version '{version}' is not a valid version id. "
                     "Allowed values are between [1, 2^31-1] and the string \"latest\""
                 ),
             },

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1215,7 +1215,8 @@ async def test_schema_subject_invalid_id(registry_async_client: Client, trail: s
     assert res.status_code == 422
     assert res.json()["error_code"] == 42202
     assert res.json()["message"] == \
-        'The specified version is not a valid version id. Allowed values are between [1, 2^31-1] and the string "latest"'
+        'The specified version \'0\' is not a valid version id. '\
+           + 'Allowed values are between [1, 2^31-1] and the string "latest"'
 
     # Find an invalid version (too large)
     res = await registry_async_client.get(f"subjects/{subject}/versions/15")


### PR DESCRIPTION
Fixed the error message in subjects/{}/versions/{} to match Schema Registry

Now test_schema_subject_invalid_id works against SR
