### PR TITLE
Fix REST and schema registry shutdown

### DIFF
--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -39,6 +39,11 @@ class KarapaceBase(RestApp):
         self.app.on_startup.append(self.create_http_client)
         self.master_lock = asyncio.Lock()
         self.log.info("Karapace initialized")
+        self.app.on_shutdown.append(self.close_by_app)
+
+    async def close_by_app(self, app):
+        # pylint: disable=unused-argument
+        await self.close()
 
     def _create_producer(self) -> KafkaProducer:
         while True:

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -43,7 +43,8 @@ def main() -> int:
         print("Both rest and registry options are disabled, exiting")
         return 1
 
-    print("=" * 100 + f"\nStarting {info_str}\n" + "=" * 100)
+    info_str_separator = "=" * 100
+    logging.log(logging.INFO, "\n%s\nStarting %s\n%s", info_str_separator, info_str, info_str_separator)
 
     try:
         kc.run(host=kc.config["host"], port=kc.config["port"])

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -15,11 +15,6 @@ class KarapaceAll(KafkaRest, KarapaceSchemaRegistry):
     def __init__(self, config: dict) -> None:
         super().__init__(config=config)
         self.log = logging.getLogger("KarapaceAll")
-        self.app.on_shutdown.append(self.close_by_app)
-
-    async def close_by_app(self, app):
-        # pylint: disable=unused-argument
-        await self.close()
 
 
 def main() -> int:


### PR DESCRIPTION
Shutdown handler for aiohttp Application was set only for
KarapaceAll. On some environments where REST application and
schema registry application is run separately, e.g. containers,
the shutdown times out and container manager sends kill signal.

Fix is to move the shutdown handler registration from KarapaceAll
to KarapaceBase.
