### PR TITLE
Use only non-versioned dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
         "jsonschema",
         "kafka-python",
         "networkx",
-        "protobuf>=3.16",  # 3.15 vunerability CVE-2021-22570
-        "requests>=2.21",  # 2.20 vunerability CVE-2018-18074
+        "protobuf",
+        "requests",
     ],
     extras_require={
         # compression algorithms supported by AioKafka and KafkaConsumer


### PR DESCRIPTION
# About this change - What it does

Use only non-versioned dependencies in `setup.py` in unified fashion for all dependencies, and leave version dependencies to locking file (`requirements.txt`)

References: #342

# Why this way

Use `requirements.txt` for pinning recent good versions, and remove partial CVE listings and minimum requirements lagging behind.

This also allows usage of system dependencies where `requirements.txt` dependencies is not in use, for example Fedora 34, which has `python3-protobuf v.3.14` with a patch for referred CVE.
