### PR TITLE
Add namespace patching if given Avro schema has invalid name for record type

### DIFF
--- a/tests/unit/test_avro_schema.py
+++ b/tests/unit/test_avro_schema.py
@@ -961,3 +961,37 @@ def are_compatible(reader: Schema, writer: Schema) -> bool:
         ReaderWriterCompatibilityChecker().get_compatibility(reader, writer).compatibility
         is SchemaCompatibilityType.compatible
     )
+
+
+def test_invalid_record_name_in_avro_schema_patching() -> None:
+    record_as_name_in_schema = parse_avro_schema_definition(
+        '{"type":"record","name":"record","fields":[{"name":"a1","type":"long"}]}}'
+    )
+    assert record_as_name_in_schema.to_json() == {
+        "type": "record",
+        "name": "record",
+        "namespace": "patched.name",
+        "fields": [{"name": "a1", "type": "long"}],
+        "doc": "Namespace was added to patch `record` to `patched.name.record`.",
+    }
+
+    record_as_name_in_schema_with_doc = parse_avro_schema_definition(
+        '{"type":"record","doc":"Documentation","name":"record","fields":[{"name":"a1","type":"long"}]}}'
+    )
+    assert record_as_name_in_schema_with_doc.to_json() == {
+        "type": "record",
+        "name": "record",
+        "namespace": "patched.name",
+        "fields": [{"name": "a1", "type": "long"}],
+        "doc": "Documentation\n\nNamespace was added to patch `record` to `patched.name.record`.",
+    }
+
+    record_as_name_in_schema_with_existing_namespace = parse_avro_schema_definition(
+        '{"type":"record","namespace":"karapace.io","name":"record","fields":[{"name":"a1","type":"long"}]}}'
+    )
+    assert record_as_name_in_schema_with_existing_namespace.to_json() == {
+        "type": "record",
+        "name": "record",
+        "namespace": "karapace.io",
+        "fields": [{"name": "a1", "type": "long"}],
+    }


### PR DESCRIPTION
Some generated Avro schemas have name `record` which is not allowed in
Python Avro parser. Patch this by adding a namespace to the root if it does not exist. This
creates enclosing namespace also for nested elements.

# Why this way
Java Avro parser accepts the `record` as a name. The specification only mentions that primitive types are not allowed to be used as name. Python Avro parser has stricter validation and rejects if `record` or any other complex type name is used.

As I know only of Flink generating such schemas and the issue is only on Avro type name `record` this PR does not try to mitigate any other complex types as name.

I think the patching by adding namespace if namespace does not exist is least intrusive option.

Other options are to:
* Add the patching to the name itself, `patched.name.record`.
* Change the name by uppercasing/adding lodash the first character, `_record`, `Record`.

One issue of this change I can think of is if Avro validation is made stricter to not allow type names at all. This renders the patching with namespaces invalid.
