### PR TITLE
schema_registry: breaking changes in some HTTP error messages

### DIFF
--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -202,7 +202,7 @@ class RestApp:
         if method in {"POST", "PUT"}:
             if not content_matcher:
                 http_error(
-                    message=HTTPStatus.UNSUPPORTED_MEDIA_TYPE.description,
+                    message="HTTP 415 Unsupported Media Type",
                     content_type=result["content_type"],
                     code=HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
                 )
@@ -214,7 +214,7 @@ class RestApp:
             return result
         self.log.error("Not acceptable: %r", request.get_header("accept"))
         http_error(
-            message=HTTPStatus.NOT_ACCEPTABLE.description,
+            message="HTTP 406 Not Acceptable",
             content_type=result["content_type"],
             code=HTTPStatus.NOT_ACCEPTABLE,
         )
@@ -226,7 +226,7 @@ class RestApp:
 
         if method in {"POST", "PUT"} and cgi.parse_header(content_type)[0] not in SCHEMA_CONTENT_TYPES:
             http_error(
-                message=HTTPStatus.UNSUPPORTED_MEDIA_TYPE.description,
+                message="HTTP 415 Unsupported Media Type",
                 content_type=response_default_content_type,
                 code=HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
             )
@@ -238,7 +238,7 @@ class RestApp:
             if not content_type_match:
                 self.log.debug("Unexpected Accept value: %r", accept_val)
                 http_error(
-                    message=HTTPStatus.NOT_ACCEPTABLE.description,
+                    message="HTTP 406 Not Acceptable",
                     content_type=response_default_content_type,
                     code=HTTPStatus.NOT_ACCEPTABLE,
                 )

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1808,12 +1808,12 @@ async def test_http_headers(registry_async_client: Client) -> None:
     # Giving an invalid Accept value
     res = await registry_async_client.get("subjects", headers={"Accept": "application/vnd.schemaregistry.v2+json"})
     assert res.status == 406
-    assert res.json()["message"] == HTTPStatus.NOT_ACCEPTABLE.description
+    assert res.json()["message"] == "HTTP 406 Not Acceptable"
 
     # PUT with an invalid Content type
     res = await registry_async_client.put("config", json={"compatibility": "NONE"}, headers={"Content-Type": "text/html"})
     assert res.status == 415
-    assert res.json()["message"] == HTTPStatus.UNSUPPORTED_MEDIA_TYPE.description
+    assert res.json()["message"] == "HTTP 415 Unsupported Media Type"
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
 
     # Multiple Accept values
@@ -1837,7 +1837,7 @@ async def test_http_headers(registry_async_client: Client) -> None:
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
     res = await registry_async_client.get("subjects", headers={"Accept": "text/*"})
     assert res.status == 406
-    assert res.json()["message"] == HTTPStatus.NOT_ACCEPTABLE.description
+    assert res.json()["message"] == "HTTP 406 Not Acceptable"
 
     # Accept without any type works
     res = await registry_async_client.get("subjects", headers={"Accept": "*/does_not_matter"})
@@ -1860,7 +1860,6 @@ async def test_http_headers(registry_async_client: Client) -> None:
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
     res = await registry_async_client.get("subjects", headers={"Accept": "application/octet-stream"})
     assert res.status == 406
-    assert res.json()["message"] == HTTPStatus.NOT_ACCEPTABLE.description
 
     # Parse Content-Type correctly
     res = await registry_async_client.put(


### PR DESCRIPTION
Now HTTP error messages match with the ones coming from Schema Registry.
Adjusted test_http_headers in test_schema.py to correctly check the messages.

Since the Kafka REST and Schema Registry REST share `rapu.py`, I assume this will also change the error messages in Kafka REST? Is that OK? Do we test those errors?