### PR TITLE
Handle schema message as string from schemas topic

### DIFF
--- a/karapace/compatibility/__init__.py
+++ b/karapace/compatibility/__init__.py
@@ -17,7 +17,8 @@ from jsonschema import Draft7Validator
 from karapace.compatibility.jsonschema.checks import compatibility as jsonschema_compatibility, incompatible_schema
 from karapace.compatibility.protobuf.checks import check_protobuf_schema_compatibility
 from karapace.protobuf.schema import ProtobufSchema
-from karapace.schema_reader import SchemaType, TypedSchema
+from karapace.schema_models import ValidatedTypedSchema
+from karapace.schema_reader import SchemaType
 from karapace.utils import assert_never
 
 import logging
@@ -75,7 +76,7 @@ def check_protobuf_compatibility(reader: ProtobufSchema, writer: ProtobufSchema)
 
 
 def check_compatibility(
-    old_schema: TypedSchema, new_schema: TypedSchema, compatibility_mode: CompatibilityModes
+    old_schema: ValidatedTypedSchema, new_schema: ValidatedTypedSchema, compatibility_mode: CompatibilityModes
 ) -> SchemaCompatibilityResult:
     """Check that `old_schema` and `new_schema` are compatible under `compatibility_mode`."""
     if old_schema.schema_type is not new_schema.schema_type:

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -1,0 +1,159 @@
+from avro.errors import SchemaParseException
+from avro.schema import parse as avro_parse, Schema as AvroSchema
+from enum import Enum, unique
+from jsonschema import Draft7Validator
+from jsonschema.exceptions import SchemaError
+from karapace.protobuf.exception import (
+    Error as ProtobufError,
+    IllegalArgumentException,
+    IllegalStateException,
+    ProtobufException,
+    ProtobufParserRuntimeException,
+    SchemaParseException as ProtobufSchemaParseException,
+)
+from karapace.protobuf.schema import ProtobufSchema
+from karapace.utils import json_encode
+from typing import Any, Dict, Union
+
+import json
+import logging
+import ujson
+
+log = logging.getLogger(__name__)
+
+
+def parse_avro_schema_definition(s: str) -> AvroSchema:
+    """Compatibility function with Avro which ignores trailing data in JSON
+    strings.
+
+    The Python stdlib `json` module doesn't allow to ignore trailing data. If
+    parsing fails because of it, the extra data can be removed and parsed
+    again.
+    """
+    try:
+        json_data = json.loads(s)
+    except json.JSONDecodeError as e:
+        if e.msg != "Extra data":
+            raise
+
+        json_data = json.loads(s[: e.pos])
+
+    return avro_parse(json.dumps(json_data))
+
+
+def parse_jsonschema_definition(schema_definition: str) -> Draft7Validator:
+    """Parses and validates `schema_definition`.
+
+    Raises:
+        SchemaError: If `schema_definition` is not a valid Draft7 schema.
+    """
+    schema = ujson.loads(schema_definition)
+    Draft7Validator.check_schema(schema)
+    return Draft7Validator(schema)
+
+
+def parse_protobuf_schema_definition(schema_definition: str) -> ProtobufSchema:
+    """Parses and validates `schema_definition`.
+
+    Raises:
+        Nothing yet.
+
+    """
+
+    return ProtobufSchema(schema_definition)
+
+
+class InvalidSchemaType(Exception):
+    pass
+
+
+class InvalidSchema(Exception):
+    pass
+
+
+@unique
+class SchemaType(str, Enum):
+    AVRO = "AVRO"
+    JSONSCHEMA = "JSON"
+    PROTOBUF = "PROTOBUF"
+
+
+class TypedSchema:
+    def __init__(self, schema_type: SchemaType, schema_str: str):
+        """Schema with type information
+
+        Args:
+            schema_type (SchemaType): The type of the schema
+            schema_str (str): The original schema string
+        """
+        self.schema_type = schema_type
+        self.schema_str = schema_str
+
+    def to_json(self) -> Dict[str, Any]:
+        if self.schema_type is SchemaType.PROTOBUF:
+            raise InvalidSchema("Protobuf do not support to_json serialization")
+        return ujson.loads(self.schema_str)
+
+    def __str__(self) -> str:
+        if self.schema_type == SchemaType.PROTOBUF:
+            return self.schema_str
+        return json_encode(self.to_json(), compact=True)
+
+    def __repr__(self) -> str:
+        if self.schema_type == SchemaType.PROTOBUF:
+            return f"TypedSchema(type={self.schema_type}, schema={str(self)})"
+        return f"TypedSchema(type={self.schema_type}, schema={json_encode(self.to_json())})"
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, TypedSchema) and self.__str__() == other.__str__() and self.schema_type is other.schema_type
+
+
+class ValidatedTypedSchema(TypedSchema):
+    def __init__(self, schema_type: SchemaType, schema_str: str, schema: Union[Draft7Validator, AvroSchema, ProtobufSchema]):
+        super().__init__(schema_type=schema_type, schema_str=schema_str)
+        self.schema = schema
+
+    @staticmethod
+    def parse(schema_type: SchemaType, schema_str: str) -> "ValidatedTypedSchema":
+        if schema_type not in [SchemaType.AVRO, SchemaType.JSONSCHEMA, SchemaType.PROTOBUF]:
+            raise InvalidSchema(f"Unknown parser {schema_type} for {schema_str}")
+
+        parsed_schema: Union[Draft7Validator, AvroSchema, ProtobufSchema]
+        if schema_type is SchemaType.AVRO:
+            try:
+                parsed_schema = parse_avro_schema_definition(schema_str)
+            except (SchemaParseException, ValueError, TypeError) as e:
+                raise InvalidSchema from e
+
+        elif schema_type is SchemaType.JSONSCHEMA:
+            try:
+                parsed_schema = parse_jsonschema_definition(schema_str)
+                # TypeError - Raised when the user forgets to encode the schema as a string.
+            except (TypeError, ValueError, SchemaError, AssertionError) as e:
+                raise InvalidSchema from e
+
+        elif schema_type is SchemaType.PROTOBUF:
+            try:
+                parsed_schema = parse_protobuf_schema_definition(schema_str)
+            except (
+                TypeError,
+                SchemaError,
+                AssertionError,
+                ProtobufParserRuntimeException,
+                IllegalStateException,
+                IllegalArgumentException,
+                ProtobufError,
+                ProtobufException,
+                ProtobufSchemaParseException,
+            ) as e:
+                log.exception("Unexpected error: %s \n schema:[%s]", e, schema_str)
+                raise InvalidSchema from e
+        else:
+            raise InvalidSchema(f"Unknown parser {schema_type} for {schema_str}")
+
+        return ValidatedTypedSchema(schema_type=schema_type, schema_str=schema_str, schema=parsed_schema)
+
+    def __str__(self) -> str:
+        if self.schema_type == SchemaType.PROTOBUF:
+            return str(self.schema)
+        return super().__str__()

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -89,20 +89,20 @@ class TypedSchema:
         self.schema_type = schema_type
         self.schema_str = schema_str
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         if self.schema_type is SchemaType.PROTOBUF:
-            raise InvalidSchema("Protobuf do not support to_json serialization")
+            raise InvalidSchema("Protobuf do not support to_dict serialization")
         return ujson.loads(self.schema_str)
 
     def __str__(self) -> str:
         if self.schema_type == SchemaType.PROTOBUF:
             return self.schema_str
-        return json_encode(self.to_json(), compact=True)
+        return json_encode(self.to_dict(), compact=True)
 
     def __repr__(self) -> str:
         if self.schema_type == SchemaType.PROTOBUF:
             return f"TypedSchema(type={self.schema_type}, schema={str(self)})"
-        return f"TypedSchema(type={self.schema_type}, schema={json_encode(self.to_json())})"
+        return f"TypedSchema(type={self.schema_type}, schema={json_encode(self.to_dict())})"
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, TypedSchema) and self.__str__() == other.__str__() and self.schema_type is other.schema_type

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -874,7 +874,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
                     subject,
                     schema_id,
                     version,
-                    new_schema.to_json(),
+                    new_schema.to_dict(),
                     schema_id,
                 )
 

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -7,7 +7,8 @@ from karapace.compatibility.jsonschema.checks import is_incompatible
 from karapace.karapace import KarapaceBase
 from karapace.master_coordinator import MasterCoordinator
 from karapace.rapu import HTTPRequest
-from karapace.schema_reader import InvalidSchema, KafkaSchemaReader, SchemaType, TypedSchema
+from karapace.schema_models import InvalidSchema, InvalidSchemaType, ValidatedTypedSchema
+from karapace.schema_reader import KafkaSchemaReader, SchemaType, TypedSchema
 from karapace.utils import json_encode, KarapaceKafkaClient
 from typing import Any, Dict, Optional, Tuple
 
@@ -43,10 +44,6 @@ class SchemaErrorMessages(Enum):
         "forward, full, backward_transitive, forward_transitive, and "
         "full_transitive"
     )
-
-
-class InvalidSchemaType(Exception):
-    pass
 
 
 class KarapaceSchemaRegistry(KarapaceBase):
@@ -292,8 +289,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.log.info("Existing schema: %r, new_schema: %r", old["schema"], body["schema"])
         try:
             schema_type = SchemaType(body.get("schemaType", "AVRO"))
-            new_schema = TypedSchema.parse(schema_type, body["schema"])
-            new_schema.validate()
+            new_schema = ValidatedTypedSchema.parse(schema_type, body["schema"])
         except InvalidSchema:
             self.log.warning("Invalid schema: %r", body["schema"])
             self.r(
@@ -306,8 +302,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             )
         try:
             old_schema_type = SchemaType(old.get("schemaType", "AVRO"))
-            old_schema = TypedSchema.parse(old_schema_type, old["schema"])
-            old_schema.validate()
+            old_schema = ValidatedTypedSchema.parse(old_schema_type, old["schema"])
         except InvalidSchema:
             self.log.warning("Invalid existing schema: %r", old["schema"])
             self.r(
@@ -716,8 +711,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         schema_str = body["schema"]
         schema_type = SchemaType(body.get("schemaType", "AVRO"))
         try:
-            new_schema = TypedSchema.parse(schema_type, schema_str)
-            new_schema.validate()
+            new_schema = ValidatedTypedSchema.parse(schema_type, schema_str)
         except InvalidSchema:
             self.log.exception("No proper parser found")
             self.r(
@@ -772,8 +766,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.log.info("Writing new schema locally since we're the master")
         schema_type = SchemaType(body.get("schemaType", SchemaType.AVRO))
         try:
-            new_schema = TypedSchema.parse(schema_type=schema_type, schema_str=body["schema"])
-            new_schema.validate()
+            new_schema = ValidatedTypedSchema.parse(schema_type=schema_type, schema_str=body["schema"])
         except (InvalidSchema, InvalidSchemaType) as e:
             self.log.warning("Invalid schema: %r", body["schema"], exc_info=True)
             if isinstance(e.__cause__, (SchemaParseException, ValueError)):
@@ -843,8 +836,11 @@ class KarapaceSchemaRegistry(KarapaceBase):
 
             for old_version in check_against:
                 old_schema = subject_data["schemas"][old_version]["schema"]
+                validated_old_schema = ValidatedTypedSchema.parse(
+                    schema_type=old_schema.schema_type, schema_str=old_schema.schema_str
+                )
                 result = check_compatibility(
-                    old_schema=old_schema,
+                    old_schema=validated_old_schema,
                     new_schema=new_schema,
                     compatibility_mode=compatibility_mode,
                 )

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -293,6 +293,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         try:
             schema_type = SchemaType(body.get("schemaType", "AVRO"))
             new_schema = TypedSchema.parse(schema_type, body["schema"])
+            new_schema.validate()
         except InvalidSchema:
             self.log.warning("Invalid schema: %r", body["schema"])
             self.r(
@@ -306,6 +307,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         try:
             old_schema_type = SchemaType(old.get("schemaType", "AVRO"))
             old_schema = TypedSchema.parse(old_schema_type, old["schema"])
+            old_schema.validate()
         except InvalidSchema:
             self.log.warning("Invalid existing schema: %r", old["schema"])
             self.r(
@@ -715,6 +717,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         schema_type = SchemaType(body.get("schemaType", "AVRO"))
         try:
             new_schema = TypedSchema.parse(schema_type, schema_str)
+            new_schema.validate()
         except InvalidSchema:
             self.log.exception("No proper parser found")
             self.r(
@@ -770,6 +773,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         schema_type = SchemaType(body.get("schemaType", SchemaType.AVRO))
         try:
             new_schema = TypedSchema.parse(schema_type=schema_type, schema_str=body["schema"])
+            new_schema.validate()
         except (InvalidSchema, InvalidSchemaType) as e:
             self.log.warning("Invalid schema: %r", body["schema"], exc_info=True)
             if isinstance(e.__cause__, (SchemaParseException, ValueError)):

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -75,7 +75,7 @@ class SchemaRegistryClient:
         if schema.schema_type is SchemaType.PROTOBUF:
             payload = {"schema": str(schema), "schemaType": schema.schema_type.value}
         else:
-            payload = {"schema": json_encode(schema.to_json()), "schemaType": schema.schema_type.value}
+            payload = {"schema": json_encode(schema.to_dict()), "schemaType": schema.schema_type.value}
         result = await self.client.post(f"subjects/{quote(subject)}/versions", json=payload)
         if not result.ok:
             raise SchemaRetrievalError(result.json())
@@ -142,7 +142,7 @@ class SchemaRegistrySerializerDeserializer:
         if schema_type is SchemaType.AVRO:
             namespace = schema_typed.schema.namespace
         if schema_type is SchemaType.JSONSCHEMA:
-            namespace = schema_typed.to_json().get("namespace", "dummy")
+            namespace = schema_typed.to_dict().get("namespace", "dummy")
         #  Protobuf does not use namespaces in terms of AVRO
         if schema_type is SchemaType.PROTOBUF:
             namespace = ""

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,7 @@ strict_equality = True
 
 [mypy-ujson]
 ignore_errors = True
+ignore_missing_imports = True
 
 [mypy-karapace.schema_registry_apis]
 ignore_errors = True

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -11,7 +11,7 @@ async def test_remote_client(registry_async_client):
     sc_id = await reg_cli.post_new_schema(subject, schema_avro)
     assert sc_id >= 0
     stored_schema = await reg_cli.get_schema_for_id(sc_id)
-    assert stored_schema == schema_avro, f"stored schema {stored_schema.to_json()} is not {schema_avro.to_json()}"
+    assert stored_schema == schema_avro, f"stored schema {stored_schema.to_dict()} is not {schema_avro.to_dict()}"
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro
@@ -25,7 +25,7 @@ async def test_remote_client_tls(registry_async_client_tls):
     sc_id = await reg_cli.post_new_schema(subject, schema_avro)
     assert sc_id >= 0
     stored_schema = await reg_cli.get_schema_for_id(sc_id)
-    assert stored_schema == schema_avro, f"stored schema {stored_schema.to_json()} is not {schema_avro.to_json()}"
+    assert stored_schema == schema_avro, f"stored schema {stored_schema.to_dict()} is not {schema_avro.to_dict()}"
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,10 +1,10 @@
-from karapace.schema_reader import SchemaType, TypedSchema
+from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.serialization import SchemaRegistryClient
 from tests.utils import new_random_name, schema_avro_json
 
 
 async def test_remote_client(registry_async_client):
-    schema_avro = TypedSchema.parse(SchemaType.AVRO, schema_avro_json)
+    schema_avro = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
     reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")
@@ -18,7 +18,7 @@ async def test_remote_client(registry_async_client):
 
 
 async def test_remote_client_tls(registry_async_client_tls):
-    schema_avro = TypedSchema.parse(SchemaType.AVRO, schema_avro_json)
+    schema_avro = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
     reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client_tls
     subject = new_random_name("subject")

--- a/tests/integration/test_client_protobuf.py
+++ b/tests/integration/test_client_protobuf.py
@@ -1,12 +1,12 @@
 from karapace.protobuf.kotlin_wrapper import trim_margin
-from karapace.schema_reader import SchemaType, TypedSchema
+from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.serialization import SchemaRegistryClient
 from tests.schemas.protobuf import schema_protobuf_order_after, schema_protobuf_order_before, schema_protobuf_plain
 from tests.utils import new_random_name
 
 
 async def test_remote_client_protobuf(registry_async_client):
-    schema_protobuf = TypedSchema.parse(SchemaType.PROTOBUF, schema_protobuf_plain)
+    schema_protobuf = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, schema_protobuf_plain)
     reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")
@@ -20,8 +20,8 @@ async def test_remote_client_protobuf(registry_async_client):
 
 
 async def test_remote_client_protobuf2(registry_async_client):
-    schema_protobuf = TypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf_order_before))
-    schema_protobuf_after = TypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf_order_after))
+    schema_protobuf = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf_order_before))
+    schema_protobuf_after = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf_order_after))
     reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")

--- a/tests/schemas/json_schemas.py
+++ b/tests/schemas/json_schemas.py
@@ -1,4 +1,4 @@
-from karapace.schema_reader import parse_jsonschema_definition
+from karapace.schema_models import parse_jsonschema_definition
 
 # boolean schemas
 NOT_OF_EMPTY_SCHEMA = parse_jsonschema_definition('{"not":{}}')

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,5 @@
 from karapace.protobuf.kotlin_wrapper import trim_margin
-from karapace.schema_reader import SchemaType, TypedSchema
+from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from tests.utils import schema_avro_json, schema_protobuf, schema_protobuf2
 
 import pytest
@@ -10,10 +10,10 @@ class MockClient:
         pass
 
     async def get_schema_for_id(self, *args, **kwargs):  # pylint: disable=unused-argument,no-self-use
-        return TypedSchema.parse(SchemaType.AVRO, schema_avro_json)
+        return ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
 
     async def get_latest_schema(self, *args, **kwargs):  # pylint: disable=unused-argument,no-self-use
-        return 1, TypedSchema.parse(SchemaType.AVRO, schema_avro_json)
+        return 1, ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
 
     async def post_new_schema(self, *args, **kwargs):  # pylint: disable=unused-argument,no-self-use
         return 1
@@ -24,15 +24,15 @@ class MockProtobufClient:
         pass
 
     async def get_schema_for_id2(self, *args, **kwargs):  # pylint: disable=unused-argument,no-self-use
-        return TypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf2))
+        return ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf2))
 
     async def get_schema_for_id(self, *args, **kwargs):  # pylint: disable=unused-argument,no-self-use
         if args[0] != 1:
             return None
-        return TypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf))
+        return ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf))
 
     async def get_latest_schema(self, *args, **kwargs):  # pylint: disable=unused-argument,no-self-use
-        return 1, TypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf))
+        return 1, ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf))
 
     async def post_new_schema(self, *args, **kwargs):  # pylint: disable=unused-argument,no-self-use
         return 1

--- a/tests/unit/protobuf/test_protobuf_schema.py
+++ b/tests/unit/protobuf/test_protobuf_schema.py
@@ -2,7 +2,7 @@ from karapace.protobuf.compare_result import CompareResult
 from karapace.protobuf.kotlin_wrapper import trim_margin
 from karapace.protobuf.location import Location
 from karapace.protobuf.schema import ProtobufSchema
-from karapace.schema_reader import SchemaType, TypedSchema
+from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from tests.schemas.protobuf import (
     schema_protobuf_compare_one,
     schema_protobuf_order_after,
@@ -15,7 +15,7 @@ location: Location = Location.get("file.proto")
 
 def test_protobuf_schema_simple():
     proto = trim_margin(schema_protobuf_schema_registry1)
-    protobuf_schema = TypedSchema.parse(SchemaType.PROTOBUF, proto)
+    protobuf_schema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto)
     result = str(protobuf_schema)
 
     assert result == proto
@@ -23,7 +23,7 @@ def test_protobuf_schema_simple():
 
 def test_protobuf_schema_sort():
     proto = trim_margin(schema_protobuf_order_before)
-    protobuf_schema = TypedSchema.parse(SchemaType.PROTOBUF, proto)
+    protobuf_schema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto)
     result = str(protobuf_schema)
     proto2 = trim_margin(schema_protobuf_order_after)
     assert result == proto2
@@ -31,9 +31,9 @@ def test_protobuf_schema_sort():
 
 def test_protobuf_schema_compare():
     proto1 = trim_margin(schema_protobuf_order_after)
-    protobuf_schema1: TypedSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1)
+    protobuf_schema1: ValidatedTypedSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1)
     proto2 = trim_margin(schema_protobuf_compare_one)
-    protobuf_schema2: TypedSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2)
+    protobuf_schema2: ValidatedTypedSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2)
     result = CompareResult()
     protobuf_schema1.schema.compare(protobuf_schema2.schema, result)
     assert result.is_compatible()
@@ -41,9 +41,9 @@ def test_protobuf_schema_compare():
 
 def test_protobuf_schema_compare2():
     proto1 = trim_margin(schema_protobuf_order_after)
-    protobuf_schema1: TypedSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1)
+    protobuf_schema1: ValidatedTypedSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1)
     proto2 = trim_margin(schema_protobuf_compare_one)
-    protobuf_schema2: TypedSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2)
+    protobuf_schema2: ValidatedTypedSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2)
     result = CompareResult()
     protobuf_schema2.schema.compare(protobuf_schema1.schema, result)
     assert result.is_compatible()
@@ -85,8 +85,8 @@ def test_protobuf_schema_compare3():
                 |"""
 
     proto2 = trim_margin(proto2)
-    protobuf_schema1: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
-    protobuf_schema2: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
+    protobuf_schema1: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
+    protobuf_schema2: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
     result = CompareResult()
 
     protobuf_schema1.compare(protobuf_schema2, result)
@@ -120,8 +120,8 @@ def test_protobuf_message_compatible_label_alter():
 
     proto2 = trim_margin(proto2)
 
-    protobuf_schema1: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
-    protobuf_schema2: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
+    protobuf_schema1: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
+    protobuf_schema2: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
     result = CompareResult()
 
     protobuf_schema1.compare(protobuf_schema2, result)
@@ -149,8 +149,8 @@ def test_protobuf_field_type_incompatible_alter():
 
     proto2 = trim_margin(proto2)
 
-    protobuf_schema1: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
-    protobuf_schema2: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
+    protobuf_schema1: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
+    protobuf_schema2: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
     result = CompareResult()
 
     protobuf_schema1.compare(protobuf_schema2, result)
@@ -184,8 +184,8 @@ def test_protobuf_field_label_compatible_alter():
 
     proto2 = trim_margin(proto2)
 
-    protobuf_schema1: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
-    protobuf_schema2: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
+    protobuf_schema1: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
+    protobuf_schema2: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
     result = CompareResult()
 
     protobuf_schema1.compare(protobuf_schema2, result)
@@ -218,8 +218,8 @@ def test_protobuf_field_incompatible_drop_from_oneof():
 
     proto2 = trim_margin(proto2)
 
-    protobuf_schema1: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
-    protobuf_schema2: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
+    protobuf_schema1: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
+    protobuf_schema2: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
     result = CompareResult()
 
     protobuf_schema1.compare(protobuf_schema2, result)
@@ -250,8 +250,8 @@ def test_protobuf_field_incompatible_alter_to_oneof():
 
     proto2 = trim_margin(proto2)
 
-    protobuf_schema1: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
-    protobuf_schema2: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
+    protobuf_schema1: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
+    protobuf_schema2: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
     result = CompareResult()
 
     protobuf_schema1.compare(protobuf_schema2, result)
@@ -282,8 +282,8 @@ def test_protobuf_field_compatible_alter_to_oneof():
 
     proto2 = trim_margin(proto2)
 
-    protobuf_schema1: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
-    protobuf_schema2: ProtobufSchema = TypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
+    protobuf_schema1: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto1).schema
+    protobuf_schema2: ProtobufSchema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto2).schema
     result = CompareResult()
 
     protobuf_schema1.compare(protobuf_schema2, result)

--- a/tests/unit/test_avro_compatibility.py
+++ b/tests/unit/test_avro_compatibility.py
@@ -5,7 +5,7 @@
 from avro.compatibility import ReaderWriterCompatibilityChecker, SchemaCompatibilityResult, SchemaCompatibilityType
 from avro.name import Names
 from avro.schema import ArraySchema, Field, MapSchema, Schema, UnionSchema
-from karapace.schema_reader import parse_avro_schema_definition
+from karapace.schema_models import parse_avro_schema_definition
 
 import pytest
 import ujson

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1,5 +1,5 @@
 from karapace.config import DEFAULTS, read_config
-from karapace.schema_reader import SchemaType, TypedSchema
+from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.serialization import (
     flatten_unions,
     HEADER_FORMAT,
@@ -49,7 +49,7 @@ async def test_happy_flow(default_config_path, mock_registry_client):
 
 
 def test_flatten_unions_record() -> None:
-    typed_schema = TypedSchema.parse(
+    typed_schema = ValidatedTypedSchema.parse(
         SchemaType.AVRO,
         ujson.dumps(
             {
@@ -78,7 +78,7 @@ def test_flatten_unions_record() -> None:
 
 
 def test_flatten_unions_array() -> None:
-    typed_schema = TypedSchema.parse(
+    typed_schema = ValidatedTypedSchema.parse(
         SchemaType.AVRO,
         ujson.dumps(
             {
@@ -106,7 +106,7 @@ def test_flatten_unions_array() -> None:
 
 
 def test_flatten_unions_map() -> None:
-    typed_schema = TypedSchema.parse(
+    typed_schema = ValidatedTypedSchema.parse(
         SchemaType.AVRO,
         ujson.dumps(
             {
@@ -129,7 +129,7 @@ def test_flatten_unions_map() -> None:
     flatten_record = {"foo": {"attr1": "sample data"}}
     assert flatten_unions(typed_schema.schema, record) == flatten_record
 
-    typed_schema = TypedSchema.parse(
+    typed_schema = ValidatedTypedSchema.parse(
         SchemaType.AVRO,
         ujson.dumps({"type": "array", "items": ["null", "string", "int"]}),
     )
@@ -156,7 +156,7 @@ def test_avro_json_write_invalid() -> None:
         {"foo": "bar"},
     ]
 
-    typed_schema = TypedSchema.parse(SchemaType.AVRO, ujson.dumps(schema))
+    typed_schema = ValidatedTypedSchema.parse(SchemaType.AVRO, ujson.dumps(schema))
     bio = io.BytesIO()
 
     for record in records:
@@ -215,7 +215,7 @@ def test_avro_json_write_accepts_json_encoded_data_without_tagged_unions() -> No
             }
         ],
     }
-    typed_schema = TypedSchema.parse(SchemaType.AVRO, ujson.dumps(schema))
+    typed_schema = ValidatedTypedSchema.parse(SchemaType.AVRO, ujson.dumps(schema))
 
     properly_tagged_encoding_a = {"outter": {duplicated_name: {duplicated_name: "data"}}}
     properly_tagged_encoding_b = {"outter": {"int": 1}}

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -255,7 +255,7 @@ async def test_deserialization_fails(default_config_path, mock_registry_client):
 
     # but we can pass in a perfectly fine doc belonging to a diff schema
     schema = await mock_registry_client.get_schema_for_id(1)
-    schema = copy.deepcopy(schema.to_json())
+    schema = copy.deepcopy(schema.to_dict())
     schema["name"] = "BadUser"
     schema["fields"][0]["type"] = "int"
     obj = {"name": 100, "favorite_number": 2, "favorite_color": "bar"}


### PR DESCRIPTION
The schema topic may contain schemas that are invalid by later versions of Avro. The schema models are separated to validated model and non-validated.
Non-validated model is used as storage model. Validated model is used when new schemas are published and on compatibility checking.
This change allows Karapace to start up and serve schemas when invalid/unparseable schemas are present in the storage.

# Why this way

The schema parsing and validity is done when adding new schema. The data present in the schemas topic has passed
validation in the past. Although the schema parsing may have had defects and invalid schemas can be present.
The existence of such data should not prevent Karapace to function and serve these schemas.