### PR TITLE
Typing and simplification of the utils module

### DIFF
--- a/karapace/client.py
+++ b/karapace/client.py
@@ -29,9 +29,7 @@ class Result:
         json_result: JsonData,
         headers: Optional[Mapping] = None,
     ) -> None:
-        # We create both status and status_code so people can be agnostic on whichever to use
         self.status_code = status
-        self.status = status
         self.json_result = json_result
         self.headers = headers if headers else {}
 

--- a/karapace/client.py
+++ b/karapace/client.py
@@ -16,7 +16,7 @@ import ssl
 log = logging.getLogger(__name__)
 
 
-async def get_aiohttp_client() -> aiohttp.ClientSession:
+async def _get_aiohttp_client() -> aiohttp.ClientSession:
     return aiohttp.ClientSession()
 
 
@@ -40,7 +40,7 @@ class Result:
 
 
 class Client:
-    def __init__(self, server_uri=None, client_factory=get_aiohttp_client, server_ca: Optional[str] = None):
+    def __init__(self, server_uri=None, client_factory=_get_aiohttp_client, server_ca: Optional[str] = None):
         self.server_uri = server_uri or ""
         self.path_for = partial(urljoin, self.server_uri)
         self.session = requests.Session()

--- a/karapace/client.py
+++ b/karapace/client.py
@@ -4,163 +4,176 @@ karapace - utils
 Copyright (c) 2022 Aiven Ltd
 See LICENSE for details
 """
-from functools import partial
-from typing import Optional
+from aiohttp import ClientSession
+from collections.abc import Mapping
+from typing import Awaitable, Callable, Optional, Union
 from urllib.parse import urljoin
 
-import aiohttp
 import logging
-import requests
 import ssl
 
 log = logging.getLogger(__name__)
+Path = str
+Headers = dict
+JsonData = object  # Type of the result after parsing JSON
 
 
-async def _get_aiohttp_client() -> aiohttp.ClientSession:
-    return aiohttp.ClientSession()
+async def _get_aiohttp_client() -> ClientSession:
+    return ClientSession()
 
 
 class Result:
-    def __init__(self, status, json_result, headers=None):
+    def __init__(
+        self,
+        status: int,
+        json_result: JsonData,
+        headers: Optional[Mapping] = None,
+    ) -> None:
         # We create both status and status_code so people can be agnostic on whichever to use
         self.status_code = status
         self.status = status
         self.json_result = json_result
         self.headers = headers if headers else {}
 
-    def json(self):
+    def json(self) -> JsonData:
         return self.json_result
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Result(status=%d, json_result=%r)" % (self.status_code, self.json_result)
 
     @property
-    def ok(self):
+    def ok(self) -> bool:
         return 200 <= self.status_code < 300
 
 
 class Client:
-    def __init__(self, server_uri=None, client_factory=_get_aiohttp_client, server_ca: Optional[str] = None):
+    def __init__(
+        self,
+        server_uri: Optional[str] = None,
+        client_factory: Callable[[], Awaitable[ClientSession]] = _get_aiohttp_client,
+        server_ca: Optional[str] = None,
+    ) -> None:
         self.server_uri = server_uri or ""
-        self.path_for = partial(urljoin, self.server_uri)
-        self.session = requests.Session()
-        self.session.verify = server_ca
         # aiohttp requires to be in the same async loop when creating its client and when using it.
         # Since karapace Client object is initialized before creating the async context, (in
         # kafka_rest_api main, when KafkaRest is created), we can't create the aiohttp here.
         # Instead we wait for the first query in async context and lazy-initialize aiohttp client.
         self.client_factory = client_factory
+
+        self.ssl_mode: Union[None, bool, ssl.SSLContext]
         if server_ca is None:
             self.ssl_mode = False
         else:
             self.ssl_mode = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
             self.ssl_mode.load_verify_locations(cafile=server_ca)
-        self._client = None
+        self._client: Optional[ClientSession] = None
 
-    async def close(self):
-        try:
-            self.session.close()
-        except:  # pylint: disable=bare-except
-            log.info("Could not close session")
+    def path_for(self, path: Path) -> str:
+        return urljoin(self.server_uri, path)
+
+    async def close(self) -> None:
         try:
             if self._client is not None:
                 await self._client.close()
         except:  # pylint: disable=bare-except
             log.info("Could not close client")
 
-    async def get_client(self):
+    async def get_client(self) -> ClientSession:
         if self._client is None:
             self._client = await self.client_factory()
+
         return self._client
 
-    async def get(self, path, json=None, headers=None):
+    async def get(
+        self,
+        path: Path,
+        json: JsonData = None,
+        headers: Optional[Headers] = None,
+    ) -> Result:
         path = self.path_for(path)
         if not headers:
             headers = {}
         client = await self.get_client()
-        if client:
-            async with client.get(
-                path,
-                json=json,
-                headers=headers,
-                ssl=self.ssl_mode,
-            ) as res:
-                # required for forcing the response body conversion to json despite missing valid Accept headers
-                json_result = await res.json(content_type=None)
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = requests.get(path, headers=headers, json=json)
-            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
+        async with client.get(
+            path,
+            json=json,
+            headers=headers,
+            ssl=self.ssl_mode,
+        ) as res:
+            # required for forcing the response body conversion to json despite missing valid Accept headers
+            json_result = await res.json(content_type=None)
+            return Result(res.status, json_result, headers=res.headers)
 
-    async def delete(self, path, headers=None):
+    async def delete(
+        self,
+        path: Path,
+        headers: Optional[Headers] = None,
+    ) -> Result:
         path = self.path_for(path)
         if not headers:
             headers = {}
         client = await self.get_client()
-        if client:
-            async with client.delete(
-                path,
-                headers=headers,
-                ssl=self.ssl_mode,
-            ) as res:
-                json_result = {} if res.status == 204 else await res.json()
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = requests.delete(path, headers=headers)
-            json_result = {} if res.status_code == 204 else res.json()
-            return Result(status=res.status_code, json_result=json_result, headers=res.headers)
+        async with client.delete(
+            path,
+            headers=headers,
+            ssl=self.ssl_mode,
+        ) as res:
+            json_result = {} if res.status == 204 else await res.json()
+            return Result(res.status, json_result, headers=res.headers)
 
-    async def post(self, path, json, headers=None):
+    async def post(
+        self,
+        path: Path,
+        json: JsonData,
+        headers: Optional[Headers] = None,
+    ) -> Result:
         path = self.path_for(path)
         if not headers:
             headers = {"Content-Type": "application/vnd.schemaregistry.v1+json"}
 
         client = await self.get_client()
-        if client:
-            async with client.post(
-                path,
-                headers=headers,
-                json=json,
-                ssl=self.ssl_mode,
-            ) as res:
-                json_result = {} if res.status == 204 else await res.json()
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = self.session.post(path, headers=headers, json=json)
-            json_body = {} if res.status_code == 204 else res.json()
-            return Result(status=res.status_code, json_result=json_body, headers=res.headers)
+        async with client.post(
+            path,
+            headers=headers,
+            json=json,
+            ssl=self.ssl_mode,
+        ) as res:
+            json_result = {} if res.status == 204 else await res.json()
+            return Result(res.status, json_result, headers=res.headers)
 
-    async def put(self, path, json, headers=None):
+    async def put(
+        self,
+        path: Path,
+        json: JsonData,
+        headers: Optional[Headers] = None,
+    ) -> Result:
         path = self.path_for(path)
         if not headers:
             headers = {"Content-Type": "application/vnd.schemaregistry.v1+json"}
 
         client = await self.get_client()
-        if client:
-            async with client.put(
-                path,
-                headers=headers,
-                json=json,
-                ssl=self.ssl_mode,
-            ) as res:
-                json_result = await res.json()
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = self.session.put(path, headers=headers, json=json)
-            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
+        async with client.put(
+            path,
+            headers=headers,
+            json=json,
+            ssl=self.ssl_mode,
+        ) as res:
+            json_result = await res.json()
+            return Result(res.status, json_result, headers=res.headers)
 
-    async def put_with_data(self, path, data, headers):
+    async def put_with_data(
+        self,
+        path: Path,
+        data: JsonData,
+        headers: Optional[Headers],
+    ) -> Result:
         path = self.path_for(path)
         client = await self.get_client()
-        if client:
-            async with client.put(
-                path,
-                headers=headers,
-                data=data,
-                ssl=self.ssl_mode,
-            ) as res:
-                json_result = await res.json()
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = self.session.put(path, headers=headers, data=data)
-            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
+        async with client.put(
+            path,
+            headers=headers,
+            data=data,
+            ssl=self.ssl_mode,
+        ) as res:
+            json_result = await res.json()
+            return Result(res.status, json_result, headers=res.headers)

--- a/karapace/client.py
+++ b/karapace/client.py
@@ -1,0 +1,166 @@
+"""
+karapace - utils
+
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+from functools import partial
+from typing import Optional
+from urllib.parse import urljoin
+
+import aiohttp
+import logging
+import requests
+import ssl
+
+log = logging.getLogger(__name__)
+
+
+async def get_aiohttp_client() -> aiohttp.ClientSession:
+    return aiohttp.ClientSession()
+
+
+class Result:
+    def __init__(self, status, json_result, headers=None):
+        # We create both status and status_code so people can be agnostic on whichever to use
+        self.status_code = status
+        self.status = status
+        self.json_result = json_result
+        self.headers = headers if headers else {}
+
+    def json(self):
+        return self.json_result
+
+    def __repr__(self):
+        return "Result(status=%d, json_result=%r)" % (self.status_code, self.json_result)
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 300
+
+
+class Client:
+    def __init__(self, server_uri=None, client_factory=get_aiohttp_client, server_ca: Optional[str] = None):
+        self.server_uri = server_uri or ""
+        self.path_for = partial(urljoin, self.server_uri)
+        self.session = requests.Session()
+        self.session.verify = server_ca
+        # aiohttp requires to be in the same async loop when creating its client and when using it.
+        # Since karapace Client object is initialized before creating the async context, (in
+        # kafka_rest_api main, when KafkaRest is created), we can't create the aiohttp here.
+        # Instead we wait for the first query in async context and lazy-initialize aiohttp client.
+        self.client_factory = client_factory
+        if server_ca is None:
+            self.ssl_mode = False
+        else:
+            self.ssl_mode = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            self.ssl_mode.load_verify_locations(cafile=server_ca)
+        self._client = None
+
+    async def close(self):
+        try:
+            self.session.close()
+        except:  # pylint: disable=bare-except
+            log.info("Could not close session")
+        try:
+            if self._client is not None:
+                await self._client.close()
+        except:  # pylint: disable=bare-except
+            log.info("Could not close client")
+
+    async def get_client(self):
+        if self._client is None:
+            self._client = await self.client_factory()
+        return self._client
+
+    async def get(self, path, json=None, headers=None):
+        path = self.path_for(path)
+        if not headers:
+            headers = {}
+        client = await self.get_client()
+        if client:
+            async with client.get(
+                path,
+                json=json,
+                headers=headers,
+                ssl=self.ssl_mode,
+            ) as res:
+                # required for forcing the response body conversion to json despite missing valid Accept headers
+                json_result = await res.json(content_type=None)
+                return Result(res.status, json_result, headers=res.headers)
+        elif self.server_uri:
+            res = requests.get(path, headers=headers, json=json)
+            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
+
+    async def delete(self, path, headers=None):
+        path = self.path_for(path)
+        if not headers:
+            headers = {}
+        client = await self.get_client()
+        if client:
+            async with client.delete(
+                path,
+                headers=headers,
+                ssl=self.ssl_mode,
+            ) as res:
+                json_result = {} if res.status == 204 else await res.json()
+                return Result(res.status, json_result, headers=res.headers)
+        elif self.server_uri:
+            res = requests.delete(path, headers=headers)
+            json_result = {} if res.status_code == 204 else res.json()
+            return Result(status=res.status_code, json_result=json_result, headers=res.headers)
+
+    async def post(self, path, json, headers=None):
+        path = self.path_for(path)
+        if not headers:
+            headers = {"Content-Type": "application/vnd.schemaregistry.v1+json"}
+
+        client = await self.get_client()
+        if client:
+            async with client.post(
+                path,
+                headers=headers,
+                json=json,
+                ssl=self.ssl_mode,
+            ) as res:
+                json_result = {} if res.status == 204 else await res.json()
+                return Result(res.status, json_result, headers=res.headers)
+        elif self.server_uri:
+            res = self.session.post(path, headers=headers, json=json)
+            json_body = {} if res.status_code == 204 else res.json()
+            return Result(status=res.status_code, json_result=json_body, headers=res.headers)
+
+    async def put(self, path, json, headers=None):
+        path = self.path_for(path)
+        if not headers:
+            headers = {"Content-Type": "application/vnd.schemaregistry.v1+json"}
+
+        client = await self.get_client()
+        if client:
+            async with client.put(
+                path,
+                headers=headers,
+                json=json,
+                ssl=self.ssl_mode,
+            ) as res:
+                json_result = await res.json()
+                return Result(res.status, json_result, headers=res.headers)
+        elif self.server_uri:
+            res = self.session.put(path, headers=headers, json=json)
+            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
+
+    async def put_with_data(self, path, data, headers):
+        path = self.path_for(path)
+        client = await self.get_client()
+        if client:
+            async with client.put(
+                path,
+                headers=headers,
+                data=data,
+                ssl=self.ssl_mode,
+            ) as res:
+                json_result = await res.json()
+                return Result(res.status, json_result, headers=res.headers)
+        elif self.server_uri:
+            res = self.session.put(path, headers=headers, data=data)
+            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)

--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -339,7 +339,7 @@ class RestApp:
             headers.update(self.cors_and_server_headers_for_request(request=rapu_request))
 
             if isinstance(data, (dict, list)):
-                resp_bytes = json_encode(data, binary=True, sort_keys=True, compact=True)
+                resp_bytes = json_encode(data, binary=True, sort_keys=True)
             elif isinstance(data, str):
                 if "Content-Type" not in headers:
                     headers["Content-Type"] = "text/plain; charset=utf-8"

--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -339,7 +339,7 @@ class RestApp:
             headers.update(self.cors_and_server_headers_for_request(request=rapu_request))
 
             if isinstance(data, (dict, list)):
-                resp_bytes = json_encode(data, binary=True, sort_keys=True)
+                resp_bytes = json_encode(data, binary=True)
             elif isinstance(data, str):
                 if "Content-Type" not in headers:
                     headers["Content-Type"] = "text/plain; charset=utf-8"

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -97,7 +97,7 @@ class TypedSchema:
     def __str__(self) -> str:
         if self.schema_type == SchemaType.PROTOBUF:
             return self.schema_str
-        return json_encode(self.to_dict(), compact=True)
+        return json_encode(self.to_dict())
 
     def __repr__(self) -> str:
         if self.schema_type == SchemaType.PROTOBUF:

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -262,7 +262,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             }
             if schema.schema_type is not SchemaType.AVRO:
                 valuedict["schemaType"] = schema.schema_type
-            value = json_encode(valuedict, compact=True)
+            value = json_encode(valuedict)
         else:
             value = ""
         return self.send_kafka_message(key, value)

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -1,10 +1,11 @@
 from avro.io import BinaryDecoder, BinaryEncoder, DatumReader, DatumWriter
 from google.protobuf.message import DecodeError
 from jsonschema import ValidationError
+from karapace.client import Client
 from karapace.protobuf.exception import ProtobufTypeException
 from karapace.protobuf.io import ProtobufDatumReader, ProtobufDatumWriter
 from karapace.schema_models import InvalidSchema, SchemaType, TypedSchema, ValidatedTypedSchema
-from karapace.utils import Client, json_encode
+from karapace.utils import json_encode
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import quote
 

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -67,12 +67,12 @@ def default_json_serialization(  # pylint: disable=inconsistent-return-statement
     assert_never("Object of type {!r} is not JSON serializable".format(obj.__class__.__name__))
 
 
-def json_encode(obj, *, compact=True, sort_keys=True, binary=False):
+def json_encode(obj, *, sort_keys=True, binary=False):
     res = jsonlib.dumps(
         obj,
-        sort_keys=sort_keys if sort_keys is not None else not compact,
-        indent=None if compact else 4,
-        separators=(",", ":") if compact else None,
+        sort_keys=sort_keys if sort_keys is not None else False,
+        indent=None,
+        separators=(",", ":"),
         default=default_json_serialization,
     )
     return res.encode("utf-8") if binary else res

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -67,10 +67,10 @@ def default_json_serialization(  # pylint: disable=inconsistent-return-statement
     assert_never("Object of type {!r} is not JSON serializable".format(obj.__class__.__name__))
 
 
-def json_encode(obj, *, sort_keys=True, binary=False):
+def json_encode(obj, *, sort_keys: bool = True, binary=False):
     res = jsonlib.dumps(
         obj,
-        sort_keys=sort_keys if sort_keys is not None else False,
+        sort_keys=sort_keys,
         indent=None,
         separators=(",", ":"),
         default=default_json_serialization,

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -12,10 +12,10 @@ from kafka.client_async import BrokerConnection, KafkaClient, MetadataRequest
 from types import MappingProxyType
 from typing import NoReturn, overload, Union
 
-import json as jsonlib
 import kafka.client_async
 import logging
 import time
+import ujson
 
 log = logging.getLogger("KarapaceUtils")
 NS_BLACKOUT_DURATION_SECONDS = 120
@@ -68,11 +68,9 @@ def default_json_serialization(  # pylint: disable=inconsistent-return-statement
 
 
 def json_encode(obj, *, sort_keys: bool = True, binary=False):
-    res = jsonlib.dumps(
+    res = ujson.dumps(
         obj,
         sort_keys=sort_keys,
-        indent=None,
-        separators=(",", ":"),
         default=default_json_serialization,
     )
     return res.encode("utf-8") if binary else res

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -26,25 +26,20 @@ log = logging.getLogger("KarapaceUtils")
 NS_BLACKOUT_DURATION_SECONDS = 120
 
 
-def isoformat(datetime_obj=None, *, preserve_subsecond=False, compact=False):
+def _isoformat(datetime_obj: datetime.datetime) -> str:
     """Return datetime to ISO 8601 variant suitable for users.
-    Assume UTC for datetime objects without a timezone, always use
-    the Z timezone designator."""
-    if datetime_obj is None:
-        datetime_obj = datetime.datetime.utcnow()
-    elif datetime_obj.tzinfo:
+
+    Assume UTC for datetime objects without a timezone, always use the Z
+    timezone designator.
+    """
+    if datetime_obj.tzinfo:
         datetime_obj = datetime_obj.astimezone(datetime.timezone.utc).replace(tzinfo=None)
-    isof = datetime_obj.isoformat()
-    if not preserve_subsecond:
-        isof = isof[:19]
-    if compact:
-        isof = isof.replace("-", "").replace(":", "").replace(".", "")
-    return isof + "Z"
+    return datetime_obj.isoformat() + "Z"
 
 
 def default_json_serialization(obj):
     if isinstance(obj, datetime.datetime):
-        return isoformat(obj, preserve_subsecond=True)
+        return _isoformat(obj)
     if isinstance(obj, datetime.timedelta):
         return obj.total_seconds()
     if isinstance(obj, decimal.Decimal):

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -7,19 +7,14 @@ See LICENSE for details
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from functools import partial
 from http import HTTPStatus
 from kafka.client_async import BrokerConnection, KafkaClient, MetadataRequest
 from types import MappingProxyType
-from typing import NoReturn, Optional, overload, Union
-from urllib.parse import urljoin
+from typing import NoReturn, overload, Union
 
-import aiohttp
 import json as jsonlib
 import kafka.client_async
 import logging
-import requests
-import ssl
 import time
 
 log = logging.getLogger("KarapaceUtils")
@@ -127,156 +122,6 @@ class Expiration:
         """
         if self.is_expired():
             raise Timeout(msg_format.format(*args, **kwargs))
-
-
-class Result:
-    def __init__(self, status, json_result, headers=None):
-        # We create both status and status_code so people can be agnostic on whichever to use
-        self.status_code = status
-        self.status = status
-        self.json_result = json_result
-        self.headers = headers if headers else {}
-
-    def json(self):
-        return self.json_result
-
-    def __repr__(self):
-        return "Result(status=%d, json_result=%r)" % (self.status_code, self.json_result)
-
-    @property
-    def ok(self):
-        return 200 <= self.status_code < 300
-
-
-async def get_aiohttp_client() -> aiohttp.ClientSession:
-    return aiohttp.ClientSession()
-
-
-class Client:
-    def __init__(self, server_uri=None, client_factory=get_aiohttp_client, server_ca: Optional[str] = None):
-        self.server_uri = server_uri or ""
-        self.path_for = partial(urljoin, self.server_uri)
-        self.session = requests.Session()
-        self.session.verify = server_ca
-        # aiohttp requires to be in the same async loop when creating its client and when using it.
-        # Since karapace Client object is initialized before creating the async context, (in
-        # kafka_rest_api main, when KafkaRest is created), we can't create the aiohttp here.
-        # Instead we wait for the first query in async context and lazy-initialize aiohttp client.
-        self.client_factory = client_factory
-        if server_ca is None:
-            self.ssl_mode = False
-        else:
-            self.ssl_mode = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            self.ssl_mode.load_verify_locations(cafile=server_ca)
-        self._client = None
-
-    async def close(self):
-        try:
-            self.session.close()
-        except:  # pylint: disable=bare-except
-            log.info("Could not close session")
-        try:
-            if self._client is not None:
-                await self._client.close()
-        except:  # pylint: disable=bare-except
-            log.info("Could not close client")
-
-    async def get_client(self):
-        if self._client is None:
-            self._client = await self.client_factory()
-        return self._client
-
-    async def get(self, path, json=None, headers=None):
-        path = self.path_for(path)
-        if not headers:
-            headers = {}
-        client = await self.get_client()
-        if client:
-            async with client.get(
-                path,
-                json=json,
-                headers=headers,
-                ssl=self.ssl_mode,
-            ) as res:
-                # required for forcing the response body conversion to json despite missing valid Accept headers
-                json_result = await res.json(content_type=None)
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = requests.get(path, headers=headers, json=json)
-            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
-
-    async def delete(self, path, headers=None):
-        path = self.path_for(path)
-        if not headers:
-            headers = {}
-        client = await self.get_client()
-        if client:
-            async with client.delete(
-                path,
-                headers=headers,
-                ssl=self.ssl_mode,
-            ) as res:
-                json_result = {} if res.status == 204 else await res.json()
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = requests.delete(path, headers=headers)
-            json_result = {} if res.status_code == 204 else res.json()
-            return Result(status=res.status_code, json_result=json_result, headers=res.headers)
-
-    async def post(self, path, json, headers=None):
-        path = self.path_for(path)
-        if not headers:
-            headers = {"Content-Type": "application/vnd.schemaregistry.v1+json"}
-
-        client = await self.get_client()
-        if client:
-            async with client.post(
-                path,
-                headers=headers,
-                json=json,
-                ssl=self.ssl_mode,
-            ) as res:
-                json_result = {} if res.status == 204 else await res.json()
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = self.session.post(path, headers=headers, json=json)
-            json_body = {} if res.status_code == 204 else res.json()
-            return Result(status=res.status_code, json_result=json_body, headers=res.headers)
-
-    async def put(self, path, json, headers=None):
-        path = self.path_for(path)
-        if not headers:
-            headers = {"Content-Type": "application/vnd.schemaregistry.v1+json"}
-
-        client = await self.get_client()
-        if client:
-            async with client.put(
-                path,
-                headers=headers,
-                json=json,
-                ssl=self.ssl_mode,
-            ) as res:
-                json_result = await res.json()
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = self.session.put(path, headers=headers, json=json)
-            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
-
-    async def put_with_data(self, path, data, headers):
-        path = self.path_for(path)
-        client = await self.get_client()
-        if client:
-            async with client.put(
-                path,
-                headers=headers,
-                data=data,
-                ssl=self.ssl_mode,
-            ) as res:
-                json_result = await res.json()
-                return Result(res.status, json_result, headers=res.headers)
-        elif self.server_uri:
-            res = self.session.put(path, headers=headers, data=data)
-            return Result(status=res.status_code, json_result=res.json(), headers=res.headers)
 
 
 def convert_to_int(object_: dict, key: str, content_type: str):

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -122,7 +122,7 @@ class Expiration:
             raise Timeout(msg_format.format(*args, **kwargs))
 
 
-def convert_to_int(object_: dict, key: str, content_type: str):
+def convert_to_int(object_: dict, key: str, content_type: str) -> None:
     if object_.get(key) is None:
         return
     try:

--- a/mypy.ini
+++ b/mypy.ini
@@ -143,9 +143,6 @@ ignore_errors = True
 [mypy-karapace.utils]
 ignore_errors = True
 
-[mypy-karapace.client]
-ignore_errors = True
-
 [mypy-karapace.rapu]
 ignore_errors = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -143,6 +143,9 @@ ignore_errors = True
 [mypy-karapace.utils]
 ignore_errors = True
 
+[mypy-karapace.client]
+ignore_errors = True
+
 [mypy-karapace.rapu]
 ignore_errors = True
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@ karapace - conftest
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from aiohttp import ClientSession
 from contextlib import closing, ExitStack
 from dataclasses import asdict, dataclass
 from filelock import FileLock
@@ -243,7 +244,7 @@ async def fixture_rest_async_client(
         client = Client(server_uri=rest_url)
     else:
 
-        async def get_client():
+        async def get_client() -> ClientSession:
             return await aiohttp_client(rest_async.app)
 
         client = Client(client_factory=get_client)
@@ -364,7 +365,7 @@ async def fixture_registry_async_client(
         client = Client(server_uri=registry_url, server_ca=request.config.getoption("server_ca"))
     else:
 
-        async def get_client():
+        async def get_client() -> ClientSession:
             return await aiohttp_client(registry_async.app)
 
         client = Client(client_factory=get_client)
@@ -465,7 +466,7 @@ async def fixture_registry_async_client_tls(
         client = Client(server_uri=registry_url, server_ca=request.config.getoption("server_ca"))
     else:
 
-        async def get_client():
+        async def get_client() -> ClientSession:
             return await aiohttp_client(registry_async_tls.app)
 
         client = Client(client_factory=get_client, server_ca=server_ca)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,10 +9,11 @@ from dataclasses import asdict, dataclass
 from filelock import FileLock
 from kafka import KafkaProducer
 from kafka.errors import LeaderNotAvailableError, NoBrokersAvailable
+from karapace.client import Client
 from karapace.config import set_config_defaults, write_config
 from karapace.kafka_rest_apis import KafkaRest, KafkaRestAdminClient
 from karapace.schema_registry_apis import KarapaceSchemaRegistry
-from karapace.utils import Client, Expiration
+from karapace.utils import Expiration
 from pathlib import Path
 from subprocess import Popen
 from tests.utils import (

--- a/tests/integration/schema_registry/test_jsonschema.py
+++ b/tests/integration/schema_registry/test_jsonschema.py
@@ -1,7 +1,7 @@
 from jsonschema import Draft7Validator
+from karapace.client import Client
 from karapace.compatibility import CompatibilityModes
 from karapace.schema_reader import SchemaType
-from karapace.utils import Client
 from tests.schemas.json_schemas import (
     A_DINT_B_DINT_OBJECT_SCHEMA,
     A_DINT_B_INT_OBJECT_SCHEMA,

--- a/tests/integration/schema_registry/test_jsonschema.py
+++ b/tests/integration/schema_registry/test_jsonschema.py
@@ -121,7 +121,7 @@ async def not_schemas_are_compatible(
 
     # sanity check
     subject_res = await client.get(f"subjects/{subject}/versions")
-    assert subject_res.status == 404, "random subject should no exist {subject}"
+    assert subject_res.status_code == 404, "random subject should no exist {subject}"
 
     older_res = await client.post(
         f"subjects/{subject}/versions",
@@ -130,13 +130,13 @@ async def not_schemas_are_compatible(
             "schemaType": SchemaType.JSONSCHEMA.value,
         },
     )
-    assert older_res.status == 200, await debugging_details(newer, older, client, subject)
+    assert older_res.status_code == 200, await debugging_details(newer, older, client, subject)
     assert "id" in older_res.json(), await debugging_details(newer, older, client, subject)
 
     # enforce the target compatibility mode. not using the global setting
     # because that interfere with parallel runs.
     subject_config_res = await client.put(f"config/{subject}", json={"compatibility": compatibility_mode.value})
-    assert subject_config_res.status == 200
+    assert subject_config_res.status_code == 200
 
     newer_res = await client.post(
         f"subjects/{subject}/versions",
@@ -145,7 +145,7 @@ async def not_schemas_are_compatible(
             "schemaType": SchemaType.JSONSCHEMA.value,
         },
     )
-    assert newer_res.status != 200, await debugging_details(newer, older, client, subject)
+    assert newer_res.status_code != 200, await debugging_details(newer, older, client, subject)
 
     # Sanity check. The compatibility must be explicitly set because any
     # difference can result in unexpected errors.
@@ -164,7 +164,7 @@ async def schemas_are_compatible(
 
     # sanity check
     subject_res = await client.get(f"subjects/{subject}/versions")
-    assert subject_res.status == 404, "random subject should no exist {subject}"
+    assert subject_res.status_code == 404, "random subject should no exist {subject}"
 
     older_res = await client.post(
         f"subjects/{subject}/versions",
@@ -173,13 +173,13 @@ async def schemas_are_compatible(
             "schemaType": SchemaType.JSONSCHEMA.value,
         },
     )
-    assert older_res.status == 200, await debugging_details(newer, older, client, subject)
+    assert older_res.status_code == 200, await debugging_details(newer, older, client, subject)
     assert "id" in older_res.json(), await debugging_details(newer, older, client, subject)
 
     # enforce the target compatibility mode. not using the global setting
     # because that interfere with parallel runs.
     subject_config_res = await client.put(f"config/{subject}", json={"compatibility": compatibility_mode.value})
-    assert subject_config_res.status == 200
+    assert subject_config_res.status_code == 200
 
     newer_res = await client.post(
         f"subjects/{subject}/versions",
@@ -188,7 +188,7 @@ async def schemas_are_compatible(
             "schemaType": SchemaType.JSONSCHEMA.value,
         },
     )
-    assert newer_res.status == 200, await debugging_details(newer, older, client, subject)
+    assert newer_res.status_code == 200, await debugging_details(newer, older, client, subject)
     # Because the IDs are global, and the same schema is used in multiple
     # tests, their order is unknown.
     assert older_res.json()["id"] != newer_res.json()["id"], await debugging_details(newer, older, client, subject)
@@ -237,7 +237,7 @@ async def test_same_jsonschema_must_have_same_id(
         subject = new_random_name("subject")
 
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility.value})
-        assert res.status == 200
+        assert res.status_code == 200
 
         first_res = await registry_async_client.post(
             f"subjects/{subject}/versions{trail}",
@@ -246,7 +246,7 @@ async def test_same_jsonschema_must_have_same_id(
                 "schemaType": SchemaType.JSONSCHEMA.value,
             },
         )
-        assert first_res.status == 200
+        assert first_res.status_code == 200
         first_id = first_res.json().get("id")
         assert first_id
 
@@ -257,7 +257,7 @@ async def test_same_jsonschema_must_have_same_id(
                 "schemaType": SchemaType.JSONSCHEMA.value,
             },
         )
-        assert second_res.status == 200
+        assert second_res.status_code == 200
         assert first_id == second_res.json()["id"]
 
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,9 +1,10 @@
+from karapace.client import Client
 from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.serialization import SchemaRegistryClient
 from tests.utils import new_random_name, schema_avro_json
 
 
-async def test_remote_client(registry_async_client):
+async def test_remote_client(registry_async_client: Client) -> None:
     schema_avro = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
     reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client
@@ -17,7 +18,7 @@ async def test_remote_client(registry_async_client):
     assert stored_schema == schema_avro
 
 
-async def test_remote_client_tls(registry_async_client_tls):
+async def test_remote_client_tls(registry_async_client_tls: Client) -> None:
     schema_avro = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
     reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client_tls

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -132,12 +132,12 @@ async def test_avro_publish(rest_async_client, registry_async_client, admin_clie
             # unknown schema id
             unknown_payload = {f"{pl_type}_schema_id": 666, "records": [{pl_type: o} for o in second_obj]}
             res = await rest_async_client.post(url, json=unknown_payload, headers=header)
-            assert res.status == 408
+            assert res.status_code == 408
             # mismatched schema
             # TODO -> maybe this test is useless, since it tests registry behavior
             # mismatch_payload = {f"{pl_type}_schema_id": new_schema_id,"records": [{pl_type: o} for o in test_objects]}
             # res = await rest_client.post(url, json=mismatch_payload, headers=header)
-            # assert res.status == 422, f"Expecting schema {second_schema_json} to not match records {test_objects}"
+            # assert res.status_code == 422, f"Expecting schema {second_schema_json} to not match records {test_objects}"
 
 
 async def test_admin_client(admin_client, producer):
@@ -264,18 +264,18 @@ async def test_publish_malformed_requests(rest_async_client, admin_client):
         # Malformed schema ++ empty records
         for js in [{"records": []}, {"foo": "bar"}, {"records": [{"valur": {"foo": "bar"}}]}]:
             res = await rest_async_client.post(url, json=js, headers=REST_HEADERS["json"])
-            assert res.status == 422
+            assert res.status_code == 422
         res = await rest_async_client.post(url, json={"records": [{"value": {"foo": "bar"}}]}, headers=REST_HEADERS["avro"])
         res_json = res.json()
-        assert res.status == 422
+        assert res.status_code == 422
         assert res_json["error_code"] == 42202
         res = await rest_async_client.post(url, json={"records": [{"key": {"foo": "bar"}}]}, headers=REST_HEADERS["avro"])
         res_json = res.json()
-        assert res.status == 422
+        assert res.status_code == 422
         assert res_json["error_code"] == 42201
         res = await rest_async_client.post(url, json={"records": [{"value": "not base64"}]}, headers=REST_HEADERS["binary"])
         res_json = res.json()
-        assert res.status == 422
+        assert res.status_code == 422
         assert res_json["error_code"] == 42205
 
 
@@ -310,14 +310,14 @@ async def test_publish_incompatible_schema(rest_async_client, admin_client):
         json={"value_schema": json.dumps(schema_1), "records": [{"value": {"name": "Foobar"}}]},
         headers=REST_HEADERS["avro"],
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
     res = await rest_async_client.post(
         url,
         json={"value_schema": json.dumps(schema_2), "records": [{"value": {"name2": "Foobar"}}]},
         headers=REST_HEADERS["avro"],
     )
-    assert res.status == 408
+    assert res.status_code == 408
     res_json = res.json()
     assert res_json["error_code"] == 40801
     assert "message" in res_json

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -7,9 +7,9 @@ See LICENSE for details
 from http import HTTPStatus
 from kafka import KafkaProducer
 from karapace import config
+from karapace.client import Client
 from karapace.rapu import is_success
 from karapace.schema_registry_apis import KarapaceSchemaRegistry, SchemaErrorMessages
-from karapace.utils import Client
 from tests.utils import (
     create_field_name_factory,
     create_schema_name_factory,

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -34,7 +34,7 @@ async def test_union_to_union(registry_async_client: Client, trail: str) -> None
 
     subject_1 = subject_name_factory()
     res = await registry_async_client.put(f"config/{subject_1}{trail}", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
     init_schema = {"name": "init", "type": "record", "fields": [{"name": "inner", "type": ["string", "int"]}]}
     evolved = {"name": "init", "type": "record", "fields": [{"name": "inner", "type": ["null", "string"]}]}
     evolved_compatible = {
@@ -54,29 +54,29 @@ async def test_union_to_union(registry_async_client: Client, trail: str) -> None
     res = await registry_async_client.post(
         f"subjects/{subject_1}/versions{trail}", json={"schema": ujson.dumps(init_schema)}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     res = await registry_async_client.post(f"subjects/{subject_1}/versions{trail}", json={"schema": ujson.dumps(evolved)})
-    assert res.status == 409
+    assert res.status_code == 409
     res = await registry_async_client.post(
         f"subjects/{subject_1}/versions{trail}", json={"schema": ujson.dumps(evolved_compatible)}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     # fw compat check
     subject_2 = subject_name_factory()
     res = await registry_async_client.put(f"config/{subject_2}{trail}", json={"compatibility": "FORWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.post(
         f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(evolved_compatible)}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(evolved)})
-    assert res.status == 409
+    assert res.status_code == 409
     res = await registry_async_client.post(
         f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(init_schema)}
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -88,11 +88,11 @@ async def test_missing_subject_compatibility(registry_async_client: Client, trai
     )
     assert res.status_code == 200, f"{res} {subject}"
     res = await registry_async_client.get(f"config/{subject}{trail}")
-    assert res.status == 404, f"{res} {subject}"
+    assert res.status_code == 404, f"{res} {subject}"
     res = await registry_async_client.get(f"config/{subject}{trail}?defaultToGlobal=false")
-    assert res.status == 404, f"subject should have no compatibility when not defaulting to global: {res.json()}"
+    assert res.status_code == 404, f"subject should have no compatibility when not defaulting to global: {res.json()}"
     res = await registry_async_client.get(f"config/{subject}{trail}?defaultToGlobal=true")
-    assert res.status == 200, f"subject should have a compatibility when not defaulting to global: {res.json()}"
+    assert res.status_code == 200, f"subject should have a compatibility when not defaulting to global: {res.json()}"
 
     assert "compatibilityLevel" in res.json(), res.json()
 
@@ -102,7 +102,7 @@ async def test_record_union_schema_compatibility(registry_async_client: Client, 
     subject = create_subject_name_factory(f"test_record_union_schema_compatibility-{trail}")()
 
     res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
     original_schema = {
         "name": "bar",
         "namespace": "foo",
@@ -123,7 +123,7 @@ async def test_record_union_schema_compatibility(registry_async_client: Client, 
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(original_schema)}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
 
     evolved_schema = {
@@ -154,11 +154,11 @@ async def test_record_union_schema_compatibility(registry_async_client: Client, 
         f"compatibility/subjects/{subject}/versions/latest{trail}",
         json={"schema": ujson.dumps(evolved_schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(evolved_schema)}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
 
     # Check that we can delete the field as well
@@ -166,11 +166,11 @@ async def test_record_union_schema_compatibility(registry_async_client: Client, 
         f"compatibility/subjects/{subject}/versions/latest{trail}",
         json={"schema": ujson.dumps(original_schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(original_schema)}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
 
 
@@ -179,7 +179,7 @@ async def test_record_nested_schema_compatibility(registry_async_client: Client,
     subject = create_subject_name_factory(f"test_record_nested_schema_compatibility-{trail}")()
 
     res = await registry_async_client.put("config", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
     schema = {
         "type": "record",
         "name": "Objct",
@@ -207,7 +207,7 @@ async def test_record_nested_schema_compatibility(registry_async_client: Client,
         f"subjects/{subject}/versions{trail}",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
 
     # change string to integer in the nested record, should fail
@@ -216,7 +216,7 @@ async def test_record_nested_schema_compatibility(registry_async_client: Client,
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 409
+    assert res.status_code == 409
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -245,10 +245,10 @@ async def test_compatibility_endpoint(registry_async_client: Client, trail: str)
         f"subjects/{subject}/versions{trail}",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
     res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
 
     # replace int with long
     schema["fields"] = [{"type": "long", "name": "age"}]
@@ -256,7 +256,7 @@ async def test_compatibility_endpoint(registry_async_client: Client, trail: str)
         f"compatibility/subjects/{subject}/versions/latest{trail}",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == {"is_compatible": True}
 
     # replace int with string
@@ -265,7 +265,7 @@ async def test_compatibility_endpoint(registry_async_client: Client, trail: str)
         f"compatibility/subjects/{subject}/versions/latest{trail}",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == {"is_compatible": False}
 
 
@@ -339,14 +339,14 @@ async def test_type_compatibility(registry_async_client: Client, trail: str) -> 
             f"subjects/{subject}/versions{trail}",
             json={"schema": ujson.dumps(schema)},
         )
-        assert res.status == 200
+        assert res.status_code == 200
 
         schema["fields"][0]["type"] = target_type
         res = await registry_async_client.post(
             f"compatibility/subjects/{subject}/versions/latest{trail}",
             json={"schema": ujson.dumps(schema)},
         )
-        assert res.status == 200
+        assert res.status_code == 200
         assert res.json() == {"is_compatible": expected}
 
 
@@ -370,12 +370,12 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
         f"subjects/{subject}/versions{trail}",
         json={"schema": ujson.dumps(schema_1)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schema_id = res.json()["id"]
 
     res = await registry_async_client.put(f"/config/{subject}{trail}", json={"compatibility": "FORWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
 
     schema_2 = {
         "type": "record",
@@ -390,7 +390,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
         f"subjects/{subject}/versions{trail}",
         json={"schema": ujson.dumps(schema_2)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schema_id2 = res.json()["id"]
     assert schema_id != schema_id2
@@ -409,7 +409,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
         json={"schema": ujson.dumps(schema_3a)},
     )
     # Fails because field removed
-    assert res.status == 409
+    assert res.status_code == 409
     res_json = res.json()
     assert res_json["error_code"] == 409
 
@@ -427,7 +427,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
         json={"schema": ujson.dumps(schema_3b)},
     )
     # Fails because incompatible type change
-    assert res.status == 409
+    assert res.status_code == 409
     res_json = res.json()
     assert res_json["error_code"] == 409
 
@@ -445,7 +445,7 @@ async def test_record_schema_compatibility_forward(registry_async_client: Client
         f"subjects/{subject}/versions{trail}",
         json={"schema": ujson.dumps(schema_4)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -468,10 +468,10 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
         f"subjects/{subject_1}/versions{trail}",
         json={"schema": ujson.dumps(schema_1)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
     res = await registry_async_client.put(f"config/{subject_1}{trail}", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
 
     # adds fourth_name w/o default, invalid
     schema_2 = {
@@ -489,7 +489,7 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
         f"subjects/{subject_1}/versions{trail}",
         json={"schema": ujson.dumps(schema_2)},
     )
-    assert res.status == 409
+    assert res.status_code == 409
 
     # Add a default value for the field
     schema_2["fields"][3] = {"name": "fourth_name", "type": "string", "default": "foof"}
@@ -497,7 +497,7 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
         f"subjects/{subject_1}/versions{trail}",
         json={"schema": ujson.dumps(schema_2)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
 
     # Try to submit schema with a different definition
@@ -506,17 +506,17 @@ async def test_record_schema_compatibility_backward(registry_async_client: Clien
         f"subjects/{subject_1}/versions{trail}",
         json={"schema": ujson.dumps(schema_2)},
     )
-    assert res.status == 409
+    assert res.status_code == 409
 
     subject_2 = subject_name_factory()
     res = await registry_async_client.put(f"config/{subject_2}{trail}", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
     schema_1 = {"type": "record", "name": schema_name, "fields": [{"name": "first_name", "type": "string"}]}
     res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(schema_1)})
-    assert res.status == 200
+    assert res.status_code == 200
     schema_1["fields"].append({"name": "last_name", "type": "string"})
     res = await registry_async_client.post(f"subjects/{subject_2}/versions{trail}", json={"schema": ujson.dumps(schema_1)})
-    assert res.status == 409
+    assert res.status_code == 409
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -526,15 +526,15 @@ async def test_enum_schema_field_add_compatibility(registry_async_client: Client
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
         schema = {"type": "enum", "name": "Suit", "symbols": ["SPADES", "HEARTS", "DIAMONDS"]}
         res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Add a field
         schema["symbols"].append("CLUBS")
         res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
-        assert res.status == status_code
+        assert res.status_code == status_code
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -544,15 +544,15 @@ async def test_array_schema_field_add_compatibility(registry_async_client: Clien
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
         schema = {"type": "array", "items": "int"}
         res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Modify the items type
         schema["items"] = "long"
         res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
-        assert res.status == status_code
+        assert res.status_code == status_code
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -562,18 +562,18 @@ async def test_array_nested_record_compatibility(registry_async_client: Client, 
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
         schema = {
             "type": "array",
             "items": {"type": "record", "name": "object", "fields": [{"name": "first_name", "type": "string"}]},
         }
         res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Add a second field to the record
         schema["items"]["fields"].append({"name": "last_name", "type": "string"})
         res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
-        assert res.status == status_code
+        assert res.status_code == status_code
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
@@ -583,19 +583,19 @@ async def test_record_nested_array_compatibility(registry_async_client: Client, 
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
         schema = {
             "type": "record",
             "name": "object",
             "fields": [{"name": "simplearray", "type": {"type": "array", "items": "int"}}],
         }
         res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Modify the array items type
         schema["fields"][0]["type"]["items"] = "long"
         res = await registry_async_client.post(f"subjects/{subject}/versions{trail}", json={"schema": ujson.dumps(schema)})
-        assert res.status == status_code
+        assert res.status_code == status_code
 
 
 async def test_map_schema_field_add_compatibility(
@@ -606,15 +606,15 @@ async def test_map_schema_field_add_compatibility(
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
         schema = {"type": "map", "values": "int"}
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Modify the items type
         schema["values"] = "long"
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == status_code
+        assert res.status_code == status_code
 
 
 async def test_enum_schema(registry_async_client: Client) -> None:
@@ -622,24 +622,24 @@ async def test_enum_schema(registry_async_client: Client) -> None:
     for compatibility in ["BACKWARD", "FORWARD", "FULL"]:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
         schema = {"type": "enum", "name": "testenum", "symbols": ["first"]}
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
 
         # Add a symbol.
         schema["symbols"].append("second")
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Remove a symbol
         schema["symbols"].pop(1)
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Change the name
         schema["name"] = "another"
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 409
+        assert res.status_code == 409
 
         # Inside record
         subject = subject_name_factory()
@@ -653,17 +653,17 @@ async def test_enum_schema(registry_async_client: Client) -> None:
         # Add a symbol.
         schema["fields"][0]["type"]["symbols"].append("second")
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Remove a symbol
         schema["fields"][0]["type"]["symbols"].pop(1)
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Change the name
         schema["fields"][0]["type"]["name"] = "another"
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 409
+        assert res.status_code == 409
 
 
 @pytest.mark.parametrize("compatibility", ["BACKWARD", "FORWARD", "FULL"])
@@ -673,25 +673,25 @@ async def test_fixed_schema(registry_async_client: Client, compatibility: str) -
     status_code_denied = 409
     subject_1 = subject_name_factory()
     res = await registry_async_client.put(f"config/{subject_1}", json={"compatibility": compatibility})
-    assert res.status == 200
+    assert res.status_code == 200
     schema = {"type": "fixed", "size": 16, "name": "md5", "aliases": ["testalias"]}
     res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
 
     # Add new alias
     schema["aliases"].append("anotheralias")
     res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == status_code_allowed
+    assert res.status_code == status_code_allowed
 
     # Try to change size
     schema["size"] = 32
     res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == status_code_denied
+    assert res.status_code == status_code_denied
 
     # Try to change name
     schema["size"] = 16
     schema["name"] = "denied"
     res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == status_code_denied
+    assert res.status_code == status_code_denied
 
     # In a record
     subject_2 = subject_name_factory()
@@ -705,18 +705,18 @@ async def test_fixed_schema(registry_async_client: Client, compatibility: str) -
     # Add new alias
     schema["fields"][0]["type"]["aliases"].append("anotheralias")
     res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == status_code_allowed
+    assert res.status_code == status_code_allowed
 
     # Try to change size
     schema["fields"][0]["type"]["size"] = 32
     res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == status_code_denied
+    assert res.status_code == status_code_denied
 
     # Try to change name
     schema["fields"][0]["type"]["size"] = 16
     schema["fields"][0]["type"]["name"] = "denied"
     res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == status_code_denied
+    assert res.status_code == status_code_denied
 
 
 async def test_primitive_schema(registry_async_client: Client) -> None:
@@ -725,26 +725,26 @@ async def test_primitive_schema(registry_async_client: Client) -> None:
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Transition from string to bytes
         schema = {"type": "string"}
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
         schema["type"] = "bytes"
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == status_code
+        assert res.status_code == status_code
 
     expected_results = [("BACKWARD", 409), ("FORWARD", 409), ("FULL", 409)]
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Transition from string to int
         schema = {"type": "string"}
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
         schema["type"] = "int"
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
 
@@ -755,51 +755,51 @@ async def test_union_comparing_to_other_types(registry_async_client: Client) -> 
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Union vs non-union with the same schema
         schema = [{"type": "array", "name": "listofstrings", "items": "string"}, "string"]
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
         plain_schema = {"type": "string"}
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(plain_schema)})
-        assert res.status == status_code
+        assert res.status_code == status_code
 
     expected_results = [("BACKWARD", 200), ("FORWARD", 409), ("FULL", 409)]
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Non-union first
         schema = {"type": "array", "name": "listofstrings", "items": "string"}
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
         union_schema = [{"type": "array", "name": "listofstrings", "items": "string"}, "string"]
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(union_schema)})
-        assert res.status == status_code
+        assert res.status_code == status_code
 
     expected_results = [("BACKWARD", 409), ("FORWARD", 409), ("FULL", 409)]
     for compatibility, status_code in expected_results:
         subject = subject_name_factory()
         res = await registry_async_client.put(f"config/{subject}", json={"compatibility": compatibility})
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Union to a completely different schema
         schema = [{"type": "array", "name": "listofstrings", "items": "string"}, "string"]
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-        assert res.status == 200
+        assert res.status_code == 200
         plain_wrong_schema = {"type": "int"}
         res = await registry_async_client.post(
             f"subjects/{subject}/versions", json={"schema": ujson.dumps(plain_wrong_schema)}
         )
-        assert res.status == status_code
+        assert res.status_code == status_code
 
 
 async def test_transitive_compatibility(registry_async_client: Client) -> None:
     subject = create_subject_name_factory("test_transitive_compatibility")()
     res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "BACKWARD_TRANSITIVE"})
-    assert res.status == 200
+    assert res.status_code == 200
 
     schema0 = {
         "type": "record",
@@ -812,7 +812,7 @@ async def test_transitive_compatibility(registry_async_client: Client) -> None:
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schema0)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
     schema1 = {
         "type": "record",
@@ -830,7 +830,7 @@ async def test_transitive_compatibility(registry_async_client: Client) -> None:
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schema1)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
     schema2 = {
         "type": "record",
@@ -852,7 +852,7 @@ async def test_transitive_compatibility(registry_async_client: Client) -> None:
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schema2)},
     )
-    assert res.status == 409
+    assert res.status_code == 409
     res_json = res.json()
     assert res_json["error_code"] == 409
 
@@ -885,7 +885,7 @@ async def register_schema(registry_async_client: Client, trail, subject: str, sc
         f"subjects/{subject}/versions{trail}",
         json={"schema": schema_str},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     schema_id = res.json()["id"]
 
     # Get version
@@ -893,7 +893,7 @@ async def register_schema(registry_async_client: Client, trail, subject: str, sc
         f"subjects/{subject}{trail}",
         json={"schema": schema_str},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json()["id"] == schema_id
     return schema_id, res.json()["version"]
 
@@ -988,7 +988,7 @@ async def test_schema_versions_deleting(registry_async_client: Client, trail: st
     await assert_schema_versions(registry_async_client, trail, schema_id_1, schema_1_versions)
 
     res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
 
     schema_id_2, version_2 = await register_schema(registry_async_client, trail, subject, schema_str_2)
     schema_2_versions = [(subject, version_2)]
@@ -1039,7 +1039,7 @@ async def test_schema_repost(registry_async_client: Client, trail: str) -> None:
         f"subjects/{subject}/versions{trail}",
         json={"schema": schema_str},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schema_id = res.json()["id"]
 
@@ -1051,7 +1051,7 @@ async def test_schema_repost(registry_async_client: Client, trail: str) -> None:
         f"subjects/{subject}/versions{trail}",
         json={"schema": schema_str},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     assert schema_id == res.json()["id"]
 
@@ -1064,7 +1064,7 @@ async def test_schema_missing_body(registry_async_client: Client, trail: str) ->
         f"subjects/{subject}/versions{trail}",
         json={},
     )
-    assert res.status == 422
+    assert res.status_code == 422
     assert res.json()["error_code"] == 42201
     assert res.json()["message"] == "Empty schema"
 
@@ -1083,7 +1083,7 @@ async def test_schema_non_invalid_id(registry_async_client: Client, trail: str) 
     Tests getting an invalid schema id
     """
     result = await registry_async_client.get(f"schemas/ids/invalid{trail}")
-    assert result.status == 404
+    assert result.status_code == 404
     assert result.json()["error_code"] == 404
     assert result.json()["message"] == "HTTP 404 Not Found"
 
@@ -1133,13 +1133,13 @@ async def test_schema_subject_post_invalid(registry_async_client: Client) -> Non
         f"subjects/{subject_1}/versions",
         json={"schema": schema_str},
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
     res = await registry_async_client.post(
         f"subjects/{subject_1}",
         json={"schema": ujson.dumps({"type": "invalid_type"})},
     )
-    assert res.status == 500, "Invalid schema for existing subject should return 500"
+    assert res.status_code == 500, "Invalid schema for existing subject should return 500"
     assert res.json()["message"] == f"Error while looking up schema under subject {subject_1}"
 
     # Subject is not found
@@ -1148,7 +1148,7 @@ async def test_schema_subject_post_invalid(registry_async_client: Client) -> Non
         f"subjects/{subject_2}",
         json={"schema": schema_str},
     )
-    assert res.status == 404
+    assert res.status_code == 404
     assert res.json()["error_code"] == 40401
     assert res.json()["message"] == f"Subject '{subject_2}' not found."
 
@@ -1157,13 +1157,13 @@ async def test_schema_subject_post_invalid(registry_async_client: Client) -> Non
         f"subjects/{subject_1}",
         json={"schema": '{"type": "int"}'},
     )
-    assert res.status == 404
+    assert res.status_code == 404
     assert res.json()["error_code"] == 40403
     assert res.json()["message"] == "Schema not found"
 
     # Schema not included in the request body
     res = await registry_async_client.post(f"subjects/{subject_1}", json={})
-    assert res.status == 500
+    assert res.status_code == 500
     assert res.json()["error_code"] == 500
     assert res.json()["message"] == f"Error while looking up schema under subject {subject_1}"
 
@@ -1173,7 +1173,7 @@ async def test_schema_subject_post_invalid(registry_async_client: Client) -> Non
         f"subjects/{subject_3}",
         json={},
     )
-    assert res.status == 404
+    assert res.status_code == 404
     assert res.json()["error_code"] == 40401
     assert res.json()["message"] == f"Subject '{subject_3}' not found."
 
@@ -1261,7 +1261,7 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
         f"subjects/{subject}/versions",
         json={"schema": '{"type": "string", "unique": "%s"}' % unique_field_factory()},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.get("subjects")
     assert subject in res.json()
     res = await registry_async_client.get(f"subjects/{subject}/versions")
@@ -1286,7 +1286,7 @@ async def test_schema_lifecycle(registry_async_client: Client, trail: str) -> No
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps({"type": "string", "foo": "string", unique_3: "string"})},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.get(f"subjects/{subject}/versions")
     assert res.json() == [4]
 
@@ -1312,11 +1312,11 @@ async def test_schema_version_numbering(registry_async_client: Client, trail: st
         ],
     }
     res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
 
     res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "FORWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
 
     schema2 = {
         "type": "record",
@@ -1333,19 +1333,19 @@ async def test_schema_version_numbering(registry_async_client: Client, trail: st
         ],
     }
     res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema2)})
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     res = await registry_async_client.get(f"subjects/{subject}/versions")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == [1, 2]
 
     # Recreate subject
     res = await registry_async_client.delete(f"subjects/{subject}")
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.get(f"subjects/{subject}/versions")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == [3]  # Version number generation should now begin at 3
 
 
@@ -1375,7 +1375,7 @@ async def test_schema_version_numbering_complex(registry_async_client: Client, t
     schema_id = res.json()["id"]
 
     res = await registry_async_client.get(f"subjects/{subject}/versions/1")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json()["subject"] == subject
     assert sorted(ujson.loads(res.json()["schema"])) == sorted(schema)
 
@@ -1409,14 +1409,14 @@ async def test_schema_three_subjects_sharing_schema(registry_async_client: Clien
         ],
     }
     res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schema_id_1 = res.json()["id"]
 
     # New subject with the same schema
     subject_2 = subject_name_factory()
     res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schema_id_2 = res.json()["id"]
     assert schema_id_1 == schema_id_2
@@ -1430,12 +1430,12 @@ async def test_schema_three_subjects_sharing_schema(registry_async_client: Clien
         f"subjects/{subject_3}/versions",
         json={"schema": '{"type": "string"}'},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.post(
         f"subjects/{subject_3}/versions",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json()["id"] == schema_id_1  # Same ID as in the previous test step
 
 
@@ -1466,24 +1466,24 @@ async def test_schema_subject_version_schema(registry_async_client: Client, trai
         f"subjects/{subject_1}/versions",
         json={"schema": schema_str},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.get(f"subjects/{subject_1}/versions/1/schema")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == ujson.loads(schema_str)
 
     subject_2 = subject_name_factory()
     res = await registry_async_client.get(f"subjects/{subject_2}/versions/1/schema")  # Invalid subject
-    assert res.status == 404
+    assert res.status_code == 404
     assert res.json()["error_code"] == 40401
     assert res.json()["message"] == f"Subject '{subject_2}' not found."
 
     res = await registry_async_client.get(f"subjects/{subject_1}/versions/2/schema")
-    assert res.status == 404
+    assert res.status_code == 404
     assert res.json()["error_code"] == 40402
     assert res.json()["message"] == "Version 2 not found."
 
     res = await registry_async_client.get(f"subjects/{subject_1}/versions/latest/schema")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == ujson.loads(schema_str)
 
 
@@ -1512,13 +1512,13 @@ async def test_schema_same_subject(registry_async_client: Client, trail: str) ->
         f"subjects/{subject}/versions",
         json={"schema": schema_str},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     schema_id = res.json()["id"]
     res = await registry_async_client.post(
         f"subjects/{subject}",
         json={"schema": schema_str},
     )
-    assert res.status == 200
+    assert res.status_code == 200
 
     # Switch the str schema to a dict for comparison
     json = res.json()
@@ -1582,11 +1582,11 @@ async def test_schema_version_number_existing_schema(registry_async_client: Clie
         ],
     }
     res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema_1)})
-    assert res.status == 200
+    assert res.status_code == 200
     schema_id_1 = res.json()["id"]
 
     res = await registry_async_client.post(f"subjects/{subject_1}/versions", json={"schema": ujson.dumps(schema_2)})
-    assert res.status == 200
+    assert res.status_code == 200
     schema_id_2 = res.json()["id"]
     assert schema_id_2 > schema_id_1
 
@@ -1596,12 +1596,12 @@ async def test_schema_version_number_existing_schema(registry_async_client: Clie
         f"config/{subject_2}", json={"compatibility": "NONE"}
     )  # We don't care about compatibility
     res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema_1)})
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json()["id"] == schema_id_1
 
     # Create a new schema
     res = await registry_async_client.post(f"subjects/{subject_2}/versions", json={"schema": ujson.dumps(schema_3)})
-    assert res.status == 200
+    assert res.status_code == 200
     schema_id_3 = res.json()["id"]
     assert res.json()["id"] == schema_id_3
     assert schema_id_3 > schema_id_2
@@ -1681,10 +1681,10 @@ async def test_config(registry_async_client: Client, trail: str) -> None:
     # Test that config is returned for a subject that does not have an existing schema
     subject_3 = subject_name_factory()
     res = await registry_async_client.put(f"config/{subject_3}", json={"compatibility": "NONE"})
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json()["compatibility"] == "NONE"
     res = await registry_async_client.get(f"config/{subject_3}")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json()["compatibilityLevel"] == "NONE"
 
 
@@ -1698,12 +1698,12 @@ async def test_http_headers(registry_async_client: Client) -> None:
 
     # Giving an invalid Accept value
     res = await registry_async_client.get("subjects", headers={"Accept": "application/vnd.schemaregistry.v2+json"})
-    assert res.status == 406
+    assert res.status_code == 406
     assert res.json()["message"] == "HTTP 406 Not Acceptable"
 
     # PUT with an invalid Content type
     res = await registry_async_client.put("config", json={"compatibility": "NONE"}, headers={"Content-Type": "text/html"})
-    assert res.status == 415
+    assert res.status_code == 415
     assert res.json()["message"] == "HTTP 415 Unsupported Media Type"
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
 
@@ -1711,7 +1711,7 @@ async def test_http_headers(registry_async_client: Client) -> None:
     res = await registry_async_client.get(
         "subjects", headers={"Accept": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
 
     # Weight works
@@ -1719,38 +1719,38 @@ async def test_http_headers(registry_async_client: Client) -> None:
         "subjects",
         headers={"Accept": "application/vnd.schemaregistry.v2+json; q=0.1, application/vnd.schemaregistry+json; q=0.9"},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry+json"
 
     # Accept without any subtype works
     res = await registry_async_client.get("subjects", headers={"Accept": "application/*"})
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
     res = await registry_async_client.get("subjects", headers={"Accept": "text/*"})
-    assert res.status == 406
+    assert res.status_code == 406
     assert res.json()["message"] == "HTTP 406 Not Acceptable"
 
     # Accept without any type works
     res = await registry_async_client.get("subjects", headers={"Accept": "*/does_not_matter"})
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
 
     # Default return is correct
     res = await registry_async_client.get("subjects", headers={"Accept": "*"})
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
     res = await registry_async_client.get("subjects", headers={"Accept": "*/*"})
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
 
     # Octet-stream is supported as a Content-Type
     res = await registry_async_client.put(
         "config", json={"compatibility": "FULL"}, headers={"Content-Type": "application/octet-stream"}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
     res = await registry_async_client.get("subjects", headers={"Accept": "application/octet-stream"})
-    assert res.status == 406
+    assert res.status_code == 406
 
     # Parse Content-Type correctly
     res = await registry_async_client.put(
@@ -1758,7 +1758,7 @@ async def test_http_headers(registry_async_client: Client) -> None:
         json={"compatibility": "NONE"},
         headers={"Content-Type": "application/vnd.schemaregistry.v1+json; charset=utf-8"},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
     assert res.json()["compatibility"] == "NONE"
 
@@ -1768,7 +1768,7 @@ async def test_http_headers(registry_async_client: Client) -> None:
         data='{"compatibility": "NONE"}'.encode("utf-16"),
         headers={"Content-Type": "application/vnd.schemaregistry.v1+json; charset=utf-16"},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.headers["Content-Type"] == "application/vnd.schemaregistry.v1+json"
     assert res.json()["compatibility"] == "NONE"
     if "SERVER_URI" in os.environ:
@@ -1790,19 +1790,19 @@ async def test_schema_body_validation(registry_async_client: Client) -> None:
     for endpoint in post_endpoints:
         # Wrong field name
         res = await registry_async_client.post(endpoint, json={"invalid_field": "invalid_value"})
-        assert res.status == 422
+        assert res.status_code == 422
         assert res.json()["error_code"] == 422
         assert res.json()["message"] == "Unrecognized field: invalid_field"
         # Additional field
         res = await registry_async_client.post(
             endpoint, json={"schema": '{"type": "string"}', "invalid_field": "invalid_value"}
         )
-        assert res.status == 422
+        assert res.status_code == 422
         assert res.json()["error_code"] == 422
         assert res.json()["message"] == "Unrecognized field: invalid_field"
         # Invalid body type
         res = await registry_async_client.post(endpoint, json="invalid")
-        assert res.status == 500
+        assert res.status_code == 500
         assert res.json()["error_code"] == 500
         assert res.json()["message"] == "Internal Server Error"
 
@@ -1823,7 +1823,7 @@ async def test_version_number_validation(registry_async_client: Client) -> None:
     assert "id" in res.json()
 
     res = await registry_async_client.get(f"subjects/{subject}/versions")
-    assert res.status == 200
+    assert res.status_code == 200
     schema_version = res.json()[0]
     invalid_schema_version = schema_version - 1
 
@@ -1831,11 +1831,11 @@ async def test_version_number_validation(registry_async_client: Client) -> None:
     for endpoint in version_endpoints:
         # Valid schema id
         res = await registry_async_client.get(endpoint.replace("$VERSION", str(schema_version)))
-        assert res.status == 200
+        assert res.status_code == 200
 
         # Invalid number
         res = await registry_async_client.get(endpoint.replace("$VERSION", str(invalid_schema_version)))
-        assert res.status == 422
+        assert res.status_code == 422
         assert res.json()["error_code"] == 42202
         assert (
             res.json()["message"] == f"The specified version '{invalid_schema_version}' is not a valid version id. "
@@ -1843,10 +1843,10 @@ async def test_version_number_validation(registry_async_client: Client) -> None:
         )
         # Valid latest string
         res = await registry_async_client.get(endpoint.replace("$VERSION", "latest"))
-        assert res.status == 200
+        assert res.status_code == 200
         # Invalid string
         res = await registry_async_client.get(endpoint.replace("$VERSION", "invalid"))
-        assert res.status == 422
+        assert res.status_code == 422
         assert res.json()["error_code"] == 42202
         assert (
             res.json()["message"] == "The specified version 'invalid' is not a valid version id. "
@@ -1856,7 +1856,7 @@ async def test_version_number_validation(registry_async_client: Client) -> None:
 
 async def test_common_endpoints(registry_async_client: Client) -> None:
     res = await registry_async_client.get("")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == {}
 
 
@@ -1864,7 +1864,7 @@ async def test_invalid_namespace(registry_async_client: Client) -> None:
     subject = create_subject_name_factory("test_invalid_namespace")()
     schema = {"type": "record", "name": "foo", "namespace": "foo-bar-baz", "fields": []}
     res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(schema)})
-    assert res.status == 422, res.json()
+    assert res.status_code == 422, res.json()
     json_res = res.json()
     assert json_res["error_code"] == 44201, json_res
     expected_message = (
@@ -2069,7 +2069,7 @@ async def test_full_transitive_failure(registry_async_client: Client, compatibil
     assert res.ok
     res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": ujson.dumps(evolved)})
     assert not res.ok
-    assert res.status == 409
+    assert res.status_code == 409
 
 
 async def test_invalid_schemas(registry_async_client: Client) -> None:
@@ -2085,14 +2085,14 @@ async def test_invalid_schemas(registry_async_client: Client) -> None:
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(repated_field)},
     )
-    assert res.status != 500, "an invalid schema should not cause a server crash"
-    assert not is_success(HTTPStatus(res.status)), "an invalid schema must not be a success"
+    assert res.status_code != 500, "an invalid schema should not cause a server crash"
+    assert not is_success(HTTPStatus(res.status_code)), "an invalid schema must not be a success"
 
 
 async def test_schema_hard_delete_version(registry_async_client: Client) -> None:
     subject = create_subject_name_factory("test_schema_hard_delete_version")()
     res = await registry_async_client.put("config", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
     schemav1 = {
         "type": "record",
         "name": "myenumtest",
@@ -2111,7 +2111,7 @@ async def test_schema_hard_delete_version(registry_async_client: Client) -> None
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schemav1)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schemav1_id = res.json()["id"]
 
@@ -2133,7 +2133,7 @@ async def test_schema_hard_delete_version(registry_async_client: Client) -> None
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schemav2)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schemav2_id = res.json()["id"]
     assert schemav1_id != schemav2_id
@@ -2176,7 +2176,7 @@ async def test_schema_hard_delete_version(registry_async_client: Client) -> None
 async def test_schema_hard_delete_whole_schema(registry_async_client: Client) -> None:
     subject = create_subject_name_factory("test_schema_hard_delete_whole_schema")()
     res = await registry_async_client.put("config", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
     schemav1 = {
         "type": "record",
         "name": "myenumtest",
@@ -2195,7 +2195,7 @@ async def test_schema_hard_delete_whole_schema(registry_async_client: Client) ->
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schemav1)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schemav1_id = res.json()["id"]
 
@@ -2217,7 +2217,7 @@ async def test_schema_hard_delete_whole_schema(registry_async_client: Client) ->
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schemav2)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schemav2_id = res.json()["id"]
     assert schemav1_id != schemav2_id
@@ -2254,7 +2254,7 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
     schema_name = create_schema_name_factory("test_schema_hard_delete_and_recreate")()
 
     res = await registry_async_client.put("config", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
     schema = {
         "type": "record",
         "name": schema_name,
@@ -2273,7 +2273,7 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     schema_id = res.json()["id"]
 
@@ -2286,7 +2286,7 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     assert schema_id == res.json()["id"], "after soft delete the same schema registered, the same identifier"
 
@@ -2307,7 +2307,7 @@ async def test_schema_hard_delete_and_recreate(registry_async_client: Client) ->
         f"subjects/{subject}/versions",
         json={"schema": ujson.dumps(schema)},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     assert schema_id == res.json()["id"], "after permanent deleted the same schema registered, the same identifier"
 

--- a/tests/integration/test_schema_backup.py
+++ b/tests/integration/test_schema_backup.py
@@ -4,9 +4,10 @@ karapace - test schema backup
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from karapace.client import Client
 from karapace.config import set_config_defaults
 from karapace.schema_backup import SchemaBackup
-from karapace.utils import Client, Expiration
+from karapace.utils import Expiration
 from pathlib import Path
 from tests.utils import KafkaServers, new_random_name
 

--- a/tests/integration/test_schema_backup.py
+++ b/tests/integration/test_schema_backup.py
@@ -18,19 +18,19 @@ import ujson
 baseurl = "http://localhost:8081"
 
 
-async def insert_data(c):
+async def insert_data(client: Client) -> str:
     subject = new_random_name("subject")
-    res = await c.post(
+    res = await client.post(
         "subjects/{}/versions".format(subject),
         json={"schema": '{"type": "string"}'},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
     return subject
 
 
 async def test_backup_get(registry_async_client, kafka_servers: KafkaServers, tmp_path: Path):
-    _ = await insert_data(registry_async_client)
+    await insert_data(registry_async_client)
 
     # Get the backup
     backup_location = tmp_path / "schemas.log"
@@ -92,7 +92,7 @@ async def test_backup_restore(
     # Test a few exotic scenarios
     subject = new_random_name("subject")
     res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "NONE"})
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json()["compatibility"] == "NONE"
 
     # Restore a compatibility config remove message
@@ -114,11 +114,11 @@ async def test_backup_restore(
             )
         )
     res = await registry_async_client.get(f"config/{subject}")
-    assert res.status == 200
+    assert res.status_code == 200
     sb.restore_backup()
     time.sleep(1.0)
     res = await registry_async_client.get(f"config/{subject}")
-    assert res.status == 404
+    assert res.status_code == 404
 
     # Restore a complete schema delete message
     subject = new_random_name("subject")
@@ -126,7 +126,7 @@ async def test_backup_restore(
     res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": '{"type": "int"}'})
     res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": '{"type": "float"}'})
     res = await registry_async_client.get(f"subjects/{subject}/versions")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == [1, 2]
     with open(restore_location, mode="w", encoding="utf8") as fp:
         fp.write(
@@ -149,7 +149,7 @@ async def test_backup_restore(
     sb.restore_backup()
     time.sleep(1.0)
     res = await registry_async_client.get(f"subjects/{subject}/versions")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == [1]
 
     # Schema delete for a nonexistent subject version is ignored
@@ -176,5 +176,5 @@ async def test_backup_restore(
     sb.restore_backup()
     time.sleep(1.0)
     res = await registry_async_client.get(f"subjects/{subject}/versions")
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == [1]

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -39,7 +39,7 @@ async def test_protobuf_schema_compatibility(registry_async_client: Client, trai
     subject = create_subject_name_factory(f"test_protobuf_schema_compatibility-{trail}")()
 
     res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": "BACKWARD"})
-    assert res.status == 200
+    assert res.status_code == 200
 
     original_schema = """
             |syntax = "proto3";
@@ -59,7 +59,7 @@ async def test_protobuf_schema_compatibility(registry_async_client: Client, trai
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}", json={"schemaType": "PROTOBUF", "schema": original_schema}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
 
     evolved_schema = """
@@ -84,13 +84,13 @@ async def test_protobuf_schema_compatibility(registry_async_client: Client, trai
         f"compatibility/subjects/{subject}/versions/latest{trail}",
         json={"schemaType": "PROTOBUF", "schema": evolved_schema},
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert res.json() == {"is_compatible": True}
 
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}", json={"schemaType": "PROTOBUF", "schema": evolved_schema}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()
 
     res = await registry_async_client.post(
@@ -98,9 +98,9 @@ async def test_protobuf_schema_compatibility(registry_async_client: Client, trai
         json={"schemaType": "PROTOBUF", "schema": original_schema},
     )
     assert res.json() == {"is_compatible": True}
-    assert res.status == 200
+    assert res.status_code == 200
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}", json={"schemaType": "PROTOBUF", "schema": original_schema}
     )
-    assert res.status == 200
+    assert res.status_code == 200
     assert "id" in res.json()

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -4,8 +4,8 @@ karapace - schema tests
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from karapace.client import Client
 from karapace.protobuf.kotlin_wrapper import trim_margin
-from karapace.utils import Client
 from tests.utils import create_subject_name_factory
 
 import logging

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,9 @@
 from aiohttp.client_exceptions import ClientOSError, ServerDisconnectedError
 from dataclasses import dataclass
 from kafka.errors import TopicAlreadyExistsError
+from karapace.client import Client
 from karapace.protobuf.kotlin_wrapper import trim_margin
-from karapace.utils import Client, Expiration
+from karapace.utils import Expiration
 from typing import Callable, List
 from urllib.parse import quote
 


### PR DESCRIPTION
Notes:
- Replaced stdlib's json with ujson in the `json_encode`, should be faster
- I simplified some function signatures:
  - removed keyword argument that have a default and were never used by any caller
  - remove keyword arguments that have a default, and were always given the same value as the default
- Moved the Client code to a separate module and add typing. Also simplified it by:
  - Remove the fallback code that used requests, turns out that `_get_client` always returned a client, so that was dead code