### PR TITLE
rapu: internal servel error returns a JSON response

### DIFF
--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -333,9 +333,9 @@ class RestApp:
                 headers = ex.headers
             except:  # pylint: disable=bare-except
                 self.log.exception("Internal server error")
+                headers = {"Content-Type": "application/json"}
                 data = {"error_code": HTTPStatus.INTERNAL_SERVER_ERROR.value, "message": "Internal server error"}
                 status = HTTPStatus.INTERNAL_SERVER_ERROR
-                headers = {}
             headers.update(self.cors_and_server_headers_for_request(request=rapu_request))
 
             if isinstance(data, (dict, list)):


### PR DESCRIPTION
this is how the error manifest itself in the tests:


```
____________________________________________________________ test_remote_client_protobuf[pyloop] _____________________________________________________________
[gw1] linux -- Python 3.8.12 /home/hacka/work/karapace-venv-3.8/bin/python3.8
tests/integration/test_client_protobuf.py:13: in test_remote_client_protobuf
    sc_id = await reg_cli.post_new_schema(subject, schema_protobuf)
        reg_cli    = <karapace.serialization.SchemaRegistryClient object at 0x7f4391343fd0>
        registry_async_client = <karapace.utils.Client object at 0x7f439122e7f0>
        schema_protobuf = TypedSchema(type=PROTOBUF, schema=syntax = "proto3";
package com.codingharbour.protobuf;

option java_outer_classname = "SimpleMessageProtos";

message SimpleMessage {
  string content = 1;
  string date_time = 2;
  string content2 = 3;
}
)
        subject    = 'subject42292f41'
karapace/serialization.py:79: in post_new_schema
    result = await self.client.post(f"subjects/{quote(subject)}/versions", json=payload)
        payload    = {'schema': 'syntax = "proto3";\npackage com.codingharbour.protobuf;\n\noption java_outer_classname = "SimpleMessagePro...impleMessage {\n  string content = 1;\n  string date_time = 2;\n  string content2 = 3;\n}\n', 'schemaType': 'PROTOBUF'}
        schema     = TypedSchema(type=PROTOBUF, schema=syntax = "proto3";
package com.codingharbour.protobuf;

option java_outer_classname = "SimpleMessageProtos";

message SimpleMessage {
  string content = 1;
  string date_time = 2;
  string content2 = 3;
}
)
        self       = <karapace.serialization.SchemaRegistryClient object at 0x7f4391343fd0>
        subject    = 'subject42292f41'
karapace/utils.py:192: in post
    json_result = {} if res.status == 204 else await res.json()
        client     = <aiohttp.test_utils.TestClient object at 0x7f43911be040>
        headers    = {'Content-Type': 'application/vnd.schemaregistry.v1+json'}
        json       = {'schema': 'syntax = "proto3";\npackage com.codingharbour.protobuf;\n\noption java_outer_classname = "SimpleMessagePro...impleMessage {\n  string content = 1;\n  string date_time = 2;\n  string content2 = 3;\n}\n', 'schemaType': 'PROTOBUF'}
        path       = 'subjects/subject42292f41/versions'
        res        = <ClientResponse(http://127.0.0.1:40807/subjects/subject42292f41/versions) [500 Internal Server Error]>
<CIMultiDictPro...e9b018', 'Content-Length': '52', 'Content-Type': 'application/octet-stream', 'Date': 'Wed, 16 Mar 2022 10:33:40 GMT')>

        self       = <karapace.utils.Client object at 0x7f439122e7f0>
../karapace-venv-3.8/lib64/python3.8/site-packages/aiohttp/client_reqrep.py:1103: in json
    raise ContentTypeError(
E   aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: application/octet-stream', url=URL('http://127.0.0.1:40807/subjects/subject42292f41/versions')
        content_type = 'application/json'
        ctype      = 'application/octet-stream'
        encoding   = None
        loads      = <function loads at 0x7f43992f0d30>
        self       = <ClientResponse(http://127.0.0.1:40807/subjects/subject42292f41/versions) [500 Internal Server Error]>
<CIMultiDictPro...e9b018', 'Content-Length': '52', 'Content-Type': 'application/octet-stream', 'Date': 'Wed, 16 Mar 2022 10:33:40 GMT')>
```