### PR TITLE
Fix protobuf in container image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -49,11 +49,11 @@ LABEL org.opencontainers.image.authors=opensource@aiven.io \
 
 RUN groupadd --system karapace && \
     useradd --system --gid karapace karapace && \
-    mkdir /opt/karapace /var/log/karapace && \
+    mkdir /opt/karapace /opt/karapace/runtime /var/log/karapace && \
     chown --recursive karapace:karapace /opt/karapace /var/log/karapace
 
 RUN apt-get update && \
-    apt-get -y install --no-install-recommends python3-pip && \
+    apt-get -y install --no-install-recommends python3-pip protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/dependencies-wheels/*.whl /build/dependencies-wheels/


### PR DESCRIPTION
# About this change - What it does

Fix protobuf in container image

Noticed while doing local test testing for #359. Also noticed that some integration tests cannot be run against separately started Karapace instance, most notably https://github.com/aiven/karapace/blob/6c818230eeefef2b0e629f9ed71270c2b51b81ef/tests/integration/test_rest.py#L182 due not suitable fixture.

# Why this way

Create directory for internal use inside container image and install required dependencies to support Protobuf with the container image.
