### PR TITLE
Build container image in GitHub Action

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,57 @@
+name: Create and publish a container image
+
+on:
+  push:
+    # Publish main branch as `develop` image
+    branches:
+      - main
+      - master
+
+    # Publish tags as versioned release and `latest` image
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push container image
+        run: |
+          # Image name may contain only lowercase letters
+          IMAGE_ID=$(echo ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # If not tag, then use `develop` as image tag
+          [ "$VERSION" == main -o "$VERSION" == master ] && VERSION=develop
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker build . --file container/Dockerfile \
+              --build-arg "CREATED=$(date --rfc-3339=seconds)" \
+              --build-arg "VERSION=$(git describe --always)" \
+              --build-arg "COMMIT=$(git rev-parse -q --verify HEAD^{commit})" \
+              --tag $IMAGE_ID:$VERSION
+
+          docker push $IMAGE_ID:$VERSION
+
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]];
+          then
+            docker tag $IMAGE_ID:$VERSION $IMAGE_ID:latest
+            docker push $IMAGE_ID:latest
+          fi

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Setup
 Using Docker
 ------------
 
-To get you up and running with the latest release of Karapace, a docker setup is available::
+To get you up and running with the latest build of Karapace, a docker setup is available::
 
     docker-compose -f ./container/docker-compose.yml up -d
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,15 @@ Setup
 Using Docker
 ------------
 
-To get you up and running with the latest build of Karapace, a docker setup is available::
+To get you up and running with the latest build of Karapace, a docker image is available::
+
+  # Fetch the latest build from main branch
+  docker pull ghcr.io/aiven/karapace:develop
+
+  # Fetch the latest release
+  docker pull ghcr.io/aiven/karapace:latest
+
+An example setup including configuration and Kafka connection is available as docker-compose example::
 
     docker-compose -f ./container/docker-compose.yml up -d
 

--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
 
   karapace-registry:
-    image: aivenoy/karapace:latest
+    image: ghcr.io/aiven/karapace:develop
     entrypoint:
       - /bin/bash
       - /opt/karapace/start.sh
@@ -78,7 +78,7 @@ services:
       KARAPACE_COMPATIBILITY: FULL
 
   karapace-rest:
-    image: aivenoy/karapace:latest
+    image: ghcr.io/aiven/karapace:develop
     entrypoint:
       - /bin/bash
       - /opt/karapace/start.sh


### PR DESCRIPTION
# About this change - What it does

Build container image automatically from the main branch commits with `develop` tag and versioned container images from version tags, including `latest` tag pointing to most recent release.

This used GitHub Container Registry instead of Docker Hub.

# Why this way

Usage of GitHub Container Registry integrates better with tooling, and fetching container images from GHCR is as easy as Docker Hub.

Usage of `latest` tag from most recent release tag requires linear release strategy. If a need to maintain multiple branches arises, this needs some adjustments.

I've also tested building container images in my forked repository by using both main branch and arbitrary release tags there, see https://github.com/tvainika/karapace/pkgs/container/karapace