### PR TITLE
Rename workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  unit-test:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
@@ -32,7 +32,6 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
          version: '3.13.0'
-
 
     - name: Execute unit-tests
       run: make unittest


### PR DESCRIPTION
When the integration tests fail in the CI, currently this is shown:

![image](https://user-images.githubusercontent.com/310139/153572925-3ffad73a-f54b-4ebc-9866-acb89b197f2d.png)


Which is super confusing if it was not the unit tests but the integration tests that failed.