### PR TITLE
RFC: validate defaults

### DIFF
--- a/karapace/avro_compatibility.py
+++ b/karapace/avro_compatibility.py
@@ -1,3 +1,4 @@
+from avro.io import Validate
 from avro.schema import (
     ARRAY, ArraySchema, BOOLEAN, BYTES, DOUBLE, ENUM, EnumSchema, Field, FIXED, FixedSchema, FLOAT, INT, LONG, MAP,
     MapSchema, NamedSchema, Names, NULL, RECORD, RecordSchema, Schema, SchemaFromJSONData, STRING, UNION, UnionSchema
@@ -26,8 +27,63 @@ def parse_avro_schema_definition(s: str) -> Schema:
 
         json_data = json.loads(s[:e.pos])
 
-    names = Names()
-    return SchemaFromJSONData(json_data, names)
+    schema = SchemaFromJSONData(json_data, Names())
+
+    validate_schema_defaults(schema)
+    return schema
+
+
+class ValidateSchemaDefaultsException(Exception):
+    def __init__(self, schema: Schema, default: Any, path: List[str]):
+        super().__init__(
+            f"{self._build_message_from_validation_path(path)}: default {default} does not match schema {schema.to_json()}"
+        )
+
+    @staticmethod
+    def _build_message_from_validation_path(path: List[str]) -> str:
+        return ": ".join(path)
+
+
+def validate_schema_defaults(schema: Schema):
+    """ This function validates that the defaults that are defined in the schema actually
+    match their schema. We try to build a proper error message internally and then throw it
+    to the user as a readable exception message.
+
+    Consider for example the schema: {'type': 'enum', 'symbols': ['A','B'], 'default':'C'}
+    """
+
+    def _validate_field_default(f: Field, acc: List[str]):
+        if f.has_default and not Validate(f.type, f.default):
+            raise ValidateSchemaDefaultsException(f.type, f.default, acc)
+
+    def _validation_crumb(s: Schema):
+        if hasattr(s, 'name'):
+            return f"bad {s.type} '{s.name}'"
+        return f"bad {s.type}"
+
+    def _validate_schema_defaults(s: Schema, acc: List[str]):
+        _acc = [*acc, _validation_crumb(s)]
+
+        if "default" in s.props:
+            default = s.props.get("default")
+            if not Validate(s, default):
+                raise ValidateSchemaDefaultsException(s, default, _acc)
+
+        if isinstance(s, RecordSchema):
+            # fields do need to be unwrapped
+            for f in s.fields:
+                _field_acc = [*_acc, f"bad field: '{f.name}'"]
+                _validate_schema_defaults(f.type, _field_acc)
+                _validate_field_default(f, _field_acc)
+        if isinstance(s, ArraySchema):
+            _validate_schema_defaults(s.items, _acc)
+        if isinstance(s, MapSchema):
+            _validate_schema_defaults(s.values, _acc)
+        if isinstance(s, UnionSchema):
+            for u in s.schemas:
+                _validate_schema_defaults(u, _acc)
+
+    _validate_schema_defaults(schema, [])
 
 
 def is_incompatible(result: "SchemaCompatibilityResult") -> bool:

--- a/karapace/avro_compatibility.py
+++ b/karapace/avro_compatibility.py
@@ -34,17 +34,13 @@ def parse_avro_schema_definition(s: str) -> Schema:
 
 
 class ValidateSchemaDefaultsException(Exception):
-    def __init__(self, schema: Schema, default: Any, path: List[str]):
-        super().__init__(
-            f"{self._build_message_from_validation_path(path)}: default {default} does not match schema {schema.to_json()}"
-        )
-
-    @staticmethod
-    def _build_message_from_validation_path(path: List[str]) -> str:
-        return ": ".join(path)
+    def __init__(self, schema: Schema, default: Any, path: List[str]) -> None:
+        prefix = ": ".join(path)
+        msg = f"{prefix}: default {default} does not match schema {schema.to_json()}"
+        super().__init__(msg)
 
 
-def validate_schema_defaults(schema: Schema):
+def validate_schema_defaults(schema: Schema) -> None:
     """ This function validates that the defaults that are defined in the schema actually
     match their schema. We try to build a proper error message internally and then throw it
     to the user as a readable exception message.
@@ -52,11 +48,32 @@ def validate_schema_defaults(schema: Schema):
     Consider for example the schema: {'type': 'enum', 'symbols': ['A','B'], 'default':'C'}
     """
 
-    def _validate_field_default(f: Field, acc: List[str]):
-        if f.has_default and not Validate(f.type, f.default):
+    def _validate_field_default(f: Field, acc: List[str]) -> None:
+        """This function validates that the default for a field matches the field type
+
+        From the Avro docs: (Note that when a default value is specified for a record
+        field whose type is a union, the type of the default value must match the first
+        element of the union. Thus, for unions containing "null", the "null" is usually
+        listed first, since the default value of such unions is typically null.)
+        """
+
+        if not f.has_default:
+            return
+
+        if isinstance(f.type, UnionSchema):
+            # select the first schema from the union to validate, if its empty just
+            # raise an exception because no default should match anyway
+            if len(f.type.schemas) == 0:
+                # if the union is empty; no default should match
+                raise ValidateSchemaDefaultsException(f.type, f.default, acc)
+            s = f.type.schemas[0]
+        else:
+            s = f.type
+
+        if not Validate(s, f.default):
             raise ValidateSchemaDefaultsException(f.type, f.default, acc)
 
-    def _validation_crumb(s: Schema):
+    def _validation_crumb(s: Schema) -> str:
         if hasattr(s, 'name'):
             return f"bad {s.type} '{s.name}'"
         return f"bad {s.type}"

--- a/karapace/avro_compatibility.py
+++ b/karapace/avro_compatibility.py
@@ -78,7 +78,7 @@ def validate_schema_defaults(schema: Schema) -> None:
             return f"bad {s.type} '{s.name}'"
         return f"bad {s.type}"
 
-    def _validate_schema_defaults(s: Schema, acc: List[str]):
+    def _validate_schema_defaults(s: Schema, acc: List[str]) -> None:
         _acc = [*acc, _validation_crumb(s)]
 
         if "default" in s.props:

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -2165,7 +2165,7 @@ async def test_full_transitive_failure(registry_async_client: Client, compatibil
                     }]
                 }
             ],
-            "default": "null"
+            "default": None,
         }]
     }
     evolved = {
@@ -2188,7 +2188,7 @@ async def test_full_transitive_failure(registry_async_client: Client, compatibil
                     }]
                 }
             ],
-            "default": "null"
+            "default": None,
         }]
     }
     await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})

--- a/tests/unit/test_avro_schema.py
+++ b/tests/unit/test_avro_schema.py
@@ -33,13 +33,35 @@ schema8 = parse_avro_schema_definition(
     '{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string",'
     '"name":"f2","default":"foo"}]},{"type":"string","name":"f3","default":"bar"}]}'
 )
-badDefaultNullString = parse_avro_schema_definition(
-    '{"type":"record","name":"myrecord","fields":[{"type":["null","string"],"name":"f1","default":'
-    '"null"},{"type":"string","name":"f2","default":"foo"},{"type":"string","name":"f3","default":"bar"}]}'
-)
 
 
-def test_schemaregistry_schema_validation():
+def test_schemaregistry_schema_validation() -> None:
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(
+            json.dumps({
+                "type": "record",
+                "name": "x",
+                "fields": [{
+                    "name": "y",
+                    "type": ["null", "int"],
+                    "default": 1,
+                }]
+            })
+        )
+
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(
+            json.dumps({
+                "type": "record",
+                "name": "x",
+                "fields": [{
+                    "name": "y",
+                    "type": [],
+                    "default": 1,
+                }]
+            })
+        )
+
     with pytest.raises(ValidateSchemaDefaultsException):
         parse_avro_schema_definition(
             json.dumps({

--- a/tests/unit/test_avro_schema.py
+++ b/tests/unit/test_avro_schema.py
@@ -4,7 +4,8 @@
 """
 from avro.schema import ArraySchema, Field, MapSchema, RecordSchema, Schema, UnionSchema
 from karapace.avro_compatibility import (
-    parse_avro_schema_definition, ReaderWriterCompatibilityChecker, SchemaCompatibilityResult, SchemaCompatibilityType
+    parse_avro_schema_definition, ReaderWriterCompatibilityChecker, SchemaCompatibilityResult, SchemaCompatibilityType,
+    ValidateSchemaDefaultsException
 )
 
 import json
@@ -36,6 +37,135 @@ badDefaultNullString = parse_avro_schema_definition(
     '{"type":"record","name":"myrecord","fields":[{"type":["null","string"],"name":"f1","default":'
     '"null"},{"type":"string","name":"f2","default":"foo"},{"type":"string","name":"f3","default":"bar"}]}'
 )
+
+
+def test_schemaregistry_schema_validation():
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(
+            json.dumps({
+                "type": "record",
+                "name": "x",
+                "fields": [{
+                    "name": "y",
+                    "type": {
+                        "name": "z",
+                        "type": "enum",
+                        "symbols": ["A"],
+                        "default": "B"
+                    }
+                }]
+            })
+        )
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(
+            json.dumps({
+                "type": "record",
+                "name": "x",
+                "fields": [{
+                    "name": "y",
+                    "type": {
+                        "name": "z",
+                        "type": "enum",
+                        "symbols": ["A"]
+                    },
+                    "default": "B"
+                }]
+            })
+        )
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(
+            json.dumps({
+                "type": "record",
+                "name": "x",
+                "fields": [{
+                    "name": "y",
+                    "type": {
+                        "name": "z",
+                        "type": "enum",
+                        "symbols": ["A"],
+                        "default": "A"
+                    },
+                    "default": "B"
+                }]
+            })
+        )
+
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(
+            json.dumps({
+                "type": "record",
+                "name": "x",
+                "fields": [{
+                    "name": "y",
+                    "type": "string",
+                    "default": 1
+                }]
+            })
+        )
+
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(
+            json.dumps({
+                "type": "record",
+                "name": "x",
+                "fields": [{
+                    "name": "y",
+                    "type": "int",
+                    "default": "z"
+                }]
+            })
+        )
+
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(json.dumps({"type": "enum", "name": "x", "symbols": ["A", "B"], "default": "C"}))
+
+    parse_avro_schema_definition(
+        json.dumps({
+            "type": "record",
+            "name": "x",
+            "fields": [{
+                "name": "y",
+                "type": "string",
+                "default": "z"
+            }]
+        })
+    )
+
+    with pytest.raises(ValidateSchemaDefaultsException):
+        parse_avro_schema_definition(
+            json.dumps({
+                "type": "record",
+                "name": "x",
+                "fields": [{
+                    "name": "y",
+                    "type": ["int", "string", "boolean"],
+                    "default": None,
+                }]
+            })
+        )
+
+    parse_avro_schema_definition(
+        json.dumps({
+            "type": "record",
+            "name": "order",
+            "namespace": "example",
+            "fields": [{
+                "name": "someField",
+                "type": [
+                    "string", {
+                        "type": "record",
+                        "name": "someEmbeddedRecord",
+                        "namespace": "example",
+                        "fields": [{
+                            "name": "name",
+                            "type": "string"
+                        }]
+                    }
+                ],
+                "default": "none",
+            }]
+        })
+    )
 
 
 def test_schemaregistry_basic_backwards_compatibility():


### PR DESCRIPTION
# About this change - What it does

This PR validates default values in avro schemas as postprocessing after parsing the schema.
