### PR TITLE
Simplified exception constructors

### DIFF
--- a/karapace/protobuf/exception.py
+++ b/karapace/protobuf/exception.py
@@ -6,9 +6,7 @@ class ProtobufParserRuntimeException(Exception):
 
 
 class IllegalStateException(Exception):
-    def __init__(self, message="IllegalStateException") -> None:
-        self.message = message
-        super().__init__(self.message)
+    pass
 
 
 class IllegalArgumentException(Exception):

--- a/karapace/protobuf/exception.py
+++ b/karapace/protobuf/exception.py
@@ -10,9 +10,7 @@ class IllegalStateException(Exception):
 
 
 class IllegalArgumentException(Exception):
-    def __init__(self, message="IllegalArgumentException") -> None:
-        self.message = message
-        super().__init__(self.message)
+    pass
 
 
 class Error(Exception):

--- a/karapace/protobuf/syntax_reader.py
+++ b/karapace/protobuf/syntax_reader.py
@@ -59,7 +59,7 @@ class SyntaxReader:
     def read_quoted_string(self) -> str:
         start_quote = self.read_char()
         if start_quote not in ('"', "'"):
-            raise IllegalStateException(" quote expected")
+            raise IllegalStateException("quote expected")
 
         result = []
 
@@ -205,7 +205,7 @@ class SyntaxReader:
     def read_comment(self) -> str:
         """ Reads a comment and returns its body. """
         if self.pos == len(self.data) or self.data[self.pos] != '/':
-            raise IllegalStateException()
+            raise IllegalStateException("comment expected")
 
         self.pos += 1
         tval = -1
@@ -360,5 +360,4 @@ class SyntaxReader:
     def unexpected(self, message: str, location: Location = None) -> NoReturn:
         if not location:
             location = self.location()
-        w = f"Syntax error in {str(location)}: {message}"
-        raise IllegalStateException(w)
+        raise IllegalStateException(f"Syntax error in {str(location)}: {message}")

--- a/tests/unit/test_proto_parser.py
+++ b/tests/unit/test_proto_parser.py
@@ -458,7 +458,7 @@ def test_invalid_trailing_comment():
 
         ProtoParser.parse(location, proto)
         pytest.fail("")
-    assert re.value.message == "Syntax error in file.proto:2:12: expected '//' or '/*'"
+    assert re.value.args[0] == "Syntax error in file.proto:2:12: expected '//' or '/*'"
 
 
 def test_enum_value_leading_and_trailing_comments_are_combined():
@@ -1463,7 +1463,7 @@ def test_invalid_hex_string_escape():
     with pytest.raises(IllegalStateException) as re:
         ProtoParser.parse(location, proto)
         pytest.fail("")
-    assert "expected a digit after \\x or \\X" in re.value.message
+    assert "expected a digit after \\x or \\X" in re.value.args[0]
 
 
 def test_service():


### PR DESCRIPTION
It seems the attribute `message` is not used anywhere. Changing the constructor signature to match the base class.