### PR TITLE
Revert release global ids

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -195,9 +195,11 @@ class KafkaSchemaReader(Thread):
 
     def get_schema_id(self, new_schema: TypedSchema) -> int:
         with self.id_lock:
-            for schema_id, schema in self.schemas.items():
-                if schema == new_schema:
-                    return schema_id
+            schemas = self.schemas.items()
+        for schema_id, schema in schemas:
+            if schema == new_schema:
+                return schema_id
+        with self.id_lock:
             self.global_schema_id += 1
             return self.global_schema_id
 
@@ -341,15 +343,13 @@ class KafkaSchemaReader(Thread):
                 }
             }
             self.log.info("Setting schema_id: %r with schema: %r", schema_id, typed_schema)
-            with self.id_lock:
-                self.schemas[schema_id] = typed_schema
-                self.global_schema_id = max(self.global_schema_id, schema_id)
+            self.schemas[schema_id] = typed_schema
+            if schema_id > self.global_schema_id:  # Not an existing schema
+                self.global_schema_id = schema_id
         elif schema_deleted is True:
             self.log.info("Deleting subject: %r, version: %r", schema_subject, schema_version)
             if schema_version not in self.subjects[schema_subject]["schemas"]:
-                with self.id_lock:
-                    self.schemas[schema_id] = typed_schema
-                    self.global_schema_id = max(self.global_schema_id, schema_id)
+                self.schemas[schema_id] = typed_schema
             else:
                 self.subjects[schema_subject]["schemas"][schema_version]["deleted"] = True
         elif schema_deleted is False:
@@ -363,7 +363,8 @@ class KafkaSchemaReader(Thread):
             self.log.info("Setting schema_id: %r with schema: %r", schema_id, schema_str)
             with self.id_lock:
                 self.schemas[schema_id] = typed_schema
-                self.global_schema_id = max(self.global_schema_id, schema_id)
+            if schema_id > self.global_schema_id:  # Not an existing schema
+                self.global_schema_id = schema_id
 
     def handle_msg(self, key: dict, value: Optional[dict]) -> None:
         if key["keytype"] == "CONFIG":

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -303,74 +303,70 @@ class KafkaSchemaReader(Thread):
             }
             self.subjects[value["subject"]]["schemas"] = updated_schemas
 
-    def _handle_msg_schema(self, key: dict, value: Optional[dict]) -> None:
-        if not value:
-            subject, version = key["subject"], key["version"]
-            self.log.info("Deleting subject: %r version: %r completely", subject, version)
-            if subject not in self.subjects:
-                self.log.error("Subject %s did not exist, should have", subject)
-            elif version not in self.subjects[subject]["schemas"]:
-                self.log.error("Version %d for subject %s did not exist, should have", version, subject)
-            else:
-                self.subjects[subject]["schemas"].pop(version, None)
-            return
-        schema_type = value.get("schemaType", "AVRO")
-        schema_str = value["schema"]
-        schema_subject = value["subject"]
-        schema_id = value["id"]
-        schema_version = value["version"]
-        schema_deleted = value.get("deleted", False)
-        try:
-            typed_schema = TypedSchema.parse(schema_type=SchemaType(schema_type), schema_str=schema_str)
-        except InvalidSchema:
-            try:
-                schema_json = json.loads(schema_str)
-                typed_schema = TypedSchema(schema_type=SchemaType(schema_type), schema=schema_json, schema_str=schema_str)
-            except JSONDecodeError:
-                self.log.error("Invalid json: %s", schema_str)
-                return
-        self.log.debug("Got typed schema %r", typed_schema)
-        if schema_subject not in self.subjects:
-            self.log.info("Adding first version of subject: %r, value: %r", schema_subject, value)
-            self.subjects[schema_subject] = {
-                "schemas": {
-                    schema_version: {
-                        "schema": typed_schema,
-                        "version": schema_version,
-                        "id": schema_id,
-                        "deleted": schema_deleted,
-                    }
-                }
-            }
-            self.log.info("Setting schema_id: %r with schema: %r", schema_id, typed_schema)
-            self.schemas[schema_id] = typed_schema
-            if schema_id > self.global_schema_id:  # Not an existing schema
-                self.global_schema_id = schema_id
-        elif schema_deleted is True:
-            self.log.info("Deleting subject: %r, version: %r", schema_subject, schema_version)
-            if schema_version not in self.subjects[schema_subject]["schemas"]:
-                self.schemas[schema_id] = typed_schema
-            else:
-                self.subjects[schema_subject]["schemas"][schema_version]["deleted"] = True
-        elif schema_deleted is False:
-            self.log.info("Adding new version of subject: %r, value: %r", schema_subject, value)
-            self.subjects[schema_subject]["schemas"][schema_version] = {
-                "schema": typed_schema,
-                "version": schema_version,
-                "id": schema_id,
-                "deleted": schema_deleted,
-            }
-            self.log.info("Setting schema_id: %r with schema: %r", schema_id, schema_str)
-            with self.id_lock:
-                self.schemas[schema_id] = typed_schema
-            if schema_id > self.global_schema_id:  # Not an existing schema
-                self.global_schema_id = schema_id
-
     def handle_msg(self, key: dict, value: Optional[dict]) -> None:
         if key["keytype"] == "CONFIG":
             self._handle_msg_config(key, value)
         elif key["keytype"] == "SCHEMA":
-            self._handle_msg_schema(key, value)
+            if not value:
+                subject, version = key["subject"], key["version"]
+                self.log.info("Deleting subject: %r version: %r completely", subject, version)
+                if subject not in self.subjects:
+                    self.log.error("Subject %s did not exist, should have", subject)
+                elif version not in self.subjects[subject]["schemas"]:
+                    self.log.error("Version %d for subject %s did not exist, should have", version, subject)
+                else:
+                    self.subjects[subject]["schemas"].pop(version, None)
+                return
+            schema_type = value.get("schemaType", "AVRO")
+            schema_str = value["schema"]
+            try:
+                typed_schema = TypedSchema.parse(schema_type=SchemaType(schema_type), schema_str=schema_str)
+            except InvalidSchema:
+                try:
+                    schema_json = json.loads(schema_str)
+                    typed_schema = TypedSchema(
+                        schema_type=SchemaType(schema_type), schema=schema_json, schema_str=schema_str
+                    )
+                except JSONDecodeError:
+                    self.log.error("Invalid json: %s", value["schema"])
+                    return
+            self.log.debug("Got typed schema %r", typed_schema)
+            subject = value["subject"]
+            if subject not in self.subjects:
+                self.log.info("Adding first version of subject: %r, value: %r", subject, value)
+                self.subjects[subject] = {
+                    "schemas": {
+                        value["version"]: {
+                            "schema": typed_schema,
+                            "version": value["version"],
+                            "id": value["id"],
+                            "deleted": value.get("deleted", False),
+                        }
+                    }
+                }
+                self.log.info("Setting schema_id: %r with schema: %r", value["id"], typed_schema)
+                self.schemas[value["id"]] = typed_schema
+                if value["id"] > self.global_schema_id:  # Not an existing schema
+                    self.global_schema_id = value["id"]
+            elif value.get("deleted", False) is True:
+                self.log.info("Deleting subject: %r, version: %r", subject, value["version"])
+                if not value["version"] in self.subjects[subject]["schemas"]:
+                    self.schemas[value["id"]] = typed_schema
+                else:
+                    self.subjects[subject]["schemas"][value["version"]]["deleted"] = True
+            elif value.get("deleted", False) is False:
+                self.log.info("Adding new version of subject: %r, value: %r", subject, value)
+                self.subjects[subject]["schemas"][value["version"]] = {
+                    "schema": typed_schema,
+                    "version": value["version"],
+                    "id": value["id"],
+                    "deleted": value.get("deleted", False),
+                }
+                self.log.info("Setting schema_id: %r with schema: %r", value["id"], value["schema"])
+                with self.id_lock:
+                    self.schemas[value["id"]] = typed_schema
+                if value["id"] > self.global_schema_id:  # Not an existing schema
+                    self.global_schema_id = value["id"]
         elif key["keytype"] == "DELETE_SUBJECT":
             self._handle_msg_delete_subject(key, value)
         elif key["keytype"] == "NOOP":  # for spec completeness

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -301,22 +301,17 @@ class KafkaSchemaReader(Thread):
             }
             self.subjects[value["subject"]]["schemas"] = updated_schemas
 
-    def _handle_msg_schema_hard_delete(self, key: dict) -> None:
-        subject, version = key["subject"], key["version"]
-
-        if subject not in self.subjects:
-            self.log.error("Hard delete: Subject %s did not exist, should have", subject)
-        elif version not in self.subjects[subject]["schemas"]:
-            self.log.error("Hard delete: Version %d for subject %s did not exist, should have", version, subject)
-        else:
-            self.log.info("Hard delete: subject: %r version: %r", subject, version)
-            self.subjects[subject]["schemas"].pop(version, None)
-
     def _handle_msg_schema(self, key: dict, value: Optional[dict]) -> None:
         if not value:
-            self._handle_msg_schema_hard_delete(key)
+            subject, version = key["subject"], key["version"]
+            self.log.info("Deleting subject: %r version: %r completely", subject, version)
+            if subject not in self.subjects:
+                self.log.error("Subject %s did not exist, should have", subject)
+            elif version not in self.subjects[subject]["schemas"]:
+                self.log.error("Version %d for subject %s did not exist, should have", version, subject)
+            else:
+                self.subjects[subject]["schemas"].pop(version, None)
             return
-
         schema_type = value.get("schemaType", "AVRO")
         schema_str = value["schema"]
         schema_subject = value["subject"]
@@ -350,7 +345,7 @@ class KafkaSchemaReader(Thread):
                 self.schemas[schema_id] = typed_schema
                 self.global_schema_id = max(self.global_schema_id, schema_id)
         elif schema_deleted is True:
-            self.log.info("Soft delete: subject: %r, version: %r", schema_subject, schema_version)
+            self.log.info("Deleting subject: %r, version: %r", schema_subject, schema_version)
             if schema_version not in self.subjects[schema_subject]["schemas"]:
                 with self.id_lock:
                     self.schemas[schema_id] = typed_schema

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -19,7 +19,6 @@ from karapace.utils import json_encode, KarapaceKafkaClient
 from queue import Queue
 from threading import Lock, Thread
 from typing import Dict, Optional
-from weakref import WeakValueDictionary
 
 import json
 import logging
@@ -105,6 +104,7 @@ class KafkaSchemaReader(Thread):
         self.timeout_ms = 200
         self.config = config
         self.subjects = {}
+        self.schemas: Dict[int, TypedSchema] = {}
         self.global_schema_id = 0
         self.offset = 0
         self.admin_client = None
@@ -119,11 +119,6 @@ class KafkaSchemaReader(Thread):
         if "tags" not in sentry_config:
             sentry_config["tags"] = {}
         self.stats = StatsClient(sentry_config=sentry_config)
-
-        # A schema has the same `id` even if registered in two different subjects. This container
-        # has a weak reference to every schema in use, used to retrieve its `id`. Weak references
-        # are used to allow for free memory when a schema is cleared from all subjects.
-        self.schemas: Dict[int, TypedSchema] = WeakValueDictionary()
 
     def init_consumer(self) -> None:
         # Group not set on purpose, all consumers read the same data

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -270,26 +270,24 @@ class KafkaSchemaReader(Thread):
                 if self.ready and add_offsets:
                     self.queue.put(self.offset)
 
-    def _handle_msg_config(self, key: dict, value: Optional[dict]) -> None:
-        subject = key.get("subject")
-        if subject is not None:
-            if subject not in self.subjects:
-                self.log.info("Adding first version of subject: %r with no schemas", subject)
-                self.subjects[subject] = {"schemas": {}}
-
-            if not value:
-                self.log.info("Deleting compatibility config completely for subject: %r", subject)
-                self.subjects[subject].pop("compatibility", None)
-            else:
-                self.log.info("Setting subject: %r config to: %r, value: %r", subject, value["compatibilityLevel"], value)
-                self.subjects[subject]["compatibility"] = value["compatibilityLevel"]
-        elif value is not None:
-            self.log.info("Setting global config to: %r, value: %r", value["compatibilityLevel"], value)
-            self.config["compatibility"] = value["compatibilityLevel"]
-
     def handle_msg(self, key: dict, value: Optional[dict]) -> None:
-        if key["keytype"] == "CONFIG":
-            self._handle_msg_config(key, value)
+        if key["keytype"] == "CONFIG" and value:
+            if "subject" in key and key["subject"] is not None:
+                if not value:
+                    self.log.info("Deleting compatibility config completely for subject: %r", key["subject"])
+                    self.subjects[key["subject"]].pop("compatibility", None)
+                    return
+                self.log.info(
+                    "Setting subject: %r config to: %r, value: %r", key["subject"], value["compatibilityLevel"], value
+                )
+                if not key["subject"] in self.subjects:
+                    self.log.info("Adding first version of subject: %r with no schemas", key["subject"])
+                    self.subjects[key["subject"]] = {"schemas": {}}
+                subject_data = self.subjects.get(key["subject"])
+                subject_data["compatibility"] = value["compatibilityLevel"]
+            else:
+                self.log.info("Setting global config to: %r, value: %r", value["compatibilityLevel"], value)
+                self.config["compatibility"] = value["compatibilityLevel"]
         elif key["keytype"] == "SCHEMA":
             if not value:
                 subject, version = key["subject"], key["version"]

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -332,27 +332,43 @@ class KafkaSchemaReader(Thread):
             except JSONDecodeError:
                 self.log.error("Invalid json: %s", schema_str)
                 return
-
+        self.log.debug("Got typed schema %r", typed_schema)
         if schema_subject not in self.subjects:
-            self.log.info("Adding first version of subject: %r with no schemas", schema_subject)
-            self.subjects[schema_subject] = {"schemas": {}}
-
-        subjects_schemas = self.subjects[schema_subject]["schemas"]
-
-        if schema_version in subjects_schemas:
-            self.log.info("Updating entry for subject: %r, value: %r", schema_subject, value)
-        else:
+            self.log.info("Adding first version of subject: %r, value: %r", schema_subject, value)
+            self.subjects[schema_subject] = {
+                "schemas": {
+                    schema_version: {
+                        "schema": typed_schema,
+                        "version": schema_version,
+                        "id": schema_id,
+                        "deleted": schema_deleted,
+                    }
+                }
+            }
+            self.log.info("Setting schema_id: %r with schema: %r", schema_id, typed_schema)
+            with self.id_lock:
+                self.schemas[schema_id] = typed_schema
+                self.global_schema_id = max(self.global_schema_id, schema_id)
+        elif schema_deleted is True:
+            self.log.info("Soft delete: subject: %r, version: %r", schema_subject, schema_version)
+            if schema_version not in self.subjects[schema_subject]["schemas"]:
+                with self.id_lock:
+                    self.schemas[schema_id] = typed_schema
+                    self.global_schema_id = max(self.global_schema_id, schema_id)
+            else:
+                self.subjects[schema_subject]["schemas"][schema_version]["deleted"] = True
+        elif schema_deleted is False:
             self.log.info("Adding new version of subject: %r, value: %r", schema_subject, value)
-
-        subjects_schemas[schema_version] = {
-            "schema": typed_schema,
-            "version": schema_version,
-            "id": schema_id,
-            "deleted": schema_deleted,
-        }
-        with self.id_lock:
-            self.schemas[schema_id] = typed_schema
-            self.global_schema_id = max(self.global_schema_id, schema_id)
+            self.subjects[schema_subject]["schemas"][schema_version] = {
+                "schema": typed_schema,
+                "version": schema_version,
+                "id": schema_id,
+                "deleted": schema_deleted,
+            }
+            self.log.info("Setting schema_id: %r with schema: %r", schema_id, schema_str)
+            with self.id_lock:
+                self.schemas[schema_id] = typed_schema
+                self.global_schema_id = max(self.global_schema_id, schema_id)
 
     def handle_msg(self, key: dict, value: Optional[dict]) -> None:
         if key["keytype"] == "CONFIG":

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -2374,9 +2374,9 @@ async def test_schema_hard_delete_whole_schema(registry_async_client: Client) ->
     assert res.json()["message"] == f"Subject '{subject}' not found."
 
 
-async def test_schema_soft_delete_and_recreate(registry_async_client: Client) -> None:
-    subject = create_subject_name_factory("test_schema_soft_delete_and_recreate")()
-    schema_name = create_schema_name_factory("test_schema_soft_delete_and_recreate")()
+async def test_schema_hard_delete_and_recreate(registry_async_client: Client) -> None:
+    subject = create_subject_name_factory("test_schema_hard_delete_and_recreate")()
+    schema_name = create_schema_name_factory("test_schema_hard_delete_and_recreate")()
 
     res = await registry_async_client.put("config", json={"compatibility": "BACKWARD"})
     assert res.status == 200
@@ -2413,35 +2413,10 @@ async def test_schema_soft_delete_and_recreate(registry_async_client: Client) ->
     assert "id" in res.json()
     assert schema_id == res.json()["id"], "after soft delete the same schema registered, the same identifier"
 
-
-async def test_schema_hard_delete_and_recreate(registry_async_client: Client) -> None:
-    subject_factory = create_subject_name_factory("test_schema_hard_delete_and_recreate")
-    subject = subject_factory()
-    schema_name = create_schema_name_factory("test_schema_hard_delete_and_recreate")()
-
-    res = await registry_async_client.put("config", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
-    schema = {
-        "type": "record",
-        "name": schema_name,
-        "fields": [{
-            "type": {
-                "type": "enum",
-                "name": "enumtest",
-                "symbols": ["first", "second"],
-            },
-            "name": "faa",
-        }]
-    }
-    res = await registry_async_client.post(
-        f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema)},
-    )
-    assert res.status == 200
-    first_schema_id = res.json()["id"]
-
+    # Soft delete whole schema
     res = await registry_async_client.delete(f"subjects/{subject}")
     assert res.status_code == 200
+    # Hard delete whole schema
     res = await registry_async_client.delete(f"subjects/{subject}?permanent=true")
     assert res.status_code == 200
 
@@ -2450,38 +2425,14 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
     assert res.json()["error_code"] == 40401
     assert res.json()["message"] == f"Subject '{subject}' not found."
 
-    # Recreate after hard delete on all subjects frees the schema, and a new id is used
+    # Recreate with same subject after hard delete
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
         json={"schema": jsonlib.dumps(schema)},
     )
     assert res.status == 200
-    msg = "permanent deleted of the schema on all subjects causes a new identifier to be used"
-    second_schema_id = res.json()["id"]
-    assert first_schema_id != second_schema_id, msg
-
-    # Register the same schema in another subject, this time the schema should not be freed
-    subject_keepalive = subject_factory()
-    res = await registry_async_client.post(
-        f"subjects/{subject_keepalive}/versions",
-        json={"schema": jsonlib.dumps(schema)},
-    )
-    assert res.status == 200
-    assert second_schema_id == res.json()["id"]
-
-    res = await registry_async_client.delete(f"subjects/{subject}")
-    assert res.status_code == 200
-
-    res = await registry_async_client.delete(f"subjects/{subject}?permanent=true")
-    assert res.status_code == 200
-
-    res = await registry_async_client.post(
-        f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema)},
-    )
-    assert res.status == 200
-    msg = "the identifier does not change when the schema is permanent deleted in only one of the subjects"
-    assert second_schema_id == res.json()["id"], msg
+    assert "id" in res.json()
+    assert schema_id == res.json()["id"], "after permanent deleted the same schema registered, the same identifier"
 
 
 async def test_invalid_schema_should_provide_good_error_messages(registry_async_client: Client) -> None:


### PR DESCRIPTION
This reverts PR #284 , That was introduced to fix a memory leak, however, it breaks _schemas topics with corrupted data. For now reverting the commit, later the new behavior may be introduced under a flag.