### PR TITLE
Fix cluster_metadata caching and locking

### DIFF
--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -37,7 +37,7 @@ class KafkaRestAdminClient(KafkaAdminClient):
         self.create_topics([NewTopic(name, 1, 1)])
 
     def cluster_metadata(self, topics: List[str] = None, retries: int = 0) -> dict:
-        """List all kafka topics."""
+        """Fetch cluster metadata and topic information for given topics or all topics if not given."""
         metadata_version = self._matching_api_version(MetadataRequest)
         if metadata_version > 6 or metadata_version < 1:
             raise UnrecognizedBrokerVersion(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -211,7 +211,7 @@ async def fixture_rest_async(
 
     config_path = tmp_path / "karapace_config.json"
 
-    config = set_config_defaults({"bootstrap_uri": kafka_servers.bootstrap_servers, "admin_metadata_max_age": 0})
+    config = set_config_defaults({"bootstrap_uri": kafka_servers.bootstrap_servers, "admin_metadata_max_age": 2})
     write_config(config_path, config)
     rest = KafkaRest(config=config)
 


### PR DESCRIPTION
# About this change - What it does

Fix `cluster_metadata` caching

# Why this way

In case `cluster_metadata` was fetched first for a limited set of
topics, the method internally cached partial metadata, which was then
returned regardless if full metadata was requested.

Also use time.monotonic() for cache expiry so that difference is
always valid.

Adjust test configuration for ability to test caching issues.