### PR TITLE
fix compatibility with aiohttp >= 3.8.0 and aiokafka >= 0.7.0

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -45,7 +45,6 @@ class KafkaRest(KarapaceBase):
     def _init_kafka_rest(self, config: dict) -> None:
         self.serializer = SchemaRegistrySerializer(config=config)
         self.log = logging.getLogger("KarapaceRest")
-        self.loop = asyncio.get_event_loop()
         self._cluster_metadata = None
         self._metadata_birth = None
         self.metadata_max_age = self.config["admin_metadata_max_age"]
@@ -183,7 +182,6 @@ class KafkaRest(KarapaceBase):
                     security_protocol=self.config["security_protocol"],
                     ssl_context=None if self.config["security_protocol"] == "PLAINTEXT" else create_ssl_context(self.config),
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
-                    loop=self.loop,
                     acks=acks,
                     compression_type=self.config["producer_compression_type"],
                     linger_ms=self.config["producer_linger_ms"],
@@ -592,9 +590,7 @@ class KafkaRest(KarapaceBase):
         try:
             prod = await self.get_producer()
             result = await asyncio.wait_for(
-                fut=prod.send_and_wait(topic, key=key, value=value, partition=partition),
-                loop=self.loop,
-                timeout=self.kafka_timeout
+                fut=prod.send_and_wait(topic, key=key, value=value, partition=partition), timeout=self.kafka_timeout
             )
             return {
                 "offset": result.offset if result else -1,

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -6,7 +6,6 @@ from karapace.utils import Client, json_encode
 from typing import Any, Dict, Optional
 from urllib.parse import quote
 
-import aiohttp
 import asyncio
 import avro
 import avro.schema
@@ -69,7 +68,7 @@ NAME_STRATEGIES = {
 
 class SchemaRegistryClient:
     def __init__(self, schema_registry_url: str = "http://localhost:8081"):
-        self.client = Client(server_uri=schema_registry_url, client=aiohttp.ClientSession())
+        self.client = Client(server_uri=schema_registry_url)
         self.base_url = schema_registry_url
 
     async def post_new_schema(self, subject: str, schema: TypedSchema) -> int:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -224,7 +224,7 @@ async def fixture_rest_async_client(
         client_factory = await aiohttp_client(rest_async.app)
         client = Client(client=client_factory)
 
-    with closing(client):
+    try:
         # wait until the server is listening, otherwise the tests may fail
         await repeat_until_successful_request(
             client.get,
@@ -236,6 +236,8 @@ async def fixture_rest_async_client(
             sleep=0.3,
         )
         yield client
+    finally:
+        await client.close()
 
 
 @pytest.fixture(scope="function", name="registry_async_pair")
@@ -331,7 +333,7 @@ async def fixture_registry_async_client(
         client_factory = await aiohttp_client(registry_async.app)
         client = Client(client=client_factory)
 
-    with closing(client):
+    try:
         # wait until the server is listening, otherwise the tests may fail
         await repeat_until_successful_request(
             client.get,
@@ -343,6 +345,8 @@ async def fixture_registry_async_client(
             sleep=0.3,
         )
         yield client
+    finally:
+        await client.close()
 
 
 def zk_java_args(cfg_path: Path) -> List[str]:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -221,8 +221,11 @@ async def fixture_rest_async_client(
     if rest_url:
         client = Client(server_uri=rest_url)
     else:
-        client_factory = await aiohttp_client(rest_async.app)
-        client = Client(client=client_factory)
+
+        async def get_client():
+            return await aiohttp_client(rest_async.app)
+
+        client = Client(client_factory=get_client)
 
     try:
         # wait until the server is listening, otherwise the tests may fail
@@ -330,8 +333,11 @@ async def fixture_registry_async_client(
     if registry_url:
         client = Client(server_uri=registry_url)
     else:
-        client_factory = await aiohttp_client(registry_async.app)
-        client = Client(client=client_factory)
+
+        async def get_client():
+            return await aiohttp_client(registry_async.app)
+
+        client = Client(client_factory=get_client)
 
     try:
         # wait until the server is listening, otherwise the tests may fail


### PR DESCRIPTION
# About this change - What it does
Fix compatibility with aiohttp >= 3.8.0 and aiokafka >= 0.7.0

# Why this way
## aiokafka
Removed the loop parameter and let python use its default behavior.

## aiohttp
Deferred the creation of the client to the first async function that needs it.
This might be a problematic approach if `utils.Client` is a public API and
can't have its `client` parameter removed.

SchemaRegistryClient didn't need to force the `client` value since it was
equivalent to the default.

While the `aiohttp.ClientSession` doesn't require the factory function
to be async, the `aiohttp_client` used during tests needed it.
