### PR TITLE
git: added .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# This file collects all bulk commits, which should not appear when using `git blame`.
+# To configure git to ignore these commits during `git blame`, set:
+#
+# 	git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+
+# Applied black
+9b67a05b82d4e2e8016f333b53ec7b16b1cd1ffc


### PR DESCRIPTION
Add `.git-blame-ignore-revs` with the commit that formatted the code using black.