### PR TITLE
Update protobuf version to 3.15.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ tests should be engineered with this in mind:
 - Don't reuse schema/subject/topic names
 - Expect other clients to be interacting with the servers at the same time.
 
+Before running the tests make sure you have `protoc` installed. `protoc` is part of the protobuf-compiler package.
+In Fedora distributions you can install it using:
+```
+dnf install protobuf-compiler
+```
+
 To run the tests use `make`. It will download Kafka to be used in the tests for you:
 
 ```sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ lz4==3.0.2
 requests==2.27.1
 networkx==2.5
 python-dateutil==2.8.2
-protobuf~=3.14.0
+protobuf~=3.15.0
 
 # Patched dependencies
 #


### PR DESCRIPTION
Resolves: #337

Updates vulnerable version of protobuf

Also adds information about the new test dependency on `protobuf-compiler`
