### PR TITLE
Schema registry simpler init

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -152,9 +152,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.log.info("Shutting down all auxiliary threads")
         self.mc.close()
         self.ksr.close()
-        if self.producer:
-            self.producer.close()
-            self.producer = None
+        self.producer.close()
 
     def _subject_get(self, subject, content_type, include_deleted=False) -> Dict[str, Any]:
         subject_data = self.ksr.subjects.get(subject)

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -57,13 +57,9 @@ class InvalidSchemaType(Exception):
 
 
 class KarapaceSchemaRegistry(KarapaceBase):
-    # pylint: disable=attribute-defined-outside-init
     def __init__(self, config: dict) -> None:
         super().__init__(config=config)
         self._add_schema_registry_routes()
-        self._init_schema_registry(config=config)
-
-    def _init_schema_registry(self, config: dict) -> None:  # pylint: disable=unused-argument
         self.ksr = None
         self.producer = self._create_producer()
         self._create_master_coordinator()

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -149,9 +149,14 @@ class KarapaceSchemaRegistry(KarapaceBase):
 
     async def close(self) -> None:
         await super().close()
-        self.log.info("Shutting down all auxiliary threads")
+
+        self.log.info("Closing master coordinator")
         self.mc.close()
+
+        self.log.info("Closing schema reader")
         self.ksr.close()
+
+        self.log.info("Closing producer")
         self.producer.close()
 
     def _subject_get(self, subject, content_type, include_deleted=False) -> Dict[str, Any]:


### PR DESCRIPTION
The resources for the schema registry server don't need None handling.