### PR TITLE
Optimize deepcopy

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [MASTER]
 jobs=4
+extension-pkg-allow-list=ujson
 
 [MESSAGES CONTROL]
 disable=

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -8,10 +8,10 @@ from enum import Enum, unique
 from pathlib import Path
 from typing import Dict, IO, List, Optional, Union
 
-import json
 import os
 import socket
 import ssl
+import ujson
 
 Config = Dict[str, Union[None, str, int, bool, List[str]]]
 
@@ -112,13 +112,13 @@ def set_config_defaults(config: Config) -> Config:
 
 
 def write_config(config_path: Path, custom_values: Config) -> None:
-    config_path.write_text(json.dumps(custom_values))
+    config_path.write_text(ujson.dumps(custom_values))
 
 
 def read_config(config_handler: IO) -> Config:
     try:
-        config = json.load(config_handler)
-    except json.JSONDecodeError as ex:
+        config = ujson.load(config_handler)
+    except ValueError as ex:
         raise InvalidConfiguration("Configuration is not a valid JSON") from ex
 
     return set_config_defaults(config)

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -12,12 +12,11 @@ from karapace.karapace import KarapaceBase
 from karapace.rapu import HTTPRequest
 from karapace.schema_reader import SchemaType
 from karapace.serialization import InvalidMessageSchema, InvalidPayload, SchemaRegistrySerializer, SchemaRetrievalError
-from karapace.utils import convert_to_int, KarapaceKafkaClient
+from karapace.utils import convert_to_int, deepcopy, KarapaceKafkaClient
 from typing import List, Optional, Tuple
 
 import asyncio
 import base64
-import copy
 import logging
 import time
 import ujson
@@ -286,7 +285,7 @@ class KafkaRest(KarapaceBase):
                 self._cluster_metadata = None
 
             if self._cluster_metadata and topics is None:
-                return copy.deepcopy(self._cluster_metadata)
+                return deepcopy(self._cluster_metadata)
 
             try:
                 metadata_birth = time.monotonic()
@@ -305,7 +304,7 @@ class KafkaRest(KarapaceBase):
                     content_type="application/json",
                     status=HTTPStatus.INTERNAL_SERVER_ERROR,
                 )
-            return copy.deepcopy(metadata)
+            return deepcopy(metadata)
 
     def init_admin_client(self):
         while True:

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -18,9 +18,9 @@ from typing import List, Optional, Tuple
 import asyncio
 import base64
 import copy
-import json
 import logging
 import time
+import ujson
 
 RECORD_KEYS = ["key", "value", "partition"]
 PUBLISH_KEYS = {"records", "value_schema", "value_schema_id", "key_schema", "key_schema_id"}
@@ -535,7 +535,7 @@ class KafkaRest(KarapaceBase):
         # not pretty
         if ser_format == "json":
             # TODO -> get encoding from headers
-            return json.dumps(obj).encode("utf8")
+            return ujson.dumps(obj).encode("utf8")
         if ser_format == "binary":
             return base64.b64decode(obj)
         if ser_format in {"avro", "jsonschema", "protobuf"}:

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -15,9 +15,9 @@ from urllib.parse import urljoin
 
 import asyncio
 import base64
-import json
 import logging
 import time
+import ujson
 import uuid
 
 KNOWN_FORMATS = {"json", "avro", "binary", "jsonschema", "protobuf"}
@@ -493,7 +493,7 @@ class ConsumerManager:
         if fmt in {"avro", "jsonschema", "protobuf"}:
             return await self.deserializer.deserialize(bytes_)
         if fmt == "json":
-            return json.loads(bytes_.decode("utf-8"))
+            return ujson.loads(bytes_.decode("utf-8"))
         return base64.b64encode(bytes_).decode("utf-8")
 
     def close(self):

--- a/karapace/protobuf/exception.py
+++ b/karapace/protobuf/exception.py
@@ -1,4 +1,4 @@
-import json
+import ujson
 
 
 class ProtobufParserRuntimeException(Exception):
@@ -30,7 +30,7 @@ class SchemaParseException(ProtobufException):
 
 
 def pretty_print_json(obj: str) -> str:
-    return json.dumps(json.loads(obj), indent=2)
+    return ujson.dumps(ujson.loads(obj), indent=2)
 
 
 class ProtobufSchemaResolutionException(ProtobufException):

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -2,7 +2,6 @@ from avro.schema import SchemaParseException
 from contextlib import closing
 from enum import Enum, unique
 from http import HTTPStatus
-from json import JSONDecodeError
 from kafka import KafkaProducer
 from karapace import version as karapace_version
 from karapace.avro_compatibility import is_incompatible
@@ -779,7 +778,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             new_schema = TypedSchema.parse(schema_type=schema_type, schema_str=body["schema"])
         except (InvalidSchema, InvalidSchemaType) as e:
             self.log.warning("Invalid schema: %r", body["schema"], exc_info=True)
-            if isinstance(e.__cause__, (SchemaParseException, JSONDecodeError)):
+            if isinstance(e.__cause__, (SchemaParseException, ValueError)):
                 human_error = f"{e.__cause__.args[0]}"  # pylint: disable=no-member
             else:
                 human_error = "Provided schema is not valid"

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -1,6 +1,5 @@
 from avro.io import BinaryDecoder, BinaryEncoder, DatumReader, DatumWriter
 from google.protobuf.message import DecodeError
-from json import load
 from jsonschema import ValidationError
 from karapace.protobuf.exception import ProtobufTypeException
 from karapace.protobuf.io import ProtobufDatumReader, ProtobufDatumWriter
@@ -14,6 +13,7 @@ import avro
 import io
 import logging
 import struct
+import ujson
 
 log = logging.getLogger(__name__)
 
@@ -188,7 +188,7 @@ def read_value(schema: TypedSchema, bio: io.BytesIO):
         reader = DatumReader(schema.schema)
         return reader.read(BinaryDecoder(bio))
     if schema.schema_type is SchemaType.JSONSCHEMA:
-        value = load(bio)
+        value = ujson.load(bio)
         try:
             schema.schema.validate(value)
         except ValidationError as e:

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -7,7 +7,7 @@ See LICENSE for details
 from functools import partial
 from http import HTTPStatus
 from kafka.client_async import BrokerConnection, KafkaClient, MetadataRequest
-from typing import NoReturn, Optional
+from typing import Any, NoReturn, Optional
 from urllib.parse import urljoin
 
 import aiohttp
@@ -20,9 +20,22 @@ import requests
 import ssl
 import time
 import types
+import ujson
 
 log = logging.getLogger("KarapaceUtils")
 NS_BLACKOUT_DURATION_SECONDS = 120
+
+
+def deepcopy(obj: Any) -> Any:
+    """Replacement for the standard library deepcopy.
+
+    The stdlib's copy.deepcopy is notoriously slow. After benchmarking the REST Proxy produce API
+    the deepcopy was identified as a bottleneck. Currently it is faster to encode the objects as
+    json and decode the result instead of using copy.deepcopy.
+    """
+    encoded = ujson.dumps(obj)
+    copy = ujson.loads(encoded)
+    return copy
 
 
 def isoformat(datetime_obj=None, *, preserve_subsecond=False, compact=False):

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,9 @@ warn_no_return = True
 warn_unreachable = True
 strict_equality = True
 
+[mypy-ujson]
+ignore_errors = True
+
 [mypy-karapace.schema_registry_apis]
 ignore_errors = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ lz4==3.0.2
 requests==2.27.1
 networkx==2.5
 python-dateutil==2.8.2
-protobuf~=3.19.4
+protobuf==3.19.4
+ujson==5.1.0
 
 # Patched dependencies
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@ from karapace.avro_compatibility import SchemaCompatibilityResult
 from pathlib import Path
 from typing import List, Optional
 
-import json
 import pytest
+import ujson
 
 pytest_plugins = "aiohttp.pytest_plugin"
 
@@ -82,5 +82,5 @@ def fixture_session_tmppath(tmp_path_factory) -> Path:
 @pytest.fixture(scope="session", name="default_config_path")
 def fixture_default_config(session_tmppath: Path) -> str:
     path = session_tmppath / "karapace_config.json"
-    path.write_text(json.dumps({"registry_host": "localhost", "registry_port": 8081}))
+    path.write_text(ujson.dumps({"registry_host": "localhost", "registry_port": 8081}))
     return str(path)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,12 +28,12 @@ from tests.utils import (
 )
 from typing import AsyncIterator, Dict, Iterator, List, Optional, Tuple
 
-import json
 import os
 import pytest
 import signal
 import socket
 import time
+import ujson
 
 # Keep these in sync with the Makefile
 KAFKA_CURRENT_VERSION = "2.7"
@@ -153,7 +153,7 @@ def fixture_kafka_server(request, session_tmppath: Path) -> Iterator[KafkaServer
         # there is an issue with pylint here, see https:/github.com/tox-dev/py-filelock/issues/102
         with FileLock(str(lock_path_for(transfer_file))):  # pylint: disable=abstract-class-instantiated
             if transfer_file.exists():
-                config_data = json.loads(transfer_file.read_text())
+                config_data = ujson.loads(transfer_file.read_text())
                 zk_config = ZKConfig.from_dict(config_data["zookeeper"])
                 kafka_config = KafkaConfig.from_dict(config_data["kafka"])
             else:
@@ -170,7 +170,7 @@ def fixture_kafka_server(request, session_tmppath: Path) -> Iterator[KafkaServer
                     "zookeeper": asdict(zk_config),
                     "kafka": asdict(kafka_config),
                 }
-                transfer_file.write_text(json.dumps(config_data))
+                transfer_file.write_text(ujson.dumps(config_data))
 
         # Make sure every test worker can communicate with kafka
         kafka_servers = KafkaServers(bootstrap_servers=[f"127.0.0.1:{kafka_config.kafka_port}"])

--- a/tests/integration/schema_registry/test_jsonschema.py
+++ b/tests/integration/schema_registry/test_jsonschema.py
@@ -94,8 +94,8 @@ from tests.schemas.json_schemas import (
 )
 from tests.utils import new_random_name
 
-import json as jsonlib
 import pytest
+import ujson
 
 
 async def debugging_details(
@@ -104,8 +104,8 @@ async def debugging_details(
     client: Client,
     subject: str,
 ) -> str:
-    newer_schema = jsonlib.dumps(newer.schema)
-    older_schema = jsonlib.dumps(older.schema)
+    newer_schema = ujson.dumps(newer.schema)
+    older_schema = ujson.dumps(older.schema)
     config_res = await client.get(f"config/{subject}?defaultToGlobal=true")
     config = config_res.json()
     return f"subject={subject} newer={newer_schema} older={older_schema} compatibility={config}"
@@ -126,7 +126,7 @@ async def not_schemas_are_compatible(
     older_res = await client.post(
         f"subjects/{subject}/versions",
         json={
-            "schema": jsonlib.dumps(older.schema),
+            "schema": ujson.dumps(older.schema),
             "schemaType": SchemaType.JSONSCHEMA.value,
         },
     )
@@ -141,7 +141,7 @@ async def not_schemas_are_compatible(
     newer_res = await client.post(
         f"subjects/{subject}/versions",
         json={
-            "schema": jsonlib.dumps(newer.schema),
+            "schema": ujson.dumps(newer.schema),
             "schemaType": SchemaType.JSONSCHEMA.value,
         },
     )
@@ -169,7 +169,7 @@ async def schemas_are_compatible(
     older_res = await client.post(
         f"subjects/{subject}/versions",
         json={
-            "schema": jsonlib.dumps(older.schema),
+            "schema": ujson.dumps(older.schema),
             "schemaType": SchemaType.JSONSCHEMA.value,
         },
     )
@@ -184,7 +184,7 @@ async def schemas_are_compatible(
     newer_res = await client.post(
         f"subjects/{subject}/versions",
         json={
-            "schema": jsonlib.dumps(newer.schema),
+            "schema": ujson.dumps(newer.schema),
             "schemaType": SchemaType.JSONSCHEMA.value,
         },
     )
@@ -242,7 +242,7 @@ async def test_same_jsonschema_must_have_same_id(
         first_res = await registry_async_client.post(
             f"subjects/{subject}/versions{trail}",
             json={
-                "schema": jsonlib.dumps(schema.schema),
+                "schema": ujson.dumps(schema.schema),
                 "schemaType": SchemaType.JSONSCHEMA.value,
             },
         )
@@ -253,7 +253,7 @@ async def test_same_jsonschema_must_have_same_id(
         second_res = await registry_async_client.post(
             f"subjects/{subject}/versions{trail}",
             json={
-                "schema": jsonlib.dumps(schema.schema),
+                "schema": ujson.dumps(schema.schema),
                 "schemaType": SchemaType.JSONSCHEMA.value,
             },
         )

--- a/tests/integration/test_master_coordinator.py
+++ b/tests/integration/test_master_coordinator.py
@@ -10,10 +10,10 @@ from karapace.master_coordinator import MasterCoordinator
 from tests.utils import get_random_port, KafkaServers, new_random_name, TESTS_PORT_RANGE
 
 import asyncio
-import json
 import pytest
 import requests
 import time
+import ujson
 
 
 class Timeout(Exception):
@@ -158,7 +158,7 @@ async def test_schema_request_forwarding(registry_async_pair):
 
     # New schema updates, last compatibility is None
     for s in [schema, other_schema]:
-        resp = requests.post(f"{slave_url}/subjects/{subject}/versions", json={"schema": json.dumps(s)})
+        resp = requests.post(f"{slave_url}/subjects/{subject}/versions", json={"schema": ujson.dumps(s)})
     assert resp.ok
     data = resp.json()
     assert "id" in data, data

--- a/tests/integration/test_rest_consumer.py
+++ b/tests/integration/test_rest_consumer.py
@@ -1,3 +1,4 @@
+from karapace.utils import deepcopy
 from tests.utils import (
     consumer_valid_payload,
     new_consumer,
@@ -244,7 +245,7 @@ async def test_consume(rest_async_client, admin_client, producer, trail):
     deserializers = {"binary": base64.b64decode, "json": lambda x: ujson.dumps(x).encode("utf-8")}
     group_name = "consume_group"
     for fmt in ["binary", "json"]:
-        header = copy.deepcopy(REST_HEADERS[fmt])
+        header = deepcopy(REST_HEADERS[fmt])
         instance_id = await new_consumer(rest_async_client, group_name, fmt=fmt, trail=trail)
         assign_path = f"/consumers/{group_name}/instances/{instance_id}/assignments{trail}"
         seek_path = f"/consumers/{group_name}/instances/{instance_id}/positions/beginning{trail}"

--- a/tests/integration/test_rest_consumer.py
+++ b/tests/integration/test_rest_consumer.py
@@ -10,9 +10,9 @@ from tests.utils import (
 
 import base64
 import copy
-import json
 import pytest
 import random
+import ujson
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -238,10 +238,10 @@ async def test_offsets(rest_async_client, admin_client, trail):
 async def test_consume(rest_async_client, admin_client, producer, trail):
     # avro to be handled in a separate testcase ??
     values = {
-        "json": [json.dumps({"foo": f"bar{i}"}).encode("utf-8") for i in range(3)],
+        "json": [ujson.dumps({"foo": f"bar{i}"}).encode("utf-8") for i in range(3)],
         "binary": [f"val{i}".encode("utf-8") for i in range(3)],
     }
-    deserializers = {"binary": base64.b64decode, "json": lambda x: json.dumps(x).encode("utf-8")}
+    deserializers = {"binary": base64.b64decode, "json": lambda x: ujson.dumps(x).encode("utf-8")}
     group_name = "consume_group"
     for fmt in ["binary", "json"]:
         header = copy.deepcopy(REST_HEADERS[fmt])

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -23,6 +23,7 @@ import json as jsonlib
 import os
 import pytest
 import requests
+import ujson
 
 baseurl = "http://localhost:8081"
 
@@ -51,14 +52,14 @@ async def test_union_to_union(registry_async_client: Client, trail: str) -> None
         ],
     }
     res = await registry_async_client.post(
-        f"subjects/{subject_1}/versions{trail}", json={"schema": jsonlib.dumps(init_schema)}
+        f"subjects/{subject_1}/versions{trail}", json={"schema": ujson.dumps(init_schema)}
     )
     assert res.status == 200
     assert "id" in res.json()
-    res = await registry_async_client.post(f"subjects/{subject_1}/versions{trail}", json={"schema": jsonlib.dumps(evolved)})
+    res = await registry_async_client.post(f"subjects/{subject_1}/versions{trail}", json={"schema": ujson.dumps(evolved)})
     assert res.status == 409
     res = await registry_async_client.post(
-        f"subjects/{subject_1}/versions{trail}", json={"schema": jsonlib.dumps(evolved_compatible)}
+        f"subjects/{subject_1}/versions{trail}", json={"schema": ujson.dumps(evolved_compatible)}
     )
     assert res.status == 200
     # fw compat check
@@ -66,14 +67,14 @@ async def test_union_to_union(registry_async_client: Client, trail: str) -> None
     res = await registry_async_client.put(f"config/{subject_2}{trail}", json={"compatibility": "FORWARD"})
     assert res.status == 200
     res = await registry_async_client.post(
-        f"subjects/{subject_2}/versions{trail}", json={"schema": jsonlib.dumps(evolved_compatible)}
+        f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(evolved_compatible)}
     )
     assert res.status == 200
     assert "id" in res.json()
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": jsonlib.dumps(evolved)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(evolved)})
     assert res.status == 409
     res = await registry_async_client.post(
-        f"subjects/{subject_2}/versions{trail}", json={"schema": jsonlib.dumps(init_schema)}
+        f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(init_schema)}
     )
     assert res.status == 200
 
@@ -83,7 +84,7 @@ async def test_missing_subject_compatibility(registry_async_client: Client, trai
     subject = create_subject_name_factory(f"test_missing_subject_compatibility-{trail}")()
 
     res = await registry_async_client.post(
-        f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps({"type": "string"})}
+        f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps({"type": "string"})}
     )
     assert res.status_code == 200, f"{res} {subject}"
     res = await registry_async_client.get(f"config/{subject}{trail}")
@@ -120,7 +121,7 @@ async def test_record_union_schema_compatibility(registry_async_client: Client, 
         ],
     }
     res = await registry_async_client.post(
-        f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(original_schema)}
+        f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(original_schema)}
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -151,11 +152,11 @@ async def test_record_union_schema_compatibility(registry_async_client: Client, 
     }
     res = await registry_async_client.post(
         f"compatibility/subjects/{subject}/versions/latest{trail}",
-        json={"schema": jsonlib.dumps(evolved_schema)},
+        json={"schema": ujson.dumps(evolved_schema)},
     )
     assert res.status == 200
     res = await registry_async_client.post(
-        f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(evolved_schema)}
+        f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(evolved_schema)}
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -163,11 +164,11 @@ async def test_record_union_schema_compatibility(registry_async_client: Client, 
     # Check that we can delete the field as well
     res = await registry_async_client.post(
         f"compatibility/subjects/{subject}/versions/latest{trail}",
-        json={"schema": jsonlib.dumps(original_schema)},
+        json={"schema": ujson.dumps(original_schema)},
     )
     assert res.status == 200
     res = await registry_async_client.post(
-        f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(original_schema)}
+        f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(original_schema)}
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -204,7 +205,7 @@ async def test_record_nested_schema_compatibility(registry_async_client: Client,
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -213,7 +214,7 @@ async def test_record_nested_schema_compatibility(registry_async_client: Client,
     schema["fields"][1]["type"]["fields"][0]["type"] = "int"
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 409
 
@@ -242,7 +243,7 @@ async def test_compatibility_endpoint(registry_async_client: Client, trail: str)
 
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 200
 
@@ -253,7 +254,7 @@ async def test_compatibility_endpoint(registry_async_client: Client, trail: str)
     schema["fields"] = [{"type": "long", "name": "age"}]
     res = await registry_async_client.post(
         f"compatibility/subjects/{subject}/versions/latest{trail}",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 200
     assert res.json() == {"is_compatible": True}
@@ -262,7 +263,7 @@ async def test_compatibility_endpoint(registry_async_client: Client, trail: str)
     schema["fields"] = [{"type": "string", "name": "age"}]
     res = await registry_async_client.post(
         f"compatibility/subjects/{subject}/versions/latest{trail}",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 200
     assert res.json() == {"is_compatible": False}
@@ -336,14 +337,14 @@ async def test_type_compatibility(registry_async_client: Client, trail: str) -> 
         }
         res = await registry_async_client.post(
             f"subjects/{subject}/versions{trail}",
-            json={"schema": jsonlib.dumps(schema)},
+            json={"schema": ujson.dumps(schema)},
         )
         assert res.status == 200
 
         schema["fields"][0]["type"] = target_type
         res = await registry_async_client.post(
             f"compatibility/subjects/{subject}/versions/latest{trail}",
-            json={"schema": jsonlib.dumps(schema)},
+            json={"schema": ujson.dumps(schema)},
         )
         assert res.status == 200
         assert res.json() == {"is_compatible": expected}
@@ -367,7 +368,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_1)},
+        json={"schema": ujson.dumps(schema_1)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -387,7 +388,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_2)},
+        json={"schema": ujson.dumps(schema_2)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -405,7 +406,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_3a)},
+        json={"schema": ujson.dumps(schema_3a)},
     )
     # Fails because field removed
     assert res.status == 409
@@ -423,7 +424,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_3b)},
+        json={"schema": ujson.dumps(schema_3b)},
     )
     # Fails because incompatible type change
     assert res.status == 409
@@ -442,7 +443,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_4)},
+        json={"schema": ujson.dumps(schema_4)},
     )
     assert res.status == 200
 
@@ -465,7 +466,7 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
     }
     res = await registry_async_client.post(
         f"subjects/{subject_1}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_1)},
+        json={"schema": ujson.dumps(schema_1)},
     )
     assert res.status == 200
 
@@ -486,7 +487,7 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
     }
     res = await registry_async_client.post(
         f"subjects/{subject_1}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_2)},
+        json={"schema": ujson.dumps(schema_2)},
     )
     assert res.status == 409
 
@@ -494,7 +495,7 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
     schema_2["fields"][3] = {"name": "fourth_name", "type": "string", "default": "foof"}
     res = await registry_async_client.post(
         f"subjects/{subject_1}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_2)},
+        json={"schema": ujson.dumps(schema_2)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -503,7 +504,7 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
     schema_2["fields"][3] = {"name": "fourth_name", "type": "int", "default": 2}
     res = await registry_async_client.post(
         f"subjects/{subject_1}/versions{trail}",
-        json={"schema": jsonlib.dumps(schema_2)},
+        json={"schema": ujson.dumps(schema_2)},
     )
     assert res.status == 409
 
@@ -511,10 +512,10 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
     res = await registry_async_client.put(f"config/{subject_2}{trail}", json={"compatibility": "BACKWARD"})
     assert res.status == 200
     schema_1 = {"type": "record", "name": schema_name, "fields": [{"name": "first_name", "type": "string"}]}
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": jsonlib.dumps(schema_1)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(schema_1)})
     assert res.status == 200
     schema_1["fields"].append({"name": "last_name", "type": "string"})
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": jsonlib.dumps(schema_1)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(schema_1)})
     assert res.status == 409
 
 
@@ -527,12 +528,12 @@ async def test_enum_schema_field_add_compatibility(registry_async_client: Client
         res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": compatibility})
         assert res.status == 200
         schema = {"type": "enum", "name": "Suit", "symbols": ["SPADES", "HEARTS", "DIAMONDS"]}
-        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Add a field
         schema["symbols"].append("CLUBS")
-        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
         assert res.status == status_code
 
 
@@ -545,12 +546,12 @@ async def test_array_schema_field_add_compatibility(registry_async_client: Clien
         res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": compatibility})
         assert res.status == 200
         schema = {"type": "array", "items": "int"}
-        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Modify the items type
         schema["items"] = "long"
-        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
         assert res.status == status_code
 
 
@@ -566,12 +567,12 @@ async def test_array_nested_record_compatibility(registry_async_client: Client, 
             "type": "array",
             "items": {"type": "record", "name": "object", "fields": [{"name": "first_name", "type": "string"}]},
         }
-        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Add a second field to the record
         schema["items"]["fields"].append({"name": "last_name", "type": "string"})
-        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
         assert res.status == status_code
 
 
@@ -588,12 +589,12 @@ async def test_record_nested_array_compatibility(registry_async_client: Client, 
             "name": "object",
             "fields": [{"name": "simplearray", "type": {"type": "array", "items": "int"}}],
         }
-        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Modify the array items type
         schema["fields"][0]["type"]["items"] = "long"
-        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
         assert res.status == status_code
 
 
@@ -607,12 +608,12 @@ async def test_map_schema_field_add_compatibility(
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
         assert res.status == 200
         schema = {"type": "map", "values": "int"}
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Modify the items type
         schema["values"] = "long"
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == status_code
 
 
@@ -623,21 +624,21 @@ async def test_enum_schema(registry_async_client: Client) -> None:
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
         assert res.status == 200
         schema = {"type": "enum", "name": "testenum", "symbols": ["first"]}
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
 
         # Add a symbol.
         schema["symbols"].append("second")
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Remove a symbol
         schema["symbols"].pop(1)
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Change the name
         schema["name"] = "another"
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 409
 
         # Inside record
@@ -647,21 +648,21 @@ async def test_enum_schema(registry_async_client: Client) -> None:
             "name": "object",
             "fields": [{"name": "enumkey", "type": {"type": "enum", "name": "testenum", "symbols": ["first"]}}],
         }
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
 
         # Add a symbol.
         schema["fields"][0]["type"]["symbols"].append("second")
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Remove a symbol
         schema["fields"][0]["type"]["symbols"].pop(1)
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
 
         # Change the name
         schema["fields"][0]["type"]["name"] = "another"
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 409
 
 
@@ -674,22 +675,22 @@ async def test_fixed_schema(registry_async_client: Client, compatibility: str) -
     res = await registry_async_client.put(f"config/{subject_1}", json={"compatibility": compatibility})
     assert res.status == 200
     schema = {"type": "fixed", "size": 16, "name": "md5", "aliases": ["testalias"]}
-    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
 
     # Add new alias
     schema["aliases"].append("anotheralias")
-    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == status_code_allowed
 
     # Try to change size
     schema["size"] = 32
-    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == status_code_denied
 
     # Try to change name
     schema["size"] = 16
     schema["name"] = "denied"
-    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == status_code_denied
 
     # In a record
@@ -699,22 +700,22 @@ async def test_fixed_schema(registry_async_client: Client, compatibility: str) -
         "name": "object",
         "fields": [{"name": "fixedkey", "type": {"type": "fixed", "size": 16, "name": "md5", "aliases": ["testalias"]}}],
     }
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
 
     # Add new alias
     schema["fields"][0]["type"]["aliases"].append("anotheralias")
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == status_code_allowed
 
     # Try to change size
     schema["fields"][0]["type"]["size"] = 32
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == status_code_denied
 
     # Try to change name
     schema["fields"][0]["type"]["size"] = 16
     schema["fields"][0]["type"]["name"] = "denied"
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == status_code_denied
 
 
@@ -728,10 +729,10 @@ async def test_primitive_schema(registry_async_client: Client) -> None:
 
         # Transition from string to bytes
         schema = {"type": "string"}
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
         schema["type"] = "bytes"
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == status_code
 
     expected_results = [("BACKWARD", 409), ("FORWARD", 409), ("FULL", 409)]
@@ -742,10 +743,10 @@ async def test_primitive_schema(registry_async_client: Client) -> None:
 
         # Transition from string to int
         schema = {"type": "string"}
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
         schema["type"] = "int"
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
 
 
 async def test_union_comparing_to_other_types(registry_async_client: Client) -> None:
@@ -758,10 +759,10 @@ async def test_union_comparing_to_other_types(registry_async_client: Client) -> 
 
         # Union vs non-union with the same schema
         schema = [{"type": "array", "name": "listofstrings", "items": "string"}, "string"]
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
         plain_schema = {"type": "string"}
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(plain_schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(plain_schema)})
         assert res.status == status_code
 
     expected_results = [("BACKWARD", 200), ("FORWARD", 409), ("FULL", 409)]
@@ -772,10 +773,10 @@ async def test_union_comparing_to_other_types(registry_async_client: Client) -> 
 
         # Non-union first
         schema = {"type": "array", "name": "listofstrings", "items": "string"}
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
         union_schema = [{"type": "array", "name": "listofstrings", "items": "string"}, "string"]
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(union_schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(union_schema)})
         assert res.status == status_code
 
     expected_results = [("BACKWARD", 409), ("FORWARD", 409), ("FULL", 409)]
@@ -786,11 +787,11 @@ async def test_union_comparing_to_other_types(registry_async_client: Client) -> 
 
         # Union to a completely different schema
         schema = [{"type": "array", "name": "listofstrings", "items": "string"}, "string"]
-        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+        res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
         assert res.status == 200
         plain_wrong_schema = {"type": "int"}
         res = await registry_async_client.post(
-            f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(plain_wrong_schema)}
+            f"subjects/{subject}/versions", json={"schema": ujson.dumps(plain_wrong_schema)}
         )
         assert res.status == status_code
 
@@ -809,7 +810,7 @@ async def test_transitive_compatibility(registry_async_client: Client) -> None:
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema0)},
+        json={"schema": ujson.dumps(schema0)},
     )
     assert res.status == 200
 
@@ -827,7 +828,7 @@ async def test_transitive_compatibility(registry_async_client: Client) -> None:
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema1)},
+        json={"schema": ujson.dumps(schema1)},
     )
     assert res.status == 200
 
@@ -849,7 +850,7 @@ async def test_transitive_compatibility(registry_async_client: Client) -> None:
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema2)},
+        json={"schema": ujson.dumps(schema2)},
     )
     assert res.status == 409
     res_json = res.json()
@@ -920,7 +921,7 @@ async def test_schema_versions_multiple_subjects_same_schema(registry_async_clie
             },
         ],
     }
-    schema_str_1 = jsonlib.dumps(schema_1)
+    schema_str_1 = ujson.dumps(schema_1)
     schema_2 = {
         "type": "record",
         "name": schema_name_factory(),
@@ -931,7 +932,7 @@ async def test_schema_versions_multiple_subjects_same_schema(registry_async_clie
             }
         ],
     }
-    schema_str_2 = jsonlib.dumps(schema_2)
+    schema_str_2 = ujson.dumps(schema_2)
 
     subject_1 = subject_name_factory()
     schema_id_1, version_1 = await register_schema(registry_async_client, trail, subject_1, schema_str_1)
@@ -972,7 +973,7 @@ async def test_schema_versions_deleting(registry_async_client: Client, trail: st
         "name": schema_name,
         "fields": [{"name": "field_1", "type": "string"}, {"name": "field_2", "type": "string"}],
     }
-    schema_str_1 = jsonlib.dumps(schema_1)
+    schema_str_1 = ujson.dumps(schema_1)
     schema_2 = {
         "type": "record",
         "name": schema_name,
@@ -980,7 +981,7 @@ async def test_schema_versions_deleting(registry_async_client: Client, trail: st
             {"name": "field_1", "type": "string"},
         ],
     }
-    schema_str_2 = jsonlib.dumps(schema_2)
+    schema_str_2 = ujson.dumps(schema_2)
 
     schema_id_1, version_1 = await register_schema(registry_async_client, trail, subject, schema_str_1)
     schema_1_versions = [(subject, version_1)]
@@ -1033,7 +1034,7 @@ async def test_schema_repost(registry_async_client: Client, trail: str) -> None:
     unique_field_factory = create_field_name_factory(trail)
 
     unique = unique_field_factory()
-    schema_str = jsonlib.dumps({"type": "string", "unique": unique})
+    schema_str = ujson.dumps({"type": "string", "unique": unique})
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
         json={"schema": schema_str},
@@ -1044,7 +1045,7 @@ async def test_schema_repost(registry_async_client: Client, trail: str) -> None:
 
     res = await registry_async_client.get(f"schemas/ids/{schema_id}{trail}")
     assert res.status_code == 200
-    assert jsonlib.loads(res.json()["schema"]) == jsonlib.loads(schema_str)
+    assert ujson.loads(res.json()["schema"]) == ujson.loads(schema_str)
 
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}",
@@ -1124,7 +1125,7 @@ async def test_schema_subject_post_invalid(registry_async_client: Client) -> Non
     """
     subject_name_factory = create_subject_name_factory("test_schema_subject_post_invalid")
 
-    schema_str = jsonlib.dumps({"type": "string"})
+    schema_str = ujson.dumps({"type": "string"})
 
     # Create the subject
     subject_1 = subject_name_factory()
@@ -1136,7 +1137,7 @@ async def test_schema_subject_post_invalid(registry_async_client: Client) -> Non
 
     res = await registry_async_client.post(
         f"subjects/{subject_1}",
-        json={"schema": jsonlib.dumps({"type": "invalid_type"})},
+        json={"schema": ujson.dumps({"type": "invalid_type"})},
     )
     assert res.status == 500, "Invalid schema for existing subject should return 500"
     assert res.json()["message"] == f"Error while looking up schema under subject {subject_1}"
@@ -1185,7 +1186,7 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
     unique_1 = unique_field_factory()
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps({"type": "string", "foo": "string", unique_1: "string"})},
+        json={"schema": ujson.dumps({"type": "string", "foo": "string", unique_1: "string"})},
     )
     assert res.status_code == 200
     schema_id_1 = res.json()["id"]
@@ -1193,7 +1194,7 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
     unique_2 = unique_field_factory()
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps({"type": "string", "foo": "string", unique_2: "string"})},
+        json={"schema": ujson.dumps({"type": "string", "foo": "string", unique_2: "string"})},
     )
     schema_id_2 = res.json()["id"]
     assert res.status_code == 200
@@ -1203,13 +1204,13 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
     await assert_schema_versions(registry_async_client, trail, schema_id_2, [(subject, 2)])
 
     result = await registry_async_client.get(os.path.join(f"schemas/ids/{schema_id_1}"))
-    schema_json_1 = jsonlib.loads(result.json()["schema"])
+    schema_json_1 = ujson.loads(result.json()["schema"])
     assert schema_json_1["type"] == "string"
     assert schema_json_1["foo"] == "string"
     assert schema_json_1[unique_1] == "string"
 
     result = await registry_async_client.get(os.path.join(f"schemas/ids/{schema_id_2}"))
-    schema_json_2 = jsonlib.loads(result.json()["schema"])
+    schema_json_2 = ujson.loads(result.json()["schema"])
     assert schema_json_2["type"] == "string"
     assert schema_json_2["foo"] == "string"
     assert schema_json_2[unique_2] == "string"
@@ -1225,7 +1226,7 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
     res = await registry_async_client.get(f"subjects/{subject}/versions/1")
     assert res.status_code == 200
     assert res.json()["subject"] == subject
-    assert jsonlib.loads(res.json()["schema"]) == schema_json_1
+    assert ujson.loads(res.json()["schema"]) == schema_json_1
 
     # Delete an actual version
     res = await registry_async_client.delete(f"subjects/{subject}/versions/1")
@@ -1235,7 +1236,7 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
     # Get the schema by id, still there, wasn't hard-deleted
     res = await registry_async_client.get(f"schemas/ids/{schema_id_1}{trail}")
     assert res.status_code == 200
-    assert jsonlib.loads(res.json()["schema"]) == schema_json_1
+    assert ujson.loads(res.json()["schema"]) == schema_json_1
 
     # Get the schema by id
     res = await registry_async_client.get(f"schemas/ids/{schema_id_2}{trail}")
@@ -1283,7 +1284,7 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
     unique_3 = unique_field_factory()
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps({"type": "string", "foo": "string", unique_3: "string"})},
+        json={"schema": ujson.dumps({"type": "string", "foo": "string", unique_3: "string"})},
     )
     assert res.status == 200
     res = await registry_async_client.get(f"subjects/{subject}/versions")
@@ -1310,7 +1311,7 @@ async def test_schema_version_numbering(registry_async_client: Client, trail: st
             }
         ],
     }
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == 200
     assert "id" in res.json()
 
@@ -1331,7 +1332,7 @@ async def test_schema_version_numbering(registry_async_client: Client, trail: st
             },
         ],
     }
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema2)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema2)})
     assert res.status == 200
     assert "id" in res.json()
     res = await registry_async_client.get(f"subjects/{subject}/versions")
@@ -1341,7 +1342,7 @@ async def test_schema_version_numbering(registry_async_client: Client, trail: st
     # Recreate subject
     res = await registry_async_client.delete(f"subjects/{subject}")
     assert res.status == 200
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == 200
     res = await registry_async_client.get(f"subjects/{subject}/versions")
     assert res.status == 200
@@ -1369,14 +1370,14 @@ async def test_schema_version_numbering_complex(registry_async_client: Client, t
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     schema_id = res.json()["id"]
 
     res = await registry_async_client.get(f"subjects/{subject}/versions/1")
     assert res.status == 200
     assert res.json()["subject"] == subject
-    assert sorted(jsonlib.loads(res.json()["schema"])) == sorted(schema)
+    assert sorted(ujson.loads(res.json()["schema"])) == sorted(schema)
 
     await assert_schema_versions(registry_async_client, trail, schema_id, [(subject, 1)])
 
@@ -1407,14 +1408,14 @@ async def test_schema_three_subjects_sharing_schema(registry_async_client: Clien
             },
         ],
     }
-    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == 200
     assert "id" in res.json()
     schema_id_1 = res.json()["id"]
 
     # New subject with the same schema
     subject_2 = subject_name_factory()
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
     assert res.status == 200
     assert "id" in res.json()
     schema_id_2 = res.json()["id"]
@@ -1432,7 +1433,7 @@ async def test_schema_three_subjects_sharing_schema(registry_async_client: Clien
     assert res.status == 200
     res = await registry_async_client.post(
         f"subjects/{subject_3}/versions",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 200
     assert res.json()["id"] == schema_id_1  # Same ID as in the previous test step
@@ -1459,7 +1460,7 @@ async def test_schema_subject_version_schema(registry_async_client: Client, trai
             }
         ],
     }
-    schema_str = jsonlib.dumps(schema)
+    schema_str = ujson.dumps(schema)
 
     res = await registry_async_client.post(
         f"subjects/{subject_1}/versions",
@@ -1468,7 +1469,7 @@ async def test_schema_subject_version_schema(registry_async_client: Client, trai
     assert res.status == 200
     res = await registry_async_client.get(f"subjects/{subject_1}/versions/1/schema")
     assert res.status == 200
-    assert res.json() == jsonlib.loads(schema_str)
+    assert res.json() == ujson.loads(schema_str)
 
     subject_2 = subject_name_factory()
     res = await registry_async_client.get(f"subjects/{subject_2}/versions/1/schema")  # Invalid subject
@@ -1483,7 +1484,7 @@ async def test_schema_subject_version_schema(registry_async_client: Client, trai
 
     res = await registry_async_client.get(f"subjects/{subject_1}/versions/latest/schema")
     assert res.status == 200
-    assert res.json() == jsonlib.loads(schema_str)
+    assert res.json() == ujson.loads(schema_str)
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -1494,7 +1495,7 @@ async def test_schema_same_subject(registry_async_client: Client, trail: str) ->
     subject_name_factory = create_subject_name_factory(f"test_schema_same_subject_{trail}")
     schema_name = create_schema_name_factory(f"test_schema_same_subject_{trail}")()
 
-    schema_str = jsonlib.dumps(
+    schema_str = ujson.dumps(
         {
             "type": "record",
             "name": schema_name,
@@ -1521,8 +1522,8 @@ async def test_schema_same_subject(registry_async_client: Client, trail: str) ->
 
     # Switch the str schema to a dict for comparison
     json = res.json()
-    json["schema"] = jsonlib.loads(json["schema"])
-    assert json == {"id": schema_id, "subject": subject, "schema": jsonlib.loads(schema_str), "version": 1}
+    json["schema"] = ujson.loads(json["schema"])
+    assert json == {"id": schema_id, "subject": subject, "schema": ujson.loads(schema_str), "version": 1}
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -1580,11 +1581,11 @@ async def test_schema_version_number_existing_schema(registry_async_client: Clie
             },
         ],
     }
-    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": jsonlib.dumps(schema_1)})
+    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema_1)})
     assert res.status == 200
     schema_id_1 = res.json()["id"]
 
-    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": jsonlib.dumps(schema_2)})
+    res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema_2)})
     assert res.status == 200
     schema_id_2 = res.json()["id"]
     assert schema_id_2 > schema_id_1
@@ -1594,12 +1595,12 @@ async def test_schema_version_number_existing_schema(registry_async_client: Clie
     res = await registry_async_client.put(
         f"config/{subject_2}", json={"compatibility": "NONE"}
     )  # We don't care about compatibility
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": jsonlib.dumps(schema_1)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema_1)})
     assert res.status == 200
     assert res.json()["id"] == schema_id_1
 
     # Create a new schema
-    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": jsonlib.dumps(schema_3)})
+    res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema_3)})
     assert res.status == 200
     schema_id_3 = res.json()["id"]
     assert res.json()["id"] == schema_id_3
@@ -1862,7 +1863,7 @@ async def test_common_endpoints(registry_async_client: Client) -> None:
 async def test_invalid_namespace(registry_async_client: Client) -> None:
     subject = create_subject_name_factory("test_invalid_namespace")()
     schema = {"type": "record", "name": "foo", "namespace": "foo-bar-baz", "fields": []}
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
     assert res.ok, res.json()
 
 
@@ -1878,12 +1879,12 @@ async def test_schema_remains_constant(registry_async_client: Client) -> None:
         "namespace": "foo-bar-baz",
         "fields": [{"type": "string", "name": "bla"}],
     }
-    schema_str = jsonlib.dumps(schema)
+    schema_str = ujson.dumps(schema)
     res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": schema_str})
     assert res.ok, res.json()
     schema_id = res.json()["id"]
     res = await registry_async_client.get(f"schemas/ids/{schema_id}")
-    assert jsonlib.loads(res.json()["schema"]) == jsonlib.loads(schema_str)
+    assert ujson.loads(res.json()["schema"]) == ujson.loads(schema_str)
 
 
 async def test_malformed_kafka_message(
@@ -1902,7 +1903,7 @@ async def test_malformed_kafka_message(
     payload = {"schema": jsonlib.dumps({"foo": "bar"}, indent=None, separators=(",", ":"))}
     message_value = {"deleted": False, "id": schema_id, "subject": "foo", "version": 1}
     message_value.update(payload)
-    producer.send(topic, key=jsonlib.dumps(message_key).encode(), value=jsonlib.dumps(message_value).encode()).get()
+    producer.send(topic, key=ujson.dumps(message_key).encode(), value=ujson.dumps(message_value).encode()).get()
 
     path = f"schemas/ids/{schema_id}"
     res = await repeat_until_successful_request(
@@ -1947,10 +1948,10 @@ async def test_inner_type_compat_failure(registry_async_client: Client) -> None:
             }
         ],
     }
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(sc)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(sc)})
     assert res.ok
     sc_id = res.json()["id"]
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(ev)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(ev)})
     assert res.ok
     assert sc_id != res.json()["id"]
 
@@ -2004,10 +2005,10 @@ async def test_anon_type_union_failure(registry_async_client: Client) -> None:
         ],
     }
 
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(schema)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
     assert res.ok
     sc_id = res.json()["id"]
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(evolved)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(evolved)})
     assert res.ok
     assert sc_id != res.json()["id"]
 
@@ -2057,9 +2058,9 @@ async def test_full_transitive_failure(registry_async_client: Client, compatibil
         ],
     }
     await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(init)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(init)})
     assert res.ok
-    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": jsonlib.dumps(evolved)})
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(evolved)})
     assert not res.ok
     assert res.status == 409
 
@@ -2075,7 +2076,7 @@ async def test_invalid_schemas(registry_async_client: Client) -> None:
 
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(repated_field)},
+        json={"schema": ujson.dumps(repated_field)},
     )
     assert res.status != 500, "an invalid schema should not cause a server crash"
     assert not is_success(HTTPStatus(res.status)), "an invalid schema must not be a success"
@@ -2101,7 +2102,7 @@ async def test_schema_hard_delete_version(registry_async_client: Client) -> None
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schemav1)},
+        json={"schema": ujson.dumps(schemav1)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -2123,7 +2124,7 @@ async def test_schema_hard_delete_version(registry_async_client: Client) -> None
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schemav2)},
+        json={"schema": ujson.dumps(schemav2)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -2185,7 +2186,7 @@ async def test_schema_hard_delete_whole_schema(registry_async_client: Client) ->
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schemav1)},
+        json={"schema": ujson.dumps(schemav1)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -2207,7 +2208,7 @@ async def test_schema_hard_delete_whole_schema(registry_async_client: Client) ->
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schemav2)},
+        json={"schema": ujson.dumps(schemav2)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -2263,7 +2264,7 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
     }
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -2276,7 +2277,7 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
     # Recreate with same subject after soft delete
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -2297,7 +2298,7 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
     # Recreate with same subject after hard delete
     res = await registry_async_client.post(
         f"subjects/{subject}/versions",
-        json={"schema": jsonlib.dumps(schema)},
+        json={"schema": ujson.dumps(schema)},
     )
     assert res.status == 200
     assert "id" in res.json()
@@ -2309,15 +2310,15 @@ async def test_invalid_schema_should_provide_good_error_messages(registry_async_
     subject_name_factory = create_subject_name_factory("test_schema_subject_post_invalid_data")
     test_subject = subject_name_factory()
 
-    schema_str = jsonlib.dumps({"type": "string"})
+    schema_str = ujson.dumps({"type": "string"})
     res = await registry_async_client.post(
         f"subjects/{test_subject}/versions",
         json={"schema": schema_str[:-1]},
     )
-    assert res.json()["message"] == "Invalid AVRO schema. Error: Expecting ',' delimiter: line 1 column 18 (char 17)"
+    assert res.json()["message"] == "Invalid AVRO schema. Error: Expecting ',' delimiter: line 1 column 17 (char 16)"
 
     # Unfortunately the AVRO library doesn't provide a good error message, it just raises an TypeError
-    schema_str = jsonlib.dumps({"type": "enum", "name": "error"})
+    schema_str = ujson.dumps({"type": "enum", "name": "error"})
     res = await registry_async_client.post(
         f"subjects/{test_subject}/versions",
         json={"schema": schema_str},
@@ -2325,7 +2326,7 @@ async def test_invalid_schema_should_provide_good_error_messages(registry_async_
     assert res.json()["message"] == "Invalid AVRO schema. Error: Provided schema is not valid"
 
     # This is an upstream bug in the python AVRO library, until the bug is fixed we should at least have a nice error message
-    schema_str = jsonlib.dumps({"type": "enum", "name": "error", "symbols": {}})
+    schema_str = ujson.dumps({"type": "enum", "name": "error", "symbols": {}})
     res = await registry_async_client.post(
         f"subjects/{test_subject}/versions",
         json={"schema": schema_str},
@@ -2333,7 +2334,7 @@ async def test_invalid_schema_should_provide_good_error_messages(registry_async_
     assert res.json()["message"] == "Invalid AVRO schema. Error: error is a reserved type name."
 
     # This is an upstream bug in the python AVRO library, until the bug is fixed we should at least have a nice error message
-    schema_str = jsonlib.dumps({"type": "enum", "name": "error", "symbols": ["A", "B"]})
+    schema_str = ujson.dumps({"type": "enum", "name": "error", "symbols": ["A", "B"]})
     res = await registry_async_client.post(
         f"subjects/{test_subject}/versions",
         json={"schema": schema_str},

--- a/tests/integration/test_schema_backup.py
+++ b/tests/integration/test_schema_backup.py
@@ -10,9 +10,9 @@ from karapace.utils import Client
 from pathlib import Path
 from tests.utils import Expiration, KafkaServers, new_random_name
 
-import json as jsonlib
 import os
 import time
+import ujson
 
 baseurl = "http://localhost:8081"
 
@@ -50,7 +50,7 @@ async def test_backup_restore(
     restore_location = tmp_path / "restore.log"
 
     with restore_location.open("w") as fp:
-        jsonlib.dump(
+        ujson.dump(
             [
                 [
                     {
@@ -68,7 +68,7 @@ async def test_backup_restore(
                     },
                 ]
             ],
-            fp=fp,
+            fp,
         )
 
     config = set_config_defaults({"bootstrap_uri": kafka_servers.bootstrap_servers})

--- a/tests/unit/test_avro_compatibility.py
+++ b/tests/unit/test_avro_compatibility.py
@@ -10,8 +10,8 @@ from karapace.avro_compatibility import (
     SchemaCompatibilityType,
 )
 
-import json
 import pytest
+import ujson
 
 # Schemas defined in AvroCompatibilityTest.java. Used here to ensure compatibility with the schema-registry
 schema1 = parse_avro_schema_definition('{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]}')
@@ -259,17 +259,17 @@ def test_basic_full_transitive_compatibility():
 
 def test_simple_schema_promotion():
     reader = parse_avro_schema_definition(
-        json.dumps({"name": "foo", "type": "record", "fields": [{"type": "int", "name": "f1"}]})
+        ujson.dumps({"name": "foo", "type": "record", "fields": [{"type": "int", "name": "f1"}]})
     )
     field_alias_reader = parse_avro_schema_definition(
-        json.dumps({"name": "foo", "type": "record", "fields": [{"type": "int", "name": "bar", "aliases": ["f1"]}]})
+        ujson.dumps({"name": "foo", "type": "record", "fields": [{"type": "int", "name": "bar", "aliases": ["f1"]}]})
     )
     record_alias_reader = parse_avro_schema_definition(
-        json.dumps({"name": "other", "type": "record", "fields": [{"type": "int", "name": "f1"}], "aliases": ["foo"]})
+        ujson.dumps({"name": "other", "type": "record", "fields": [{"type": "int", "name": "f1"}], "aliases": ["foo"]})
     )
 
     writer = parse_avro_schema_definition(
-        json.dumps(
+        ujson.dumps(
             {
                 "name": "foo",
                 "type": "record",
@@ -295,7 +295,7 @@ def test_simple_schema_promotion():
     assert res != SchemaCompatibilityResult.compatible(), res
 
     writer = parse_avro_schema_definition(
-        json.dumps(
+        ujson.dumps(
             {
                 "type": "record",
                 "name": "CA",
@@ -312,7 +312,7 @@ def test_simple_schema_promotion():
         )
     )
     reader = parse_avro_schema_definition(
-        json.dumps(
+        ujson.dumps(
             {
                 "type": "record",
                 "name": "CA",
@@ -357,8 +357,8 @@ def test_union_to_simple_comparison(field):
             }
         ],
     }
-    reader = parse_avro_schema_definition(json.dumps(reader))
-    writer = parse_avro_schema_definition(json.dumps(writer))
+    reader = parse_avro_schema_definition(ujson.dumps(reader))
+    writer = parse_avro_schema_definition(ujson.dumps(writer))
     assert are_compatible(reader, writer)
 
 
@@ -367,32 +367,32 @@ def test_union_to_simple_comparison(field):
 #            There's one test per Java file, so expect the first one to be a mammoth
 #  ================================================================================================
 
-BOOLEAN_SCHEMA = parse_avro_schema_definition(json.dumps("boolean"))
-NULL_SCHEMA = parse_avro_schema_definition(json.dumps("null"))
-INT_SCHEMA = parse_avro_schema_definition(json.dumps("int"))
-LONG_SCHEMA = parse_avro_schema_definition(json.dumps("long"))
-STRING_SCHEMA = parse_avro_schema_definition(json.dumps("string"))
-BYTES_SCHEMA = parse_avro_schema_definition(json.dumps("bytes"))
-FLOAT_SCHEMA = parse_avro_schema_definition(json.dumps("float"))
-DOUBLE_SCHEMA = parse_avro_schema_definition(json.dumps("double"))
+BOOLEAN_SCHEMA = parse_avro_schema_definition(ujson.dumps("boolean"))
+NULL_SCHEMA = parse_avro_schema_definition(ujson.dumps("null"))
+INT_SCHEMA = parse_avro_schema_definition(ujson.dumps("int"))
+LONG_SCHEMA = parse_avro_schema_definition(ujson.dumps("long"))
+STRING_SCHEMA = parse_avro_schema_definition(ujson.dumps("string"))
+BYTES_SCHEMA = parse_avro_schema_definition(ujson.dumps("bytes"))
+FLOAT_SCHEMA = parse_avro_schema_definition(ujson.dumps("float"))
+DOUBLE_SCHEMA = parse_avro_schema_definition(ujson.dumps("double"))
 INT_ARRAY_SCHEMA = ArraySchema(INT_SCHEMA)
 LONG_ARRAY_SCHEMA = ArraySchema(LONG_SCHEMA)
 STRING_ARRAY_SCHEMA = ArraySchema(STRING_SCHEMA)
 INT_MAP_SCHEMA = MapSchema(INT_SCHEMA)
 LONG_MAP_SCHEMA = MapSchema(LONG_SCHEMA)
 STRING_MAP_SCHEMA = MapSchema(STRING_SCHEMA)
-ENUM1_AB_SCHEMA = parse_avro_schema_definition(json.dumps({"type": "enum", "name": "Enum1", "symbols": ["A", "B"]}))
-ENUM1_ABC_SCHEMA = parse_avro_schema_definition(json.dumps({"type": "enum", "name": "Enum1", "symbols": ["A", "B", "C"]}))
-ENUM1_BC_SCHEMA = parse_avro_schema_definition(json.dumps({"type": "enum", "name": "Enum1", "symbols": ["B", "C"]}))
-ENUM2_AB_SCHEMA = parse_avro_schema_definition(json.dumps({"type": "enum", "name": "Enum2", "symbols": ["A", "B"]}))
+ENUM1_AB_SCHEMA = parse_avro_schema_definition(ujson.dumps({"type": "enum", "name": "Enum1", "symbols": ["A", "B"]}))
+ENUM1_ABC_SCHEMA = parse_avro_schema_definition(ujson.dumps({"type": "enum", "name": "Enum1", "symbols": ["A", "B", "C"]}))
+ENUM1_BC_SCHEMA = parse_avro_schema_definition(ujson.dumps({"type": "enum", "name": "Enum1", "symbols": ["B", "C"]}))
+ENUM2_AB_SCHEMA = parse_avro_schema_definition(ujson.dumps({"type": "enum", "name": "Enum2", "symbols": ["A", "B"]}))
 ENUM_ABC_ENUM_DEFAULT_A_SCHEMA = parse_avro_schema_definition(
-    json.dumps({"type": "enum", "name": "Enum", "symbols": ["A", "B", "C"], "default": "A"})
+    ujson.dumps({"type": "enum", "name": "Enum", "symbols": ["A", "B", "C"], "default": "A"})
 )
 ENUM_AB_ENUM_DEFAULT_A_SCHEMA = parse_avro_schema_definition(
-    json.dumps({"type": "enum", "name": "Enum", "symbols": ["A", "B"], "default": "A"})
+    ujson.dumps({"type": "enum", "name": "Enum", "symbols": ["A", "B"], "default": "A"})
 )
 ENUM_ABC_ENUM_DEFAULT_A_RECORD = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record",
@@ -403,7 +403,7 @@ ENUM_ABC_ENUM_DEFAULT_A_RECORD = parse_avro_schema_definition(
     )
 )
 ENUM_AB_ENUM_DEFAULT_A_RECORD = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record",
@@ -412,7 +412,7 @@ ENUM_AB_ENUM_DEFAULT_A_RECORD = parse_avro_schema_definition(
     )
 )
 ENUM_ABC_FIELD_DEFAULT_B_ENUM_DEFAULT_A_RECORD = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record",
@@ -427,7 +427,7 @@ ENUM_ABC_FIELD_DEFAULT_B_ENUM_DEFAULT_A_RECORD = parse_avro_schema_definition(
     )
 )
 ENUM_AB_FIELD_DEFAULT_A_ENUM_DEFAULT_B_RECORD = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record",
@@ -456,22 +456,24 @@ INT_LONG_UNION_SCHEMA = UnionSchema([INT_SCHEMA, LONG_SCHEMA])
 INT_LONG_FLOAT_DOUBLE_UNION_SCHEMA = UnionSchema([INT_SCHEMA, LONG_SCHEMA, FLOAT_SCHEMA, DOUBLE_SCHEMA])
 NULL_INT_ARRAY_UNION_SCHEMA = UnionSchema([NULL_SCHEMA, INT_ARRAY_SCHEMA])
 NULL_INT_MAP_UNION_SCHEMA = UnionSchema([NULL_SCHEMA, INT_MAP_SCHEMA])
-EMPTY_RECORD1 = parse_avro_schema_definition(json.dumps({"type": "record", "name": "Record1", "fields": []}))
-EMPTY_RECORD2 = parse_avro_schema_definition(json.dumps({"type": "record", "name": "Record2", "fields": []}))
+EMPTY_RECORD1 = parse_avro_schema_definition(ujson.dumps({"type": "record", "name": "Record1", "fields": []}))
+EMPTY_RECORD2 = parse_avro_schema_definition(ujson.dumps({"type": "record", "name": "Record2", "fields": []}))
 A_INT_RECORD1 = parse_avro_schema_definition(
-    json.dumps({"type": "record", "name": "Record1", "fields": [{"name": "a", "type": "int"}]})
+    ujson.dumps({"type": "record", "name": "Record1", "fields": [{"name": "a", "type": "int"}]})
 )
 A_LONG_RECORD1 = parse_avro_schema_definition(
-    json.dumps({"type": "record", "name": "Record1", "fields": [{"name": "a", "type": "long"}]})
+    ujson.dumps({"type": "record", "name": "Record1", "fields": [{"name": "a", "type": "long"}]})
 )
 A_INT_B_INT_RECORD1 = parse_avro_schema_definition(
-    json.dumps({"type": "record", "name": "Record1", "fields": [{"name": "a", "type": "int"}, {"name": "b", "type": "int"}]})
+    ujson.dumps(
+        {"type": "record", "name": "Record1", "fields": [{"name": "a", "type": "int"}, {"name": "b", "type": "int"}]}
+    )
 )
 A_DINT_RECORD1 = parse_avro_schema_definition(
-    json.dumps({"type": "record", "name": "Record1", "fields": [{"name": "a", "type": "int", "default": 0}]})
+    ujson.dumps({"type": "record", "name": "Record1", "fields": [{"name": "a", "type": "int", "default": 0}]})
 )
 A_INT_B_DINT_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -480,7 +482,7 @@ A_INT_B_DINT_RECORD1 = parse_avro_schema_definition(
     )
 )
 A_DINT_B_DINT_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -489,7 +491,7 @@ A_DINT_B_DINT_RECORD1 = parse_avro_schema_definition(
     )
 )
 A_DINT_B_DFIXED_4_BYTES_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -501,7 +503,7 @@ A_DINT_B_DFIXED_4_BYTES_RECORD1 = parse_avro_schema_definition(
     )
 )
 A_DINT_B_DFIXED_8_BYTES_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -513,7 +515,7 @@ A_DINT_B_DFIXED_8_BYTES_RECORD1 = parse_avro_schema_definition(
     )
 )
 A_DINT_B_DINT_STRING_UNION_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -522,7 +524,7 @@ A_DINT_B_DINT_STRING_UNION_RECORD1 = parse_avro_schema_definition(
     )
 )
 A_DINT_B_DINT_UNION_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -531,7 +533,7 @@ A_DINT_B_DINT_UNION_RECORD1 = parse_avro_schema_definition(
     )
 )
 A_DINT_B_DENUM_1_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -543,7 +545,7 @@ A_DINT_B_DENUM_1_RECORD1 = parse_avro_schema_definition(
     )
 )
 A_DINT_B_DENUM_2_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -554,10 +556,10 @@ A_DINT_B_DENUM_2_RECORD1 = parse_avro_schema_definition(
         }
     )
 )
-FIXED_4_BYTES = parse_avro_schema_definition(json.dumps({"type": "fixed", "name": "Fixed", "size": 4}))
-FIXED_8_BYTES = parse_avro_schema_definition(json.dumps({"type": "fixed", "name": "Fixed", "size": 8}))
+FIXED_4_BYTES = parse_avro_schema_definition(ujson.dumps({"type": "fixed", "name": "Fixed", "size": 4}))
+FIXED_8_BYTES = parse_avro_schema_definition(ujson.dumps({"type": "fixed", "name": "Fixed", "size": 8}))
 NS_RECORD1 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -582,7 +584,7 @@ NS_RECORD1 = parse_avro_schema_definition(
     )
 )
 NS_RECORD2 = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {
             "type": "record",
             "name": "Record1",
@@ -607,10 +609,10 @@ NS_RECORD2 = parse_avro_schema_definition(
     )
 )
 INT_LIST_RECORD = parse_avro_schema_definition(
-    json.dumps({"type": "record", "name": "List", "fields": [{"name": "head", "type": "int"}]})
+    ujson.dumps({"type": "record", "name": "List", "fields": [{"name": "head", "type": "int"}]})
 )
 LONG_LIST_RECORD = parse_avro_schema_definition(
-    json.dumps({"type": "record", "name": "List", "fields": [{"name": "head", "type": "long"}]})
+    ujson.dumps({"type": "record", "name": "List", "fields": [{"name": "head", "type": "long"}]})
 )
 int_reader_field = Field(name="tail", type=INT_LIST_RECORD, index=1, has_default=False)
 long_reader_field = Field(name="tail", type=LONG_LIST_RECORD, index=1, has_default=False)
@@ -625,10 +627,10 @@ INT_LIST_RECORD._props["fields"] = INT_LIST_RECORD._fields
 LONG_LIST_RECORD._props["fields"] = LONG_LIST_RECORD._fields
 # pylint: enable=protected-access
 RECORD1_WITH_INT = parse_avro_schema_definition(
-    json.dumps({"type": "record", "name": "Record1", "fields": [{"name": "field1", "type": "int"}]})
+    ujson.dumps({"type": "record", "name": "Record1", "fields": [{"name": "field1", "type": "int"}]})
 )
 RECORD2_WITH_INT = parse_avro_schema_definition(
-    json.dumps({"type": "record", "name": "Record2", "fields": [{"name": "field1", "type": "int"}]})
+    ujson.dumps({"type": "record", "name": "Record2", "fields": [{"name": "field1", "type": "int"}]})
 )
 UNION_INT_RECORD1 = UnionSchema([INT_SCHEMA, RECORD1_WITH_INT])
 UNION_INT_RECORD2 = UnionSchema([INT_SCHEMA, RECORD2_WITH_INT])
@@ -638,14 +640,14 @@ UNION_INT_BOOLEAN = UnionSchema([INT_SCHEMA, BOOLEAN_SCHEMA])
 UNION_INT_ARRAY_INT = UnionSchema([INT_SCHEMA, INT_ARRAY_SCHEMA])
 UNION_INT_MAP_INT = UnionSchema([INT_SCHEMA, INT_MAP_SCHEMA])
 UNION_INT_NULL = UnionSchema([INT_SCHEMA, NULL_SCHEMA])
-FIXED_4_ANOTHER_NAME = parse_avro_schema_definition(json.dumps({"type": "fixed", "name": "AnotherName", "size": 4}))
+FIXED_4_ANOTHER_NAME = parse_avro_schema_definition(ujson.dumps({"type": "fixed", "name": "AnotherName", "size": 4}))
 RECORD1_WITH_ENUM_AB = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {"type": "record", "name": "Record1", "fields": [{"name": "field1", "type": dict(ENUM1_AB_SCHEMA.to_json())}]}
     )
 )
 RECORD1_WITH_ENUM_ABC = parse_avro_schema_definition(
-    json.dumps(
+    ujson.dumps(
         {"type": "record", "name": "Record1", "fields": [{"name": "field1", "type": dict(ENUM1_ABC_SCHEMA.to_json())}]}
     )
 )
@@ -654,7 +656,7 @@ RECORD1_WITH_ENUM_ABC = parse_avro_schema_definition(
 def test_schema_compatibility():
     # testValidateSchemaPairMissingField
     writer = parse_avro_schema_definition(
-        json.dumps(
+        ujson.dumps(
             {
                 "type": "record",
                 "name": "Record",
@@ -663,17 +665,17 @@ def test_schema_compatibility():
         )
     )
     reader = parse_avro_schema_definition(
-        json.dumps({"type": "record", "name": "Record", "fields": [{"name": "oldField1", "type": "int"}]})
+        ujson.dumps({"type": "record", "name": "Record", "fields": [{"name": "oldField1", "type": "int"}]})
     )
     assert are_compatible(reader, writer)
     # testValidateSchemaPairMissingSecondField
     reader = parse_avro_schema_definition(
-        json.dumps({"type": "record", "name": "Record", "fields": [{"name": "oldField2", "type": "string"}]})
+        ujson.dumps({"type": "record", "name": "Record", "fields": [{"name": "oldField2", "type": "string"}]})
     )
     assert are_compatible(reader, writer)
     # testValidateSchemaPairAllFields
     reader = parse_avro_schema_definition(
-        json.dumps(
+        ujson.dumps(
             {
                 "type": "record",
                 "name": "Record",
@@ -684,7 +686,7 @@ def test_schema_compatibility():
     assert are_compatible(reader, writer)
     # testValidateSchemaNewFieldWithDefault
     reader = parse_avro_schema_definition(
-        json.dumps(
+        ujson.dumps(
             {
                 "type": "record",
                 "name": "Record",
@@ -695,7 +697,7 @@ def test_schema_compatibility():
     assert are_compatible(reader, writer)
     # testValidateSchemaNewField
     reader = parse_avro_schema_definition(
-        json.dumps(
+        ujson.dumps(
             {
                 "type": "record",
                 "name": "Record",
@@ -705,24 +707,24 @@ def test_schema_compatibility():
     )
     assert not are_compatible(reader, writer)
     # testValidateArrayWriterSchema
-    writer = parse_avro_schema_definition(json.dumps({"type": "array", "items": {"type": "string"}}))
-    reader = parse_avro_schema_definition(json.dumps({"type": "array", "items": {"type": "string"}}))
+    writer = parse_avro_schema_definition(ujson.dumps({"type": "array", "items": {"type": "string"}}))
+    reader = parse_avro_schema_definition(ujson.dumps({"type": "array", "items": {"type": "string"}}))
     assert are_compatible(reader, writer)
-    reader = parse_avro_schema_definition(json.dumps({"type": "map", "values": {"type": "string"}}))
+    reader = parse_avro_schema_definition(ujson.dumps({"type": "map", "values": {"type": "string"}}))
     assert not are_compatible(reader, writer)
     # testValidatePrimitiveWriterSchema
-    writer = parse_avro_schema_definition(json.dumps({"type": "string"}))
-    reader = parse_avro_schema_definition(json.dumps({"type": "string"}))
+    writer = parse_avro_schema_definition(ujson.dumps({"type": "string"}))
+    reader = parse_avro_schema_definition(ujson.dumps({"type": "string"}))
     assert are_compatible(reader, writer)
-    reader = parse_avro_schema_definition(json.dumps({"type": "int"}))
+    reader = parse_avro_schema_definition(ujson.dumps({"type": "int"}))
     assert not are_compatible(reader, writer)
     # testUnionReaderWriterSubsetIncompatibility
     # cannot have a union as a top level data type, so im cheating a bit here
     writer = parse_avro_schema_definition(
-        json.dumps({"name": "Record", "type": "record", "fields": [{"name": "f1", "type": ["int", "string", "long"]}]})
+        ujson.dumps({"name": "Record", "type": "record", "fields": [{"name": "f1", "type": ["int", "string", "long"]}]})
     )
     reader = parse_avro_schema_definition(
-        json.dumps({"name": "Record", "type": "record", "fields": [{"name": "f1", "type": ["int", "string"]}]})
+        ujson.dumps({"name": "Record", "type": "record", "fields": [{"name": "f1", "type": ["int", "string"]}]})
     )
     reader = reader.fields[0].type
     writer = writer.fields[0].type
@@ -798,8 +800,8 @@ def test_schema_compatibility():
         (A_DINT_B_DINT_RECORD1, A_INT_RECORD1),
         (A_INT_B_INT_RECORD1, A_DINT_B_DINT_RECORD1),
         (
-            parse_avro_schema_definition(json.dumps({"type": "null"})),
-            parse_avro_schema_definition(json.dumps({"type": "null"})),
+            parse_avro_schema_definition(ujson.dumps({"type": "null"})),
+            parse_avro_schema_definition(ujson.dumps({"type": "null"})),
         ),
         (INT_LIST_RECORD, INT_LIST_RECORD),
         (LONG_LIST_RECORD, LONG_LIST_RECORD),

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -8,10 +8,10 @@ from karapace.serialization import (
     SchemaRegistrySerializer,
     START_BYTE,
 )
+from karapace.utils import deepcopy
 from tests.utils import test_objects_avro
 
 import avro
-import copy
 import io
 import logging
 import pytest
@@ -65,7 +65,7 @@ async def test_deserialization_fails(default_config_path, mock_registry_client):
 
     # but we can pass in a perfectly fine doc belonging to a diff schema
     schema = await mock_registry_client.get_schema_for_id(1)
-    schema = copy.deepcopy(schema.to_json())
+    schema = deepcopy(schema.to_json())
     schema["name"] = "BadUser"
     schema["fields"][0]["type"] = "int"
     obj = {"name": 100, "favorite_number": 2, "favorite_color": "bar"}

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -13,10 +13,10 @@ from tests.utils import test_objects_avro
 import avro
 import copy
 import io
-import json
 import logging
 import pytest
 import struct
+import ujson
 
 log = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ async def test_deserialization_fails(default_config_path, mock_registry_client):
     schema["name"] = "BadUser"
     schema["fields"][0]["type"] = "int"
     obj = {"name": 100, "favorite_number": 2, "favorite_color": "bar"}
-    writer = avro.io.DatumWriter(avro.io.schema.parse(json.dumps(schema)))
+    writer = avro.io.DatumWriter(avro.io.schema.parse(ujson.dumps(schema)))
     with io.BytesIO() as bio:
         enc = avro.io.BinaryEncoder(bio)
         bio.write(struct.pack(HEADER_FORMAT, START_BYTE, 1))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,9 +8,9 @@ from urllib.parse import quote
 
 import asyncio
 import copy
-import json
 import random
 import time
+import ujson
 import uuid
 
 consumer_valid_payload = {
@@ -20,7 +20,7 @@ consumer_valid_payload = {
     "fetch.min.bytes": 100000,
     "auto.commit.enable": "true",
 }
-schema_jsonschema_json = json.dumps(
+schema_jsonschema_json = ujson.dumps(
     {
         "type": "object",
         "properties": {
@@ -29,7 +29,7 @@ schema_jsonschema_json = json.dumps(
     }
 )
 
-schema_avro_json = json.dumps(
+schema_avro_json = ujson.dumps(
     {
         "namespace": "example.avro",
         "type": "record",
@@ -137,7 +137,7 @@ test_objects_protobuf_second = [
 
 schema_data_second = {"protobuf": (schema_protobuf_second, test_objects_protobuf_second)}
 
-second_schema_json = json.dumps(
+second_schema_json = ujson.dumps(
     {"namespace": "example.avro.other", "type": "record", "name": "Dude", "fields": [{"name": "name", "type": "string"}]}
 )
 


### PR DESCRIPTION
While investigating performance issues with the REST Proxy API I took a profile using `py-spy`, the profiler shows the cost of deepcopy is significant for the produce endpoint. This PR replaces the use of `copy.deepcopy` with a faster version based on `ujson`, at the same time replaces all usages of `json` with `ujson`.

Using stdlib's deepcopy:

![profile](https://user-images.githubusercontent.com/310139/152835848-a75cdec9-3a01-481c-9be2-21f51b7317da.svg)

Using the ujson deepcopy:

![profile2](https://user-images.githubusercontent.com/310139/152835839-496be436-eb62-4012-8d20-97a6f199d75b.svg)

The commit also contains a small timeit script to compare the performance of the two implementations.