### PR TITLE
bugfix: _tags should default to a dict

### DIFF
--- a/karapace/statsd.py
+++ b/karapace/statsd.py
@@ -48,7 +48,7 @@ class StatsClient:
         })
         self._dest_addr = (host, port)
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self._tags = self.sentry_config.get("tags")
+        self._tags = self.sentry_config.get("tags", dict())
 
     @contextmanager
     def timing_manager(self, metric: str, tags: Optional[Dict] = None) -> Iterator[None]:


### PR DESCRIPTION
When running the tests we get these errors:

> 2021-06-04T08:28:15.1782569Z ERROR    StatsClient:statsd.py:126 Unexpected exception in statsd send: AttributeError: 'NoneType' object has no attribute 'copy'

It seems it was caused by this line:

https://github.com/aiven/karapace/blob/fa7211f3fe3f20f4ccc8d306303b3dd97655ea03/karapace/statsd.py#L107

The bug was caught by `mypy`, unfortunately I think it is not yet enforced in the CI.