### PR TITLE
schema_registry: breaking change in POST subjects/{subject}/versions

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -21,6 +21,7 @@ import time
 
 @unique
 class SchemaErrorCodes(Enum):
+    EMPTY_SCHEMA = 42201
     HTTP_NOT_FOUND = HTTPStatus.NOT_FOUND.value
     HTTP_CONFLICT = HTTPStatus.CONFLICT.value
     HTTP_UNPROCESSABLE_ENTITY = HTTPStatus.UNPROCESSABLE_ENTITY.value
@@ -681,11 +682,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
         if "schema" not in body:
             self.r(
                 body={
-                    "error_code": SchemaErrorCodes.HTTP_INTERNAL_SERVER_ERROR.value,
-                    "message": "Internal Server Error",
+                    "error_code": SchemaErrorCodes.EMPTY_SCHEMA.value,
+                    "message": "Empty schema",
                 },
                 content_type=content_type,
-                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
     async def subjects_schema_post(self, content_type, *, subject, request):

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1172,9 +1172,9 @@ async def test_schema_missing_body(registry_async_client: Client, trail: str) ->
         f"subjects/{subject}/versions{trail}",
         json={},
     )
-    assert res.status == 500
-    assert res.json()["error_code"] == 500
-    assert res.json()["message"] == "Internal Server Error"
+    assert res.status == 422
+    assert res.json()["error_code"] == 42201
+    assert res.json()["message"] == "Empty schema"
 
 
 async def test_schema_non_existing_id(registry_async_client: Client) -> None:


### PR DESCRIPTION
In the case the endpoint is submitted without body, changed the HTTP status code, error_code and message match the ones in Schema Registry. Made the necessary changes so that Karapace also returns correct values.

test_schema.py: test_schema_missing_body fixed accordingly.
