### PR TITLE
Config GitHub actions to avoid double triggering #271

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,5 @@ jobs:
 
         - name: Enforce copyright headers
           run: make copyright
+
+# This is added to be removed later

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,5 +31,3 @@ jobs:
 
         - name: Enforce copyright headers
           run: make copyright
-
-# This is added to be removed later

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - master
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: Test Suite
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - master
 
 jobs:
   unit-test:


### PR DESCRIPTION
References: #271
Lint and tests will now run when:
- A PR is created, updated, reopened...
- A push event happens on the master branch

