### PR TITLE
Bump Avro library to 1.11.0

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -4,7 +4,8 @@ karapace - Kafka schema reader
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
-from avro.schema import Schema as AvroSchema, SchemaParseException
+from avro.errors import SchemaParseException
+from avro.schema import Schema as AvroSchema
 from enum import Enum, unique
 from jsonschema import Draft7Validator
 from jsonschema.exceptions import SchemaError

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -1,4 +1,4 @@
-from avro.schema import SchemaParseException
+from avro.errors import SchemaParseException
 from contextlib import closing
 from enum import Enum, unique
 from http import HTTPStatus

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -223,16 +223,16 @@ def flatten_unions(schema: avro.schema.Schema, value: Any) -> Any:
         return result
 
     if isinstance(schema, avro.schema.UnionSchema) and isinstance(value, dict):
+
         def get_name(obj) -> str:
             if isinstance(obj, avro.schema.PrimitiveSchema):
                 return obj.fullname
-            else:
-                return obj.name
+            return obj.name
+
         f = next((s for s in schema.schemas if get_name(s) in value), None)
         if f is not None:
             # Note: This is intentionally skipping the dictionary, here the JSON representation
             # is flattened to the Python representation
-            vv = value[get_name(f)]
             return flatten_unions(f, value[get_name(f)])
 
     if isinstance(schema, avro.schema.ArraySchema) and isinstance(value, list):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ networkx==2.5
 python-dateutil==2.8.2
 protobuf==3.19.4
 ujson==5.1.0
-
+avro==1.11.0
 # Patched dependencies
 #
 # Note: It is important to use commits to reference patched dependencies. This
@@ -18,7 +18,6 @@ ujson==5.1.0
 # - The contents of the file change, which invalidates the existing docker
 #   images and forces a new image generation.
 #
-git+https://github.com/aiven/avro.git@513b153bac5040af6bba5847aef202adb680b67b#subdirectory=lang/py3/
 git+https://github.com/aiven/kafka-python.git@b9f2f78377d56392f61cba8856dc6c02ae841b79
 
 # Indirect dependencies

--- a/tests/unit/test_avro_compatibility.py
+++ b/tests/unit/test_avro_compatibility.py
@@ -2,7 +2,8 @@
     These are duplicates of other test_schema.py tests, but do not make use of the registry client fixture
     and are here for debugging and speed, and as an initial sanity check
 """
-from avro.schema import ArraySchema, Field, MapSchema, RecordSchema, Schema, UnionSchema
+from avro.name import Names
+from avro.schema import ArraySchema, Field, MapSchema, Schema, UnionSchema
 from karapace.avro_compatibility import (
     parse_avro_schema_definition,
     ReaderWriterCompatibilityChecker,
@@ -375,12 +376,12 @@ STRING_SCHEMA = parse_avro_schema_definition(ujson.dumps("string"))
 BYTES_SCHEMA = parse_avro_schema_definition(ujson.dumps("bytes"))
 FLOAT_SCHEMA = parse_avro_schema_definition(ujson.dumps("float"))
 DOUBLE_SCHEMA = parse_avro_schema_definition(ujson.dumps("double"))
-INT_ARRAY_SCHEMA = ArraySchema(INT_SCHEMA)
-LONG_ARRAY_SCHEMA = ArraySchema(LONG_SCHEMA)
-STRING_ARRAY_SCHEMA = ArraySchema(STRING_SCHEMA)
-INT_MAP_SCHEMA = MapSchema(INT_SCHEMA)
-LONG_MAP_SCHEMA = MapSchema(LONG_SCHEMA)
-STRING_MAP_SCHEMA = MapSchema(STRING_SCHEMA)
+INT_ARRAY_SCHEMA = ArraySchema(INT_SCHEMA.to_json(), Names())
+LONG_ARRAY_SCHEMA = ArraySchema(LONG_SCHEMA.to_json(), Names())
+STRING_ARRAY_SCHEMA = ArraySchema(STRING_SCHEMA.to_json(), Names())
+INT_MAP_SCHEMA = MapSchema(INT_SCHEMA.to_json(), Names())
+LONG_MAP_SCHEMA = MapSchema(LONG_SCHEMA.to_json(), Names())
+STRING_MAP_SCHEMA = MapSchema(STRING_SCHEMA.to_json(), Names())
 ENUM1_AB_SCHEMA = parse_avro_schema_definition(ujson.dumps({"type": "enum", "name": "Enum1", "symbols": ["A", "B"]}))
 ENUM1_ABC_SCHEMA = parse_avro_schema_definition(ujson.dumps({"type": "enum", "name": "Enum1", "symbols": ["A", "B", "C"]}))
 ENUM1_BC_SCHEMA = parse_avro_schema_definition(ujson.dumps({"type": "enum", "name": "Enum1", "symbols": ["B", "C"]}))
@@ -442,20 +443,22 @@ ENUM_AB_FIELD_DEFAULT_A_ENUM_DEFAULT_B_RECORD = parse_avro_schema_definition(
     )
 )
 EMPTY_UNION_SCHEMA = UnionSchema([])
-NULL_UNION_SCHEMA = UnionSchema([NULL_SCHEMA])
-INT_UNION_SCHEMA = UnionSchema([INT_SCHEMA])
-LONG_UNION_SCHEMA = UnionSchema([LONG_SCHEMA])
-FLOAT_UNION_SCHEMA = UnionSchema([FLOAT_SCHEMA])
-DOUBLE_UNION_SCHEMA = UnionSchema([DOUBLE_SCHEMA])
-STRING_UNION_SCHEMA = UnionSchema([STRING_SCHEMA])
-BYTES_UNION_SCHEMA = UnionSchema([BYTES_SCHEMA])
-INT_STRING_UNION_SCHEMA = UnionSchema([INT_SCHEMA, STRING_SCHEMA])
-STRING_INT_UNION_SCHEMA = UnionSchema([STRING_SCHEMA, INT_SCHEMA])
-INT_FLOAT_UNION_SCHEMA = UnionSchema([INT_SCHEMA, FLOAT_SCHEMA])
-INT_LONG_UNION_SCHEMA = UnionSchema([INT_SCHEMA, LONG_SCHEMA])
-INT_LONG_FLOAT_DOUBLE_UNION_SCHEMA = UnionSchema([INT_SCHEMA, LONG_SCHEMA, FLOAT_SCHEMA, DOUBLE_SCHEMA])
-NULL_INT_ARRAY_UNION_SCHEMA = UnionSchema([NULL_SCHEMA, INT_ARRAY_SCHEMA])
-NULL_INT_MAP_UNION_SCHEMA = UnionSchema([NULL_SCHEMA, INT_MAP_SCHEMA])
+NULL_UNION_SCHEMA = UnionSchema([NULL_SCHEMA.to_json()], Names())
+INT_UNION_SCHEMA = UnionSchema([INT_SCHEMA.to_json()], Names())
+LONG_UNION_SCHEMA = UnionSchema([LONG_SCHEMA.to_json()], Names())
+FLOAT_UNION_SCHEMA = UnionSchema([FLOAT_SCHEMA.to_json()], Names())
+DOUBLE_UNION_SCHEMA = UnionSchema([DOUBLE_SCHEMA.to_json()], Names())
+STRING_UNION_SCHEMA = UnionSchema([STRING_SCHEMA.to_json()], Names())
+BYTES_UNION_SCHEMA = UnionSchema([BYTES_SCHEMA.to_json()], Names())
+INT_STRING_UNION_SCHEMA = UnionSchema([INT_SCHEMA.to_json(), STRING_SCHEMA.to_json()], Names())
+STRING_INT_UNION_SCHEMA = UnionSchema([STRING_SCHEMA.to_json(), INT_SCHEMA.to_json()], Names())
+INT_FLOAT_UNION_SCHEMA = UnionSchema([INT_SCHEMA.to_json(), FLOAT_SCHEMA.to_json()], Names())
+INT_LONG_UNION_SCHEMA = UnionSchema([INT_SCHEMA.to_json(), LONG_SCHEMA.to_json()], Names())
+INT_LONG_FLOAT_DOUBLE_UNION_SCHEMA = UnionSchema(
+    [INT_SCHEMA.to_json(), LONG_SCHEMA.to_json(), FLOAT_SCHEMA.to_json(), DOUBLE_SCHEMA.to_json()], Names()
+)
+NULL_INT_ARRAY_UNION_SCHEMA = UnionSchema([NULL_SCHEMA.to_json(), INT_ARRAY_SCHEMA.to_json()], Names())
+NULL_INT_MAP_UNION_SCHEMA = UnionSchema([NULL_SCHEMA.to_json(), INT_MAP_SCHEMA.to_json()], Names())
 EMPTY_RECORD1 = parse_avro_schema_definition(ujson.dumps({"type": "record", "name": "Record1", "fields": []}))
 EMPTY_RECORD2 = parse_avro_schema_definition(ujson.dumps({"type": "record", "name": "Record2", "fields": []}))
 A_INT_RECORD1 = parse_avro_schema_definition(
@@ -614,15 +617,15 @@ INT_LIST_RECORD = parse_avro_schema_definition(
 LONG_LIST_RECORD = parse_avro_schema_definition(
     ujson.dumps({"type": "record", "name": "List", "fields": [{"name": "head", "type": "long"}]})
 )
-int_reader_field = Field(name="tail", type=INT_LIST_RECORD, index=1, has_default=False)
-long_reader_field = Field(name="tail", type=LONG_LIST_RECORD, index=1, has_default=False)
+int_reader_field = Field(name="tail", type_=INT_LIST_RECORD.to_json(), has_default=False)
+long_reader_field = Field(name="tail", type_=LONG_LIST_RECORD.to_json(), has_default=False)
 
 INT_LIST_RECORD._fields = (INT_LIST_RECORD.fields[0], int_reader_field)
 LONG_LIST_RECORD._fields = (LONG_LIST_RECORD.fields[0], long_reader_field)
 
 # pylint: disable=protected-access
-INT_LIST_RECORD._field_map = RecordSchema._MakeFieldMap(INT_LIST_RECORD._fields)
-LONG_LIST_RECORD._field_map = RecordSchema._MakeFieldMap(LONG_LIST_RECORD._fields)
+INT_LIST_RECORD._field_map = INT_LIST_RECORD.fields_dict
+LONG_LIST_RECORD._field_map = LONG_LIST_RECORD.fields_dict
 INT_LIST_RECORD._props["fields"] = INT_LIST_RECORD._fields
 LONG_LIST_RECORD._props["fields"] = LONG_LIST_RECORD._fields
 # pylint: enable=protected-access
@@ -632,14 +635,14 @@ RECORD1_WITH_INT = parse_avro_schema_definition(
 RECORD2_WITH_INT = parse_avro_schema_definition(
     ujson.dumps({"type": "record", "name": "Record2", "fields": [{"name": "field1", "type": "int"}]})
 )
-UNION_INT_RECORD1 = UnionSchema([INT_SCHEMA, RECORD1_WITH_INT])
-UNION_INT_RECORD2 = UnionSchema([INT_SCHEMA, RECORD2_WITH_INT])
-UNION_INT_ENUM1_AB = UnionSchema([INT_SCHEMA, ENUM1_AB_SCHEMA])
-UNION_INT_FIXED_4_BYTES = UnionSchema([INT_SCHEMA, FIXED_4_BYTES])
-UNION_INT_BOOLEAN = UnionSchema([INT_SCHEMA, BOOLEAN_SCHEMA])
-UNION_INT_ARRAY_INT = UnionSchema([INT_SCHEMA, INT_ARRAY_SCHEMA])
-UNION_INT_MAP_INT = UnionSchema([INT_SCHEMA, INT_MAP_SCHEMA])
-UNION_INT_NULL = UnionSchema([INT_SCHEMA, NULL_SCHEMA])
+UNION_INT_RECORD1 = UnionSchema([INT_SCHEMA.to_json(), RECORD1_WITH_INT.to_json()], Names())
+UNION_INT_RECORD2 = UnionSchema([INT_SCHEMA.to_json(), RECORD2_WITH_INT.to_json()], Names())
+UNION_INT_ENUM1_AB = UnionSchema([INT_SCHEMA.to_json(), ENUM1_AB_SCHEMA.to_json()], Names())
+UNION_INT_FIXED_4_BYTES = UnionSchema([INT_SCHEMA.to_json(), FIXED_4_BYTES.to_json()], Names())
+UNION_INT_BOOLEAN = UnionSchema([INT_SCHEMA.to_json(), BOOLEAN_SCHEMA.to_json()], Names())
+UNION_INT_ARRAY_INT = UnionSchema([INT_SCHEMA.to_json(), INT_ARRAY_SCHEMA.to_json()], Names())
+UNION_INT_MAP_INT = UnionSchema([INT_SCHEMA.to_json(), INT_MAP_SCHEMA.to_json()], Names())
+UNION_INT_NULL = UnionSchema([INT_SCHEMA.to_json(), NULL_SCHEMA.to_json()], Names())
 FIXED_4_ANOTHER_NAME = parse_avro_schema_definition(ujson.dumps({"type": "fixed", "name": "AnotherName", "size": 4}))
 RECORD1_WITH_ENUM_AB = parse_avro_schema_definition(
     ujson.dumps(

--- a/tests/unit/test_avro_compatibility.py
+++ b/tests/unit/test_avro_compatibility.py
@@ -40,6 +40,12 @@ badDefaultNullString = parse_avro_schema_definition(
     '{"type":"record","name":"myrecord","fields":[{"type":["null","string"],"name":"f1","default":'
     '"null"},{"type":"string","name":"f2","default":"foo"},{"type":"string","name":"f3","default":"bar"}]}'
 )
+invalidEnumDefaultValue = parse_avro_schema_definition(
+    '{"type": "enum", "name": "test_default", "symbols": ["A"], "default": "B"}'
+)
+correctEnumDefaultValue = parse_avro_schema_definition(
+    '{"type": "enum", "name": "test_default", "symbols": ["A"], "default": "A"}'
+)
 
 
 def test_schemaregistry_basic_backwards_compatibility():
@@ -74,6 +80,10 @@ def test_schemaregistry_basic_backwards_compatibility():
     msg = "removing a type from a union is NOT a backward compatible change"
     res = ReaderWriterCompatibilityChecker().get_compatibility(schema6, schema7)
     assert res != SchemaCompatibilityResult.compatible(), msg
+
+    msg = "changing a default value in enum is a backward compatible change"
+    res = ReaderWriterCompatibilityChecker().get_compatibility(invalidEnumDefaultValue, correctEnumDefaultValue)
+    assert res == SchemaCompatibilityResult.compatible(), msg
 
 
 def test_schemaregistry_basic_backwards_transitive_compatibility():


### PR DESCRIPTION
# About this change - What it does
Bump Python Avro dependency to upstream 1.11.0 from forked and patched version.
Changes in this PR mainly consist of using 1.11.0 Avro API's.
 
Backwards compatibility study:
* Enum type defaults are not validated in 1.11.0, same behavior as with 1.10.x. This will be validated in version 1.11.1 and resulting exception will be `avro.errors.InvalidDefault: Enum default 'B' is not a valid member of symbols '['A']`. A test is added for this in. This test will fail with 1.11.1.
* With default values on fields accepting null the validation is similar with 1.11.0 as with 1.10.x. Following schema is parsed fine: `{"type": "record", "name": "test_record", "fields": [{"type": ["null", "int"], "name": "test_default", "default": "null"}]}` See that value `"null"` does not conform with the field type `null`.
* This version bump PR still uses the schema compatibility check module from Karapace. Move to Avro provided schema compatiblity checking is in #334.

My current knowledge is that version 1.11.0 does not cause backwards compatibility issues. The next Avro release 1.11.1 does cause.
