### PR TITLE
karapace/rapu: handle HTTPRequestEntityTooLarge in rapu

### DIFF
--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -15,6 +15,7 @@ from typing import Dict, NoReturn, Optional, overload, Union
 
 import aiohttp
 import aiohttp.web
+import aiohttp.web_exceptions
 import aiohttp_socks
 import async_timeout
 import asyncio
@@ -354,6 +355,16 @@ class RestApp:
                 resp = aiohttp.web.Response(text=ex.body, status=ex.status.value, headers=ex.headers)
             else:
                 resp = aiohttp.web.Response(body=ex.body, status=ex.status.value, headers=ex.headers)
+        except aiohttp.web_exceptions.HTTPRequestEntityTooLarge:
+            # This exception is not our usual http response, so to keep a consistent error interface
+            # we construct http response manually here
+            status = HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+            body = json_encode({
+                "error_code": status,
+                "message": "HTTP Request Entity Too Large",
+            }, binary=True)
+            headers = {"Content-Type": "application/json"}
+            resp = aiohttp.web.Response(body=body, status=status.value, headers=headers)
         except asyncio.CancelledError:
             self.log.debug("Client closed connection")
             raise

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -20,6 +20,14 @@ def check_successful_publish_response(success_response, objects, partition_id=No
                 assert partition_id == o["partition"]
 
 
+async def test_request_body_too_large(rest_async_client, admin_client):
+    tn = new_topic(admin_client)
+    await wait_for_topics(rest_async_client, topic_names=[tn], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+    pl = {"records": [{"value": 1_048_576 * "a"}]}
+    res = await rest_async_client.post(f'/topics/{tn}', pl, headers={"Content-Type": "application/json"})
+    assert res.status_code == 413
+
+
 async def test_content_types(rest_async_client, admin_client):
     tn = new_topic(admin_client)
     await wait_for_topics(rest_async_client, topic_names=[tn], timeout=NEW_TOPIC_TIMEOUT, sleep=1)


### PR DESCRIPTION
This error is expected and should be a client error instead of 500.

If the client POSTs a request body that is too large, we catch the internal aiohttp and wrap it into a client facing user error response instead of returning a internal server error response.