### PR TITLE
Hierarchical loggers

### DIFF
--- a/karapace/kafka_rest_apis/__main__.py
+++ b/karapace/kafka_rest_apis/__main__.py
@@ -18,7 +18,7 @@ def main() -> int:
         config = read_config(arg.config_file)
 
     logging.basicConfig(level=logging.INFO, format=DEFAULT_LOG_FORMAT_JOURNAL)
-    logging.getLogger().setLevel(config["log_level"])
+    logging.getLogger("karapace").setLevel(config["log_level"])
     kc = KafkaRest(config=config)
     try:
         kc.run(host=kc.config["host"], port=kc.config["port"])

--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -9,12 +9,10 @@ from typing import List
 
 import logging
 
+log = logging.getLogger(__name__)
+
 
 class KafkaRestAdminClient(KafkaAdminClient):
-    def __init__(self, **configs):
-        super().__init__(**configs)
-        self.log = logging.getLogger("AdminClient")
-
     def get_topic_config(self, topic: str) -> dict:
         config_version = self._matching_api_version(DescribeConfigsRequest)
         req_cfgs = [ConfigResource(ConfigResourceType.TOPIC, topic)]
@@ -50,7 +48,7 @@ class KafkaRestAdminClient(KafkaAdminClient):
         except Cancelled:
             if retries > 3:
                 raise
-            self.log.debug("Retrying metadata with %d retires", retries)
+            log.debug("Retrying metadata with %d retires", retries)
             return self.cluster_metadata(topics, retries + 1)
         return self._make_metadata_response(future.value)
 

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -17,6 +17,8 @@ import logging
 import os
 import time
 
+log = logging.getLogger(__name__)
+
 
 class KarapaceBase(RestApp):
     def __init__(self, config: dict) -> None:
@@ -35,10 +37,9 @@ class KarapaceBase(RestApp):
         self._sentry_config["tags"]["app"] = "Karapace"
 
         self.route("/", callback=self.root_get, method="GET")
-        self.log = logging.getLogger("Karapace")
         self.app.on_startup.append(self.create_http_client)
         self.master_lock = asyncio.Lock()
-        self.log.info("Karapace initialized")
+        log.info("Karapace initialized")
 
     def _create_producer(self) -> KafkaProducer:
         while True:
@@ -59,7 +60,7 @@ class KarapaceBase(RestApp):
                     kafka_client=KarapaceKafkaClient,
                 )
             except:  # pylint: disable=bare-except
-                self.log.exception("Unable to create producer, retrying")
+                log.exception("Unable to create producer, retrying")
                 time.sleep(1)
 
     async def close(self) -> None:

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -14,7 +14,6 @@ class KarapaceAll(KafkaRest, KarapaceSchemaRegistry):
     # pylint: disable=super-init-not-called
     def __init__(self, config: dict) -> None:
         super().__init__(config=config)
-        self.log = logging.getLogger("KarapaceAll")
         self.app.on_shutdown.append(self.close_by_app)
 
     async def close_by_app(self, app):
@@ -32,7 +31,7 @@ def main() -> int:
         config = read_config(arg.config_file)
 
     logging.basicConfig(level=logging.INFO, format=DEFAULT_LOG_FORMAT_JOURNAL)
-    logging.getLogger().setLevel(config["log_level"])
+    logging.getLogger("karapace").setLevel(config["log_level"])
 
     kc: RestApp
     if config["karapace_rest"] and config["karapace_registry"]:

--- a/karapace/master_coordinator.py
+++ b/karapace/master_coordinator.py
@@ -37,7 +37,7 @@ class SchemaCoordinator(BaseCoordinator):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.log = logging.getLogger("SchemaCoordinator")
+        self.log = logging.getLogger("karapace.schemacoordinator")
 
     def protocol_type(self):
         return "sr"
@@ -135,7 +135,7 @@ class MasterCoordinator(Thread):
         self._metrics = Metrics(metric_config, reporters=[])
         self.lock = Lock()
         self.lock.acquire()
-        self.log = logging.getLogger("MasterCoordinator")
+        self.log = logging.getLogger("karapace.mastercoordinator")
 
     def init_kafka_client(self):
         try:

--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -162,7 +162,7 @@ class RestApp:
         self.app.on_cleanup.append(self.cleanup_http_client)
         self.http_client_v = None
         self.http_client_no_v = None
-        self.log = logging.getLogger(self.app_name)
+        self.log = logging.getLogger(__name__)
         self.stats = StatsClient(sentry_config=sentry_config)
         self.raven_client = self.stats.raven_client
         self.app.on_cleanup.append(self.cleanup_stats_client)

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -884,7 +884,7 @@ def main() -> int:
         config = read_config(arg.config_file)
 
     logging.basicConfig(level=logging.INFO, format=DEFAULT_LOG_FORMAT_JOURNAL)
-    logging.getLogger().setLevel(config["log_level"])
+    logging.getLogger("karapace").setLevel(config["log_level"])
     kc = KarapaceSchemaRegistry(config=config)
     try:
         kc.run(host=kc.config["host"], port=kc.config["port"])

--- a/karapace/statsd.py
+++ b/karapace/statsd.py
@@ -17,6 +17,8 @@ import os
 import socket
 import time
 
+log = logging.getLogger(__name__)
+
 STATSD_HOST = "127.0.0.1"
 STATSD_PORT = 8125
 
@@ -25,7 +27,6 @@ class StatsClient:
     def __init__(self, host: str = STATSD_HOST, port: int = STATSD_PORT, sentry_config: Dict = None) -> None:
         self.sentry_config: Dict
 
-        self.log = logging.getLogger("StatsClient")
         if sentry_config is None:
             self.sentry_config = {
                 "dsn": os.environ.get("SENTRY_DSN"),
@@ -70,7 +71,7 @@ class StatsClient:
                 self.raven_client = raven.Client(**self.sentry_config)
             except ImportError:
                 self.raven_client = None
-                self.log.warning("Cannot enable Sentry.io sending: importing 'raven' failed")
+                log.warning("Cannot enable Sentry.io sending: importing 'raven' failed")
         else:
             self.raven_client = None
 
@@ -123,7 +124,7 @@ class StatsClient:
 
             self._socket.sendto(b"".join(parts), self._dest_addr)
         except Exception as ex:  # pylint: disable=broad-except
-            self.log.error("Unexpected exception in statsd send: %s: %s", ex.__class__.__name__, ex)
+            log.error("Unexpected exception in statsd send: %s: %s", ex.__class__.__name__, ex)
 
     def close(self) -> None:
         self._socket.close()

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -18,7 +18,7 @@ import requests
 import time
 import types
 
-log = logging.getLogger("KarapaceUtils")
+log = logging.getLogger(__name__)
 NS_BLACKOUT_DURATION_SECONDS = 120
 
 


### PR DESCRIPTION
# About this change - What it does

Change loggers to follow hierarchical module based naming.  Also use static singleton loggers when possible.  This changes logger names of existing loggers to `karapace.<submodule>`.

# Why this way

Main entry points change log level only for loggers under `karapace` to avoid setting log level for libraries used.  python-kafka library no longer logs on DEBUG level even if DEBUG level is set on Karapace config, which reduces amount of logging a lot.
