### PR TITLE
Handle incompatible schemas with produce endpoint

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -464,6 +464,15 @@ class KafkaRest(KarapaceBase):
                 content_type=content_type,
                 status=HTTPStatus.BAD_REQUEST,
             )
+        except SchemaRetrievalError:
+            self.r(
+                body={
+                    "error_code": RESTErrorCodes.SCHEMA_RETRIEVAL_ERROR.value,
+                    "message": f"Error when registering schema. format = {schema_type}, subject = {topic}-{prefix}",
+                },
+                content_type=content_type,
+                status=HTTPStatus.REQUEST_TIMEOUT,
+            )
 
     async def _prepare_records(
         self,


### PR DESCRIPTION
# About this change - What it does

Handle incompatible schemas with produce endpoint

# Why this way

Produce message endpoint takes full schemas with the message in some cases, and registers the schema during producing the message.  Produce endpoint needs to handle also case if the schema is not compatible with a valid error message.
