### PR TITLE
Clean up obsolete sections and remove "simply" wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,18 +53,6 @@ make integrationtest
 If you want to run the tests from within the IDE, first download Kafka using `make fetch-kafka`, and
 use the project root as the working directory.
 
-### Compatibility tests
-
-The integration tests can be configured to use an external REST (`--rest-url`), Registry
-(`--registry-url`) and Kafka (`--kafka-bootstrap-servers`).  These can be used to make sure the
-tests conform to the Kafka REST or Schema Registry APIs, and then that Karapace conform to the
-tests:
-
-```sh
-docker-compose -f ./tests/integration/confluent-docker-compose.yml up -d
-pytest --kafka-bootstrap-servers localhost:9092 --registry-url http://localhost:8081 --rest-url http://localhost:8082/ tests/integration
-```
-
 ## Static checking and Linting
 
 The code is statically checked and formatted using [a few
@@ -74,7 +62,7 @@ Alternatively you can run it manually with `make pre-commit`.
 
 ## Manual testing
 
-To use your development code, you just need to set up a Kafka server and run Karapace from you
+To use your development code, you need to set up a Kafka server and run Karapace from you
 virtual environment:
 
 ```

--- a/README.rst
+++ b/README.rst
@@ -77,14 +77,14 @@ Quickstart
 To register the first version of a schema under the subject "test" using Avro schema::
 
   $ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-  --data '{"schema": "{\"type\": \"record\", \"name\": \"Obj\", \"fields\":[{\"name\": \"age\", \"type\": \"int\"}]}"}' \
+    --data '{"schema": "{\"type\": \"record\", \"name\": \"Obj\", \"fields\":[{\"name\": \"age\", \"type\": \"int\"}]}"}' \
     http://localhost:8081/subjects/test-key/versions
   {"id":1}
 
 To register a version of a schema using JSON Schema, one needs to use `schemaType` property::
 
   $ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-  --data '{"schemaType": "JSON", "schema": "{\"type\": \"object\",\"properties\":{\"age\":{\"type\": \"number\"}},\"additionalProperties\":true}"}' \
+    --data '{"schemaType": "JSON", "schema": "{\"type\": \"object\",\"properties\":{\"age\":{\"type\": \"number\"}},\"additionalProperties\":true}"}' \
     http://localhost:8081/subjects/test-key-json-schema/versions
   {"id":2}
 
@@ -106,47 +106,47 @@ To fetch back the schema whose global id is 1 (i.e. the one registered above)::
 To get the specific version 1 of the schema just registered run::
 
   $ curl -X GET http://localhost:8081/subjects/test-key/versions/1
-    {"subject":"test-key","version":1,"id":1,"schema":"{\"fields\":[{\"name\":\"age\",\"type\":\"int\"}],\"name\":\"Obj\",\"type\":\"record\"}"}
+  {"subject":"test-key","version":1,"id":1,"schema":"{\"fields\":[{\"name\":\"age\",\"type\":\"int\"}],\"name\":\"Obj\",\"type\":\"record\"}"}
 
 To get the latest version of the schema under subject test-key run::
 
   $ curl -X GET http://localhost:8081/subjects/Kafka-value/versions/latest
-    {"subject":"test-key","version":1,"id":1,"schema":"{\"fields\":[{\"name\":\"age\",\"type\":\"int\"}],\"name\":\"Obj\",\"type\":\"record\"}"}
+  {"subject":"test-key","version":1,"id":1,"schema":"{\"fields\":[{\"name\":\"age\",\"type\":\"int\"}],\"name\":\"Obj\",\"type\":\"record\"}"}
 
 In order to delete version 10 of the schema registered under subject "test-key" (if it exists)::
 
   $ curl -X DELETE http://localhost:8081/subjects/test-key/versions/10
-    10
+   10
 
 To Delete all versions of the schema registered under subject "test-key"::
 
   $ curl -X DELETE http://localhost:8081/subjects/test-key
-    [1]
+  [1]
 
 Test the compatibility of a schema with the latest schema under subject "test-key"::
 
   $ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-      --data '{"schema": "{\"type\": \"int\"}"}' \
-      http://localhost:8081/compatibility/subjects/test-key/versions/latest
-    {"is_compatible":true}
+    --data '{"schema": "{\"type\": \"int\"}"}' \
+    http://localhost:8081/compatibility/subjects/test-key/versions/latest
+  {"is_compatible":true}
 
 Get current global backwards compatibility setting value::
 
   $ curl -X GET http://localhost:8081/config
-    {"compatibilityLevel":"BACKWARD"}
+  {"compatibilityLevel":"BACKWARD"}
 
 Change compatibility requirements for all subjects where it's not
 specifically defined otherwise::
 
   $ curl -X PUT -H "Content-Type: application/vnd.schemaregistry.v1+json" \
     --data '{"compatibility": "NONE"}' http://localhost:8081/config
-    {"compatibility":"NONE"}
+  {"compatibility":"NONE"}
 
 Change compatibility requirement to FULL for the test-key subject::
 
   $ curl -X PUT -H "Content-Type: application/vnd.schemaregistry.v1+json" \
-      --data '{"compatibility": "FULL"}' http://localhost:8081/config/test-key
-    {"compatibility":"FULL"}
+    --data '{"compatibility": "FULL"}' http://localhost:8081/config/test-key
+  {"compatibility":"FULL"}
 
 List topics::
 
@@ -159,8 +159,8 @@ Get info for one particular topic::
 Produce a message backed up by schema registry::
 
   $ curl -H "Content-Type: application/vnd.kafka.avro.v2+json" -X POST -d \
-  '{"value_schema": "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"simple\", \"fields\": \
-  [{\"name\": \"name\", \"type\": \"string\"}]}", "records": [{"value": {"name": "name0"}}]}' http://localhost:8081/topics/my_topic
+    '{"value_schema": "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"simple\", \"fields\": \
+    [{\"name\": \"name\", \"type\": \"string\"}]}", "records": [{"value": {"name": "name0"}}]}' http://localhost:8081/topics/my_topic
 
 Create a consumer::
 
@@ -176,9 +176,9 @@ Subscribe to the topic we previously published to::
 Consume previously published message::
 
   $ curl -X GET -H "Accept: application/vnd.kafka.avro.v2+json" \
-  http://localhost:8081/consumers/avro_consumers/instances/my_consumer/records?timeout=1000
+    http://localhost:8081/consumers/avro_consumers/instances/my_consumer/records?timeout=1000
 
-Commit offsets for a particular topic partition:
+Commit offsets for a particular topic partition::
 
   $ curl -X POST -H "Content-Type: application/vnd.kafka.v2+json" --data '{}' \
     http://localhost:8081/consumers/avro_consumers/instances/my_consumer/offsets
@@ -186,7 +186,7 @@ Commit offsets for a particular topic partition:
 Delete consumer::
 
   $ curl -X DELETE -H "Accept: application/vnd.kafka.v2+json" \
-  http://localhost:8081/consumers/avro_consumers/instances/my_consumer
+    http://localhost:8081/consumers/avro_consumers/instances/my_consumer
 
 Backing up your Karapace
 ========================

--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ Karapace includes a tool to backing up and restoring data. To back up, run::
 
   karapace_schema_backup get --config karapace.config.json --location schemas.log
 
-You can also back up the data simply by using Kafka's Java console
+You can also back up the data by using Kafka's Java console
 consumer::
 
   ./kafka-console-consumer.sh --bootstrap-server brokerhostname:9092 --topic _schemas --from-beginning --property print.key=true --timeout-ms 1000 1> schemas.log


### PR DESCRIPTION
Words like easy, painless, straightforward, trivial, simple and just
when referring to simplicity should be avoided from any docs.
Just might be OK to use when it referst to the temporal adverb, like
"the thing we did just before".
