### PR TITLE
Container accepting all config options

### DIFF
--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -66,16 +66,16 @@ services:
     ports:
       - "8081:8081"
     environment:
-      KARAPACE_REGISTRY_ADVERTISED_HOSTNAME: karapace-registry
-      KARAPACE_REGISTRY_BOOTSTRAP_URI: kafka:29092
-      KARAPACE_REGISTRY_PORT: 8081
-      KARAPACE_REGISTRY_HOST: 0.0.0.0
-      KARAPACE_REGISTRY_CLIENT_ID: karapace
-      KARAPACE_REGISTRY_GROUP_ID: karapace-registry
-      KARAPACE_REGISTRY_MASTER_ELIGIBITY: "true"
-      KARAPACE_REGISTRY_TOPIC_NAME: _schemas
-      KARAPACE_REGISTRY_LOG_LEVEL: WARNING
-      KARAPACE_REGISTRY_COMPATIBILITY: FULL
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-registry
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_PORT: 8081
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_CLIENT_ID: karapace
+      KARAPACE_GROUP_ID: karapace-registry
+      KARAPACE_MASTER_ELIGIBITY: "true"
+      KARAPACE_TOPIC_NAME: _schemas
+      KARAPACE_LOG_LEVEL: WARNING
+      KARAPACE_COMPATIBILITY: FULL
 
   karapace-rest:
     image: aivenoy/karapace:latest
@@ -89,13 +89,11 @@ services:
     ports:
       - "8082:8082"
     environment:
-      KARAPACE_REST_PORT: 8082
-      KARAPACE_REST_HOST: 0.0.0.0
-      KARAPACE_REST_ADVERTISED_HOSTNAME: karapace-rest
-      KARAPACE_REST_BOOTSTRAP_URI: kafka:29092
-      KARAPACE_REST_REGISTRY_HOST: karapace-registry
-      KARAPACE_REST_REGISTRY_PORT: 8081
-      # Keep in sync with tests/integration/conftest.py::fixture_rest_async,
-      # new entries may need to be added to containers/start.sh
-      KARAPACE_REST_ADMIN_METADATA_MAX_AGE: 0
-      KARAPACE_REST_LOG_LEVEL: WARNING
+      KARAPACE_PORT: 8082
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-rest
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_REGISTRY_HOST: karapace-registry
+      KARAPACE_REGISTRY_PORT: 8081
+      KARAPACE_ADMIN_METADATA_MAX_AGE: 0
+      KARAPACE_LOG_LEVEL: WARNING

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -37,6 +37,7 @@ DEFAULTS = {
     "ssl_certfile": None,
     "ssl_keyfile": None,
     "ssl_check_hostname": True,
+    "ssl_crlfile": None,
     "sasl_mechanism": None,
     "sasl_plain_username": None,
     "sasl_plain_password": None,
@@ -118,7 +119,7 @@ def create_ssl_context(config: Config) -> ssl.SSLContext:
         ssl_context.load_cert_chain(
             certfile=config['ssl_certfile'], keyfile=config['ssl_keyfile'], password=config.get('ssl_password')
         )
-    if config.get('ssl_crlfile'):
+    if config['ssl_crlfile']:
         if not hasattr(ssl, 'VERIFY_CRL_CHECK_LEAF'):
             raise RuntimeError('This version of Python does not support ssl_crlfile!')
         ssl_context.load_verify_locations(config['ssl_crlfile'])

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -38,6 +38,7 @@ DEFAULTS = {
     "ssl_keyfile": None,
     "ssl_check_hostname": True,
     "ssl_crlfile": None,
+    "ssl_password": None,
     "sasl_mechanism": None,
     "sasl_plain_username": None,
     "sasl_plain_password": None,
@@ -117,7 +118,9 @@ def create_ssl_context(config: Config) -> ssl.SSLContext:
         ssl_context.verify_mode = ssl.CERT_REQUIRED
     if config['ssl_certfile'] and config['ssl_keyfile']:
         ssl_context.load_cert_chain(
-            certfile=config['ssl_certfile'], keyfile=config['ssl_keyfile'], password=config.get('ssl_password')
+            certfile=config['ssl_certfile'],
+            keyfile=config['ssl_keyfile'],
+            password=config['ssl_password'],
         )
     if config['ssl_crlfile']:
         if not hasattr(ssl, 'VERIFY_CRL_CHECK_LEAF'):

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -36,6 +36,7 @@ DEFAULTS = {
     "ssl_cafile": None,
     "ssl_certfile": None,
     "ssl_keyfile": None,
+    "ssl_check_hostname": True,
     "sasl_mechanism": None,
     "sasl_plain_username": None,
     "sasl_plain_password": None,
@@ -108,7 +109,7 @@ def create_ssl_context(config: Config) -> ssl.SSLContext:
     ssl_context.options |= ssl.OP_NO_TLSv1  # pylint: disable=no-member
     ssl_context.options |= ssl.OP_NO_TLSv1_1  # pylint: disable=no-member
     ssl_context.verify_mode = ssl.CERT_OPTIONAL
-    if config.get('ssl_check_hostname'):
+    if config['ssl_check_hostname']:
         ssl_context.check_hostname = True
     if config['ssl_cafile']:
         ssl_context.load_verify_locations(config['ssl_cafile'])


### PR DESCRIPTION
The previous `start.sh` had two issues. 1. It gave the impression configurations had to be manually saved to the configuration file 2. it had some bad defaults for ssh. This caused trouble to some users: https://github.com/aiven/karapace/pull/219 https://github.com/aiven/karapace/pull/263 . This PR modifies the `start.sh` with a comment explaining about the `KARAPACE_` env variables, and changes the existing script to use that too.