### PR TITLE
logging: add optional aiohttp.access debug logger

### DIFF
--- a/karapace.config.json
+++ b/karapace.config.json
@@ -1,4 +1,5 @@
 {
+    "access_logs_debug": false,
     "advertised_hostname": "localhost",
     "bootstrap_uri": "127.0.0.1:9092",
     "client_id": "sr-1",

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -4,6 +4,7 @@ karapace - configuration validation
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from aiohttp.web_log import AccessLogger
 from enum import Enum, unique
 from pathlib import Path
 from typing import Dict, IO, List, Optional, Union
@@ -14,11 +15,12 @@ import socket
 import ssl
 import ujson
 
-Config = Dict[str, Union[None, str, int, bool, List[str]]]
+Config = Dict[str, Union[None, str, int, bool, List[str], AccessLogger]]
 LOG = logging.getLogger(__name__)
 HOSTNAME = socket.gethostname()
 
 DEFAULTS = {
+    "access_logs_debug": False,
     "advertised_hostname": HOSTNAME,
     "bootstrap_uri": "127.0.0.1:9092",
     "client_id": "sr-1",

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -1,9 +1,11 @@
+from aiohttp.web_log import AccessLogger
 from contextlib import closing
 from karapace import version as karapace_version
 from karapace.config import Config, DEFAULT_LOG_FORMAT_JOURNAL, read_config
 from karapace.kafka_rest_apis import KafkaRest
 from karapace.rapu import RestApp
 from karapace.schema_registry_apis import KarapaceSchemaRegistry
+from karapace.utils import DebugAccessLogger
 
 import argparse
 import logging
@@ -27,6 +29,11 @@ def main() -> int:
 
     logging.basicConfig(level=logging.INFO, format=DEFAULT_LOG_FORMAT_JOURNAL)
     logging.getLogger().setLevel(config["log_level"])
+    if config.get("access_logs_debug") is True:
+        config["access_log_class"] = DebugAccessLogger
+        logging.getLogger("aiohttp.access").setLevel(logging.DEBUG)
+    else:
+        config["access_log_class"] = AccessLogger
 
     app: RestApp
     if config["karapace_rest"] and config["karapace_registry"]:

--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -503,6 +503,7 @@ class RestApp:
             host=self.config["host"],
             port=self.config["port"],
             ssl_context=ssl_context,
+            access_log_class=self.config["access_log_class"],
             access_log_format='%Tfs %{x-client-ip}i "%r" %s "%{user-agent}i" response=%bb request_body=%{content-length}ib',
         )
 

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -4,6 +4,9 @@ karapace - utils
 Copyright (c) 2019 Aiven Ltd
 See LICENSE for details
 """
+from aiohttp.web_log import AccessLogger
+from aiohttp.web_request import BaseRequest
+from aiohttp.web_response import StreamResponse
 from dataclasses import dataclass
 from functools import partial
 from http import HTTPStatus
@@ -375,3 +378,36 @@ class KarapaceBrokerConnection(BrokerConnection):
 
     def blacked_out(self):
         return self.ns_blackout() or super().blacked_out()
+
+
+class DebugAccessLogger(AccessLogger):
+    """
+    Logs access logs as DEBUG instead of INFO.
+    Source: https://github.com/aio-libs/aiohttp/blob/d01e257da9b37c35c68b3931026a2d918c271446/aiohttp/web_log.py#L191-L210
+    """
+
+    def log(
+        self,
+        request: BaseRequest,
+        response: StreamResponse,
+        time: float,  # pylint: disable=redefined-outer-name
+    ) -> None:
+        try:
+            fmt_info = self._format_line(request, response, time)
+
+            values = list()
+            extra = dict()
+            for key, value in fmt_info:
+                values.append(value)
+
+                if key.__class__ is str:
+                    extra[key] = value
+                else:
+                    k1, k2 = key
+                    dct = extra.get(k1, {})
+                    dct[k2] = value
+                    extra[k1] = dct
+
+            self.logger.debug(self._log_format % tuple(values), extra=extra)
+        except Exception:  # pylint: disable=broad-except
+            self.logger.exception("Error in logging")


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Take 2 of https://github.com/aiven/karapace/pull/345

`aiohttp.access` logs can be numerous should clients be constantly
talking to `karapace`, and often these access logs don't provide
significant value for operators.

In order to not throw the baby out with the bath water, this set of
changes allows the use of a logger that outputs `aiohttp.access` logs as
`DEBUG` instead of `INFO` statements. Log filtering can then be applied
at log collection to drop the `DEBUG` logging.

# Why this way

This is really the only way to modify the log level that
`aiohttp.access` logs are emitted at, as `aiohttp` only lets you
totally disable them otherwise. This lets us optionally keep the logs.

An aggregated log would be ideal, but unfortunately the architecture
of `aiohttp` precludes this.