### PR TITLE
Improved error message for the addition of a property to an open model

### DIFF
--- a/karapace/avro_compatibility.py
+++ b/karapace/avro_compatibility.py
@@ -215,7 +215,7 @@ class ReaderWriter:
     def __hash__(self) -> int:
         return id(self.reader) ^ id(self.writer)
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, ReaderWriter):
             return False
         return self.reader is other.reader and self.writer is other.writer
@@ -224,7 +224,7 @@ class ReaderWriter:
 class ReaderWriterCompatibilityChecker:
     ROOT_REFERENCE_TOKEN = "/"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.memoize_map: Dict[ReaderWriter, SchemaCompatibilityResult] = {}
 
     def get_compatibility(

--- a/karapace/avro_compatibility.py
+++ b/karapace/avro_compatibility.py
@@ -1,5 +1,5 @@
-from avro.io import Validate
-from avro.schema import (
+from avro.io import Validate  # type: ignore
+from avro.schema import (  # type: ignore
     ARRAY, ArraySchema, BOOLEAN, BYTES, DOUBLE, ENUM, EnumSchema, Field, FIXED, FixedSchema, FLOAT, INT, LONG, MAP,
     MapSchema, NamedSchema, Names, NULL, RECORD, RecordSchema, Schema, SchemaFromJSONData, STRING, UNION, UnionSchema
 )

--- a/karapace/compatibility/__init__.py
+++ b/karapace/compatibility/__init__.py
@@ -4,6 +4,7 @@ karapace - schema compatibility checking
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from avro.schema import Schema as AvroSchema
 from enum import Enum, unique
 from jsonschema import Draft7Validator
 from karapace.avro_compatibility import (
@@ -47,7 +48,7 @@ class CompatibilityModes(Enum):
         return self.value in TRANSITIVE_MODES
 
 
-def check_avro_compatibility(reader_schema, writer_schema) -> SchemaCompatibilityResult:
+def check_avro_compatibility(reader_schema: AvroSchema, writer_schema: AvroSchema) -> SchemaCompatibilityResult:
     result = AvroChecker().get_compatibility(reader=reader_schema, writer=writer_schema)
     if (
         result.compatibility is SchemaCompatibilityType.incompatible

--- a/karapace/compatibility/__init__.py
+++ b/karapace/compatibility/__init__.py
@@ -4,9 +4,9 @@ karapace - schema compatibility checking
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
-from avro.schema import Schema as AvroSchema
+from avro.schema import Schema as AvroSchema  # type: ignore
 from enum import Enum, unique
-from jsonschema import Draft7Validator
+from jsonschema import Draft7Validator  # type: ignore
 from karapace.avro_compatibility import (
     ReaderWriterCompatibilityChecker as AvroChecker, SchemaCompatibilityResult, SchemaCompatibilityType,
     SchemaIncompatibilityType

--- a/karapace/compatibility/jsonschema/checks.py
+++ b/karapace/compatibility/jsonschema/checks.py
@@ -595,9 +595,11 @@ def compatibility_object(reader_schema, writer_schema, location: List[str]) -> S
         if is_writer_open_model:
             properties = ', '.join(properties_unknown_to_writer)
             message_property_added_to_open_content_model = (
-                f"Restricting properties is an incompatible change because "
-                f"previously valid values may become invalid. Properties with new "
-                f"validation: {properties}."
+                f"Restricting acceptable values of properties is an incompatible "
+                f"change. The following properties {properties} accepted any "
+                f"value because of the lack of validation (the object schema had "
+                f"neither patternProperties nor additionalProperties), now "
+                f"these values are restricted."
             )
             result.add_incompatibility(
                 incompat_type=Incompatibility.property_added_to_open_content_model,

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,3 +15,14 @@ warn_unused_ignores = True
 warn_no_return = True
 warn_unreachable = True
 strict_equality = True
+
+[mypy-karapace.compatibility]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_no_return = True
+warn_unreachable = True
+strict_equality = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,17 @@
+[mypy]
+python_version = 3.7
+warn_redundant_casts = True
+
+[mypy-karapace.*]
+ignore_errors = True
+
+[mypy-karapace.avro_compatibility]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_no_return = True
+warn_unreachable = True
+strict_equality = True


### PR DESCRIPTION
This tries to make the error message a bit more informative, users may be unaware that the lack of a property in a schema means that any value is acceptable.

I also sneaked a mypy config in there, just to get that rolling.