### PR TITLE
test_schema.py: test_schema_hard_delete_and_recreate

### DIFF
--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -2369,11 +2369,13 @@ async def test_schema_hard_delete_whole_schema(registry_async_client: Client) ->
 
 async def test_schema_hard_delete_and_recreate(registry_async_client: Client) -> None:
     subject = create_subject_name_factory("test_schema_hard_delete_and_recreate")()
+    schema_name = create_schema_name_factory("test_schema_hard_delete_and_recreate")()
+
     res = await registry_async_client.put("config", json={"compatibility": "BACKWARD"})
     assert res.status == 200
     schema = {
         "type": "record",
-        "name": "myenumtest",
+        "name": schema_name,
         "fields": [{
             "type": {
                 "type": "enum",
@@ -2402,7 +2404,7 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
     )
     assert res.status == 200
     assert "id" in res.json()
-    assert schema_id == res.json()["id"], "the same schema registered, the same identifier"
+    assert schema_id == res.json()["id"], "after soft delete the same schema registered, the same identifier"
 
     # Soft delete whole schema
     res = await registry_async_client.delete(f"subjects/{subject}")
@@ -2423,4 +2425,4 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
     )
     assert res.status == 200
     assert "id" in res.json()
-    assert schema_id == res.json()["id"], "the same schema registered, the same identifier"
+    assert schema_id == res.json()["id"], "after permanent deleted the same schema registered, the same identifier"


### PR DESCRIPTION
Using a unique schema name to support parallel execution.
Small improvement in the assert messages.

The test doesn't work against Schema Registry. The issue is that SR doesn't reuse the same schema id after hard delete. Karapace reuses.

We still can merge this PR and handle the incompatibility in another PR.

