### PR TITLE
Expose Expiration class

### DIFF
--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -76,15 +76,40 @@ class Timeout(Exception):
 
 @dataclass(frozen=True)
 class Expiration:
+    start_time: float
     deadline: float
 
     @classmethod
     def from_timeout(cls, timeout: float) -> "Expiration":
-        return cls(time.monotonic() + timeout)
+        start_time = time.monotonic()
+        deadline = start_time + timeout
+        return cls(start_time, deadline)
 
-    def raise_if_expired(self, msg: str) -> None:
-        if time.monotonic() > self.deadline:
-            raise Timeout(msg)
+    @property
+    def elapsed(self) -> float:
+        return time.monotonic() - self.start_time
+
+    def is_expired(self) -> bool:
+        return time.monotonic() > self.deadline
+
+    def raise_timeout_if_expired(self, msg_format: str, *args: object, **kwargs: object) -> None:
+        """Raise `Timeout` if this object is expired.
+
+        Note:
+            This method is supposed to be used in a loop, e.g.:
+
+                expiration = Expiration.from_timeout(timeout=60)
+                while is_data_ready(data):
+                    expiration.raise_timeout_if_expired("something about", data)
+                    data = gather_data()
+
+            The exception message should be meaningful, so it may format data
+            into the message itself. However formatting is expensive and should
+            be done only when the deadline is expired, so this uses a similar
+            interface to `logging.<level>()`.
+        """
+        if self.is_expired():
+            raise Timeout(msg_format.format(*args, **kwargs))
 
 
 class Result:

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -4,6 +4,7 @@ karapace - utils
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from dataclasses import dataclass
 from functools import partial
 from http import HTTPStatus
 from kafka.client_async import BrokerConnection, KafkaClient, MetadataRequest
@@ -67,6 +68,23 @@ def json_encode(obj, *, compact=True, sort_keys=True, binary=False):
 
 def assert_never(value: NoReturn) -> NoReturn:
     raise RuntimeError(f"This code should never be reached, got: {value}")
+
+
+class Timeout(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class Expiration:
+    deadline: float
+
+    @classmethod
+    def from_timeout(cls, timeout: float) -> "Expiration":
+        return cls(time.monotonic() + timeout)
+
+    def raise_if_expired(self, msg: str) -> None:
+        if time.monotonic() > self.deadline:
+            raise Timeout(msg)
 
 
 class Result:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,11 +12,10 @@ from kafka.errors import LeaderNotAvailableError, NoBrokersAvailable
 from karapace.config import set_config_defaults, write_config
 from karapace.kafka_rest_apis import KafkaRest, KafkaRestAdminClient
 from karapace.schema_registry_apis import KarapaceSchemaRegistry
-from karapace.utils import Client
+from karapace.utils import Client, Expiration
 from pathlib import Path
 from subprocess import Popen
 from tests.utils import (
-    Expiration,
     get_random_port,
     KAFKA_PORT_RANGE,
     KafkaConfig,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -82,9 +82,11 @@ def wait_for_kafka(kafka_servers: KafkaServers, wait_time) -> None:
         expiration = Expiration.from_timeout(timeout=wait_time)
 
         list_topics_successful = False
-        msg = f"Could not contact kafka cluster on host `{server}`"
         while not list_topics_successful:
-            expiration.raise_if_expired(msg)
+            expiration.raise_timeout_if_expired(
+                msg_format="Could not contact kafka cluster on host `{server}`",
+                server=server,
+            )
             try:
                 KafkaRestAdminClient(bootstrap_servers=server).cluster_metadata()
             # ValueError:
@@ -112,15 +114,17 @@ def wait_for_port(
     wait_time: float = 20.0,
     ipv6: bool = False,
 ) -> None:
-    start_time = time.monotonic()
-    expiration = Expiration(deadline=start_time + wait_time)
-    msg = f"Timeout waiting for `{hostname}:{port}`"
+    expiration = Expiration.from_timeout(wait_time)
 
     while not port_is_listening(hostname, port, ipv6):
-        expiration.raise_if_expired(msg)
+        expiration.raise_timeout_if_expired(
+            msg_format="Timeout waiting for `{hostname}:{port}`",
+            hostname=hostname,
+            port=port,
+        )
         time.sleep(2.0)
 
-    elapsed = time.monotonic() - start_time
+    elapsed = expiration.elapsed
     print(f"Server `{hostname}:{port}` listening after {elapsed} seconds")
 
 

--- a/tests/integration/test_schema_backup.py
+++ b/tests/integration/test_schema_backup.py
@@ -6,9 +6,9 @@ See LICENSE for details
 """
 from karapace.config import set_config_defaults
 from karapace.schema_backup import SchemaBackup
-from karapace.utils import Client
+from karapace.utils import Client, Expiration
 from pathlib import Path
-from tests.utils import Expiration, KafkaServers, new_random_name
+from tests.utils import KafkaServers, new_random_name
 
 import os
 import time

--- a/tests/integration/test_schema_backup.py
+++ b/tests/integration/test_schema_backup.py
@@ -79,7 +79,11 @@ async def test_backup_restore(
     all_subjects = []
     expiration = Expiration.from_timeout(timeout=10)
     while subject not in all_subjects:
-        expiration.raise_if_expired(msg=f"{subject} not in {all_subjects}")
+        expiration.raise_timeout_if_expired(
+            msg_format="{subject} not in {all_subjects}",
+            subject=subject,
+            all_subjects=all_subjects,
+        )
         res = await registry_async_client.get("subjects")
         assert res.status_code == 200
         all_subjects = res.json()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,14 +2,13 @@ from aiohttp.client_exceptions import ClientOSError, ServerDisconnectedError
 from dataclasses import dataclass
 from kafka.errors import TopicAlreadyExistsError
 from karapace.protobuf.kotlin_wrapper import trim_margin
-from karapace.utils import Client
+from karapace.utils import Client, Expiration
 from typing import Callable, List
 from urllib.parse import quote
 
 import asyncio
 import copy
 import random
-import time
 import ujson
 import uuid
 
@@ -167,10 +166,6 @@ REST_HEADERS = {
 }
 
 
-class Timeout(Exception):
-    pass
-
-
 @dataclass
 class KafkaConfig:
     datadir: str
@@ -200,19 +195,6 @@ class KafkaServers:
         )
         if not is_bootstrap_uris_valid:
             raise ValueError("bootstrap_servers must be a non-empty list of urls")
-
-
-@dataclass(frozen=True)
-class Expiration:
-    deadline: float
-
-    @classmethod
-    def from_timeout(cls, timeout: float) -> "Expiration":
-        return cls(time.monotonic() + timeout)
-
-    def raise_if_expired(self, msg: str) -> None:
-        if time.monotonic() > self.deadline:
-            raise Timeout(msg)
 
 
 @dataclass(frozen=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -306,7 +306,11 @@ async def wait_for_topics(rest_async_client: Client, topic_names: List[str], tim
 
         while not topic_found:
             await asyncio.sleep(sleep)
-            expiration.raise_if_expired(msg=f"New topic {topic} must be in the result of /topics. Result={current_topics}")
+            expiration.raise_timeout_if_expired(
+                msg_format="New topic {topic} must be in the result of /topics. Result={current_topics}",
+                topic=topic,
+                current_topics=current_topics,
+            )
             res = await rest_async_client.get("/topics")
             assert res.ok, f"Status code is not 200: {res.status_code}"
             current_topics = res.json()
@@ -331,7 +335,12 @@ async def repeat_until_successful_request(
 
     while not ok:
         await asyncio.sleep(sleep)
-        expiration.raise_if_expired(msg=f"{error_msg} {res} after {timeout} secs")
+        expiration.raise_timeout_if_expired(
+            msg_format=f"{error_msg} {res} after {timeout} secs",
+            error_msg=error_msg,
+            res=res,
+            timeout=timeout,
+        )
 
         try:
             res = await callback(path, json=json_data, headers=headers)


### PR DESCRIPTION
## What is this about?

I'm moving an utility class from the testing to the main codebase

## Why?

The motivation was this comment from @mhoffm-aiven https://github.com/aiven/karapace/pull/364#issuecomment-1081810314, the idea is to re-use that util to do the timeout and reply with a 204.

## What about the other changes?

I have not changed the APIs to actually return `204` because I found some issues, for example, the delete API sends multiple messages per request:

https://github.com/aiven/karapace/blob/f2746bb925a7687f24115c244ef517c36769618f/karapace/schema_registry_apis.py#L492-L499

So that needs some additional work, instead of having everything in a single PR I'm opening this separately so that it is easier to review.