### PR TITLE
Registries must use different group ids

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -333,7 +333,7 @@ async def fixture_registry_async(
             # Because of this every test must be written in such a way that it can
             # be executed twice with the same servers.
             # "topic_name": new_random_name("topic"),
-            # "group_id": new_random_name("schema_registry")
+            "group_id": new_random_name("registry_async"),
         }
     )
     write_config(config_path, config)
@@ -434,7 +434,7 @@ async def fixture_registry_async_tls(
             # Because of this every test must be written in such a way that it can
             # be executed twice with the same servers.
             # "topic_name": new_random_name("topic"),
-            # "group_id": new_random_name("schema_registry")
+            "group_id": new_random_name("registry_async_tls"),
         }
     )
     write_config(config_path, config)


### PR DESCRIPTION
Otherwise while running in parallel the nodes will join the same group, and cause flakiness.

Example of failure:

```
ERROR    Karapace:rapu.py:335 Internal server error
Traceback (most recent call last):
  File "/home/hacka/work/karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/connector.py", line 986, in _wrap_create_connection
    return await self._loop.create_connection(*args, **kwargs)  # type: ignore[return-value]  # noqa
  File "/usr/lib64/python3.8/asyncio/base_events.py", line 1025, in create_connection
    raise exceptions[0]
  File "/usr/lib64/python3.8/asyncio/base_events.py", line 1010, in create_connection
    sock = await self._connect_sock(
  File "/usr/lib64/python3.8/asyncio/base_events.py", line 924, in _connect_sock
    await self.sock_connect(sock, address)
  File "/usr/lib64/python3.8/asyncio/selector_events.py", line 496, in sock_connect
    return await fut
  File "/usr/lib64/python3.8/asyncio/selector_events.py", line 528, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
ConnectionRefusedError: [Errno 111] Connect call failed ('192.168.122.1', 8081)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/hacka/work/karapace/karapace/rapu.py", line 327, in _handle_request
    data = await callback(**callback_kwargs)
  File "/home/hacka/work/karapace/karapace/schema_registry_apis.py", line 771, in subject_post
    await self.forward_request_remote(body=body, url=url, content_type=content_type, method="POST")
  File "/home/hacka/work/karapace/karapace/schema_registry_apis.py", line 898, in forward_request_remote
    response = await self.http_request(url=url, method=method, json=body, timeout=60.0)
  File "/home/hacka/work/karapace/karapace/rapu.py", line 484, in http_request
    async with func(url, json=json) as response:
  File "/home/hacka/work/karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/client.py", line 1138, in __aenter__
    self._resp = await self._coro
  File "/home/hacka/work/karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/client.py", line 535, in _request
    conn = await self._connector.connect(
  File "/home/hacka/work/karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/connector.py", line 542, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "/home/hacka/work/karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/connector.py", line 907, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
  File "/home/hacka/work/karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/connector.py", line 1206, in _create_direct_connection
    raise last_exc
  File "/home/hacka/work/karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/connector.py", line 1175, in _create_direct_connection
    transp, proto = await self._wrap_create_connection(
  File "/home/hacka/work/karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/connector.py", line 992, in _wrap_create_connection
    raise client_error(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host hacka-aiven:8081 ssl:default [Connect call failed ('192.168.122.1', 8081)]
```