### PR TITLE
schemas: better error messages for invalid schemas

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -68,7 +68,7 @@ class TypedSchema:
         try:
             ts = TypedSchema(parse_avro_schema_definition(schema_str), SchemaType.AVRO, schema_str)
             return ts
-        except SchemaParseException as e:
+        except (SchemaParseException, JSONDecodeError, TypeError) as e:
             raise InvalidSchema from e
 
     @staticmethod


### PR DESCRIPTION
This provides a bit more of context of the error to the user