### PR TITLE
Add Open Source team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @aiven/team-helpful-husky
+*   @aiven/team-helpful-husky @aiven/aiven-open-source


### PR DESCRIPTION
Add the Open Source team so they can get notified when a new PR is sent

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
This change is to help in reducing time to respond for PRs

<!-- Provide the issue number below if it exists. -->


# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
This is the way to do it according to GitHub
