### PR TITLE
Update requests to 2.27.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp-socks==0.5.5
 aiokafka==0.7.2
 jsonschema==3.2.0
 lz4==3.0.2
-requests==2.23.0
+requests==2.27.1
 networkx==2.5
 python-dateutil==2.8.2
 protobuf~=3.14.0
@@ -27,13 +27,13 @@ async-timeout==4.0.2
 attrs==21.4.0
 certifi==2021.10.8
 chardet==3.0.4
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
 decorator==5.1.1
 frozenlist==1.3.0
-idna==2.10
+idna==3.3
 multidict==6.0.2
 pyrsistent==0.18.1
 python-socks==2.0.3
 six==1.16.0
-urllib3==1.25.11
+urllib3==1.26.8
 yarl==1.7.2


### PR DESCRIPTION
Avoids CVE-2021-33503 in urllib3 dependency.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
