### PR TITLE
fix: imp module is deprecated

### DIFF
--- a/version.py
+++ b/version.py
@@ -4,7 +4,7 @@ karapace - version
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
-import imp
+import importlib.util
 import os
 import subprocess
 
@@ -19,13 +19,11 @@ def save_version(new_ver, old_ver, version_file):
     return True
 
 
-def get_project_version(version_file):
-    version_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), version_file)
-    try:
-        module = imp.load_source("verfile", version_file)
-        file_ver = module.__version__
-    except IOError:
-        file_ver = None
+def get_project_version(version_file: str) -> str:
+    version_file_full_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), version_file)
+    module_spec = importlib.util.spec_from_file_location("verfile", version_file_full_path)
+    module = importlib.util.module_from_spec(module_spec)
+    file_ver = getattr(module, "__version__", None)
 
     os.chdir(os.path.dirname(__file__) or ".")
     try:


### PR DESCRIPTION
Usage of `imp` is deprecated, when running `pytest tests/unit` the following warnings are printed:

```
bringing up nodes...                  
................................................                                                                                                                                                                                       [100%]
============================================================================================================== warnings summary ==============================================================================================================
version.py:7
version.py:7
version.py:7
version.py:7
  /home/hacka/work/karapace/version.py:7: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/warnings.html
48 passed, 4 warnings in 0.81s
```

This PR fixes that by replacing `imp` with the `importlib` module.