### PR TITLE
 schema_registry: breaking change in /schemas/ids/<>/versions

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -360,17 +360,6 @@ class KarapaceSchemaRegistry(KarapaceBase):
                     for version, schema in schemas.items():
                         if int(schema["id"]) == schema_id_int and not schema["deleted"]:
                             subject_versions.append({"subject": subject, "version": int(version)})
-
-        if not subject_versions:
-            self.r(
-                body={
-                    "error_code": SchemaErrorCodes.HTTP_NOT_FOUND.value,
-                    "message": "HTTP 404 Not Found",
-                },
-                content_type=content_type,
-                status=HTTPStatus.NOT_FOUND,
-            )
-
         subject_versions = sorted(subject_versions, key=lambda s: (s["subject"], s["version"]))
         self.r(subject_versions, content_type)
 

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1070,25 +1070,28 @@ async def test_schema_versions_deleting(registry_async_client: Client, trail: st
     subject = create_subject_name_factory(f"test_schema_versions_deleting_{trail}")()
     schema_name = create_schema_name_factory(f"test_schema_versions_deleting_{trail}")()
 
+    field_name = create_field_name_factory(trail)()
     schema_1 = {
         "type": "record",
         "name": schema_name,
         "fields": [{
-            "name": "f1",
-            "type": "string",
+            "name": field_name,
+            "type": "string"
         }, {
-            "name": "f2",
-            "type": "string",
+            "name": "field_1",
+            "type": "string"
         }]
     }
     schema_str_1 = jsonlib.dumps(schema_1)
     schema_2 = {
         "type": "record",
         "name": schema_name,
-        "fields": [{
-            "name": "f1",
-            "type": "string",
-        }]
+        "fields": [
+            {
+                "name": field_name,
+                "type": "string"
+            },
+        ]
     }
     schema_str_2 = jsonlib.dumps(schema_2)
 
@@ -1108,7 +1111,7 @@ async def test_schema_versions_deleting(registry_async_client: Client, trail: st
     assert res.status_code == 200
     assert res.json() == version_1
 
-    await assert_schema_versions_failed(registry_async_client, trail, schema_id_1)
+    await assert_schema_versions(registry_async_client, trail, schema_id_1, [])
     await assert_schema_versions(registry_async_client, trail, schema_id_2, schema_2_versions)
 
     # Deleting the subject, the schema version 2 cannot be found anymore
@@ -1116,8 +1119,8 @@ async def test_schema_versions_deleting(registry_async_client: Client, trail: st
     assert res.status_code == 200
     assert res.json() == [version_2]
 
-    await assert_schema_versions_failed(registry_async_client, trail, schema_id_1)
-    await assert_schema_versions_failed(registry_async_client, trail, schema_id_2)
+    await assert_schema_versions(registry_async_client, trail, schema_id_1, [])
+    await assert_schema_versions(registry_async_client, trail, schema_id_2, [])
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -1356,7 +1359,7 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
     assert res.status_code == 200
 
     # Get the versions, old version not found anymore (even if schema itself is)
-    await assert_schema_versions_failed(registry_async_client, trail, schema_id_1)
+    await assert_schema_versions(registry_async_client, trail, schema_id_1, [])
     await assert_schema_versions(registry_async_client, trail, schema_id_2, [(subject, 2)])
 
     # Delete a whole subject

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1070,15 +1070,14 @@ async def test_schema_versions_deleting(registry_async_client: Client, trail: st
     subject = create_subject_name_factory(f"test_schema_versions_deleting_{trail}")()
     schema_name = create_schema_name_factory(f"test_schema_versions_deleting_{trail}")()
 
-    field_name = create_field_name_factory(trail)()
     schema_1 = {
         "type": "record",
         "name": schema_name,
         "fields": [{
-            "name": field_name,
+            "name": "field_1",
             "type": "string"
         }, {
-            "name": "field_1",
+            "name": "field_2",
             "type": "string"
         }]
     }
@@ -1088,7 +1087,7 @@ async def test_schema_versions_deleting(registry_async_client: Client, trail: st
         "name": schema_name,
         "fields": [
             {
-                "name": field_name,
+                "name": "field_1",
                 "type": "string"
             },
         ]


### PR DESCRIPTION
/schemas/ids/<schema_id:path>/versions now returns empty list in case nothing is found.
This is the behaviour of SR. Karapace used to fail in this case before this change.

The tests test_schema_lifecycle and test_schema_versions_deleting now works against Schema Registry (in addition to Karapace)