### PR TITLE
REST API single producer

### DIFF
--- a/karapace/config.py
+++ b/karapace/config.py
@@ -54,7 +54,7 @@ DEFAULTS = {
     "producer_acks": 1,
     "producer_compression_type": None,
     "producer_count": 5,
-    "producer_linger_ms": 0,
+    "producer_linger_ms": 100,
     "session_timeout_ms": 10000,
     "karapace_rest": False,
     "karapace_registry": False,

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -586,11 +586,13 @@ class KafkaRest(KarapaceBase):
 
             # Cancelling the returned future **will not** stop event from being sent, but cancelling
             # the ``send`` coroutine itself **will**.
-            coroutine = prod.send_and_wait(topic, key=key, value=value, partition=partition)
+            coroutine = prod.send(topic, key=key, value=value, partition=partition)
 
             # Schedule the co-routine, it will be cancelled if the it is not complete in
             # `self.kafka_timeout` seconds.
-            result = await asyncio.wait_for(fut=coroutine, timeout=self.kafka_timeout)
+            future = await asyncio.wait_for(fut=coroutine, timeout=self.kafka_timeout)
+
+            result = await future
             return {
                 "offset": result.offset if result else -1,
                 "partition": result.topic_partition.partition if result else 0,

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -583,9 +583,14 @@ class KafkaRest(KarapaceBase):
         prod = None
         try:
             prod = await self.get_producer()
-            result = await asyncio.wait_for(
-                fut=prod.send_and_wait(topic, key=key, value=value, partition=partition), timeout=self.kafka_timeout
-            )
+
+            # Cancelling the returned future **will not** stop event from being sent, but cancelling
+            # the ``send`` coroutine itself **will**.
+            coroutine = prod.send_and_wait(topic, key=key, value=value, partition=partition)
+
+            # Schedule the co-routine, it will be cancelled if the it is not complete in
+            # `self.kafka_timeout` seconds.
+            result = await asyncio.wait_for(fut=coroutine, timeout=self.kafka_timeout)
             return {
                 "offset": result.offset if result else -1,
                 "partition": result.topic_partition.partition if result else 0,


### PR DESCRIPTION
The aiokafka producer has internal batching, the REST API doesn't need multiple producers to work properly