### PR TITLE
Use configured protobuf runtime directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -414,6 +414,9 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
      - If the registry part of the app should be included in the starting process
        At least one of this and ``karapace_rest`` options need to be enabled in order
        for the service to start
+   * - ``protobuf_runtime_directory``
+     - ``runtime``
+     - Runtime directory for the ``protoc`` protobuf schema parser and code generator
    * - ``name_strategy``
      - ``subject_name``
      - Name strategy to use when storing schemas from the kafka rest proxy service

--- a/karapace.config.json
+++ b/karapace.config.json
@@ -22,5 +22,6 @@
     "karapace_rest": true,
     "karapace_registry": true,
     "topic_name": "_schemas",
+    "protobuf_runtime_directory": "runtime",
     "session_timeout_ms": 10000
 }

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -144,7 +144,7 @@ class TypedSchema:
 
 class KafkaSchemaReader(Thread):
     def __init__(self, config, master_coordinator=None):
-        Thread.__init__(self)
+        Thread.__init__(self, name="schema-reader")
         self.master_coordinator = master_coordinator
         self.log = logging.getLogger("KafkaSchemaReader")
         self.timeout_ms = 200

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1,4 +1,4 @@
-from karapace.config import read_config
+from karapace.config import DEFAULTS, read_config
 from karapace.schema_reader import SchemaType, TypedSchema
 from karapace.serialization import (
     flatten_unions,
@@ -161,7 +161,7 @@ def test_avro_json_write_invalid() -> None:
 
     for record in records:
         with pytest.raises(avro.io.AvroTypeException):
-            write_value(typed_schema, bio, record)
+            write_value(DEFAULTS, typed_schema, bio, record)
 
 
 def test_avro_json_write_accepts_json_encoded_data_without_tagged_unions() -> None:
@@ -224,14 +224,14 @@ def test_avro_json_write_accepts_json_encoded_data_without_tagged_unions() -> No
 
     buffer_a = io.BytesIO()
     buffer_b = io.BytesIO()
-    write_value(typed_schema, buffer_a, properly_tagged_encoding_a)
-    write_value(typed_schema, buffer_b, missing_tag_encoding_a)
+    write_value(DEFAULTS, typed_schema, buffer_a, properly_tagged_encoding_a)
+    write_value(DEFAULTS, typed_schema, buffer_b, missing_tag_encoding_a)
     assert buffer_a.getbuffer() == buffer_b.getbuffer()
 
     buffer_a = io.BytesIO()
     buffer_b = io.BytesIO()
-    write_value(typed_schema, buffer_a, properly_tagged_encoding_b)
-    write_value(typed_schema, buffer_b, missing_tag_encoding_b)
+    write_value(DEFAULTS, typed_schema, buffer_a, properly_tagged_encoding_b)
+    write_value(DEFAULTS, typed_schema, buffer_b, missing_tag_encoding_b)
     assert buffer_a.getbuffer() == buffer_b.getbuffer()
 
 


### PR DESCRIPTION
# About this change - What it does

Use configured protobuf runtime directory

# Why this way

Fix `protobuf_runtime_directory` configuration handling to pass configured value around instead of falling back to defaults.
