### PR TITLE
perf: Skip deepcopy

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -12,11 +12,12 @@ from karapace.karapace import KarapaceBase
 from karapace.rapu import HTTPRequest
 from karapace.schema_reader import SchemaType
 from karapace.serialization import InvalidMessageSchema, InvalidPayload, SchemaRegistrySerializer, SchemaRetrievalError
-from karapace.utils import convert_to_int, deepcopy, KarapaceKafkaClient
+from karapace.utils import convert_to_int, KarapaceKafkaClient
 from typing import List, Optional, Tuple
 
 import asyncio
 import base64
+import copy
 import logging
 import time
 import ujson
@@ -285,7 +286,7 @@ class KafkaRest(KarapaceBase):
                 self._cluster_metadata = None
 
             if self._cluster_metadata and topics is None:
-                return deepcopy(self._cluster_metadata)
+                return copy.deepcopy(self._cluster_metadata)
 
             try:
                 metadata_birth = time.monotonic()
@@ -304,7 +305,7 @@ class KafkaRest(KarapaceBase):
                     content_type="application/json",
                     status=HTTPStatus.INTERNAL_SERVER_ERROR,
                 )
-            return deepcopy(metadata)
+            return copy.deepcopy(metadata)
 
     def init_admin_client(self):
         while True:

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -17,7 +17,6 @@ from typing import List, Optional, Tuple
 
 import asyncio
 import base64
-import copy
 import logging
 import time
 import ujson
@@ -286,7 +285,7 @@ class KafkaRest(KarapaceBase):
                 self._cluster_metadata = None
 
             if self._cluster_metadata and topics is None:
-                return copy.deepcopy(self._cluster_metadata)
+                return self._cluster_metadata
 
             try:
                 metadata_birth = time.monotonic()
@@ -305,7 +304,7 @@ class KafkaRest(KarapaceBase):
                     content_type="application/json",
                     status=HTTPStatus.INTERNAL_SERVER_ERROR,
                 )
-            return copy.deepcopy(metadata)
+            return metadata
 
     def init_admin_client(self):
         while True:
@@ -685,5 +684,6 @@ class KafkaRest(KarapaceBase):
 
     async def list_brokers(self, content_type: str):
         metadata = await self.cluster_metadata()
+        metadata = metadata.copy()  # shallow copy as we want to mutate it
         metadata.pop("topics")
         self.r(metadata, content_type)

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -7,7 +7,7 @@ See LICENSE for details
 from functools import partial
 from http import HTTPStatus
 from kafka.client_async import BrokerConnection, KafkaClient, MetadataRequest
-from typing import Any, NoReturn, Optional
+from typing import NoReturn, Optional
 from urllib.parse import urljoin
 
 import aiohttp
@@ -20,22 +20,9 @@ import requests
 import ssl
 import time
 import types
-import ujson
 
 log = logging.getLogger("KarapaceUtils")
 NS_BLACKOUT_DURATION_SECONDS = 120
-
-
-def deepcopy(obj: Any) -> Any:
-    """Replacement for the standard library deepcopy.
-
-    The stdlib's copy.deepcopy is notoriously slow. After benchmarking the REST Proxy produce API
-    the deepcopy was identified as a bottleneck. Currently it is faster to encode the objects as
-    json and decode the result instead of using copy.deepcopy.
-    """
-    encoded = ujson.dumps(obj)
-    copy = ujson.loads(encoded)
-    return copy
 
 
 def isoformat(datetime_obj=None, *, preserve_subsecond=False, compact=False):

--- a/tests/integration/test_rest_consumer.py
+++ b/tests/integration/test_rest_consumer.py
@@ -1,4 +1,3 @@
-from karapace.utils import deepcopy
 from tests.utils import (
     consumer_valid_payload,
     new_consumer,
@@ -245,7 +244,7 @@ async def test_consume(rest_async_client, admin_client, producer, trail):
     deserializers = {"binary": base64.b64decode, "json": lambda x: ujson.dumps(x).encode("utf-8")}
     group_name = "consume_group"
     for fmt in ["binary", "json"]:
-        header = deepcopy(REST_HEADERS[fmt])
+        header = copy.deepcopy(REST_HEADERS[fmt])
         instance_id = await new_consumer(rest_async_client, group_name, fmt=fmt, trail=trail)
         assign_path = f"/consumers/{group_name}/instances/{instance_id}/assignments{trail}"
         seek_path = f"/consumers/{group_name}/instances/{instance_id}/positions/beginning{trail}"

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -11,10 +11,10 @@ from karapace.serialization import (
     START_BYTE,
     write_value,
 )
-from karapace.utils import deepcopy
 from tests.utils import test_objects_avro
 
 import avro
+import copy
 import io
 import logging
 import pytest
@@ -255,7 +255,7 @@ async def test_deserialization_fails(default_config_path, mock_registry_client):
 
     # but we can pass in a perfectly fine doc belonging to a diff schema
     schema = await mock_registry_client.get_schema_for_id(1)
-    schema = deepcopy(schema.to_json())
+    schema = copy.deepcopy(schema.to_json())
     schema["name"] = "BadUser"
     schema["fields"][0]["type"] = "int"
     obj = {"name": 100, "favorite_number": 2, "favorite_color": "bar"}


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
Deepcopy uses most of the CPU currently when publishing to a topic. 

<!-- Provide a small sentence that summarizes the change. -->

Deepcopy is not necessary. So not doing it. Do one shallow copy where it matters (reading from dicts is async thread safe in Python anyway, so reusing same structure without making copy of it should be fine).

<!-- Provide the issue number below if it exists. -->

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
