### PR TITLE
Reduced logging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
       run: python3 -m pytest -s -vvv tests/unit/
 
     - name: Execute integration-tests
+      timeout-minutes: 10
       run: python3 -m pytest -s -vvv tests/integration/ --log-dir=/tmp/ci-logs --log-file=/tmp/ci-logs/pytest.log
 
     - name: Archive logs

--- a/karapace/client.py
+++ b/karapace/client.py
@@ -12,10 +12,11 @@ from urllib.parse import urljoin
 import logging
 import ssl
 
-log = logging.getLogger(__name__)
 Path = str
 Headers = dict
 JsonData = object  # Type of the result after parsing JSON
+
+LOG = logging.getLogger(__name__)
 
 
 async def _get_aiohttp_client() -> ClientSession:
@@ -74,7 +75,7 @@ class Client:
             if self._client is not None:
                 await self._client.close()
         except:  # pylint: disable=bare-except
-            log.info("Could not close client")
+            LOG.error("Could not close client")
 
     async def get_client(self) -> ClientSession:
         if self._client is None:

--- a/karapace/compatibility/jsonschema/checks.py
+++ b/karapace/compatibility/jsonschema/checks.py
@@ -30,10 +30,7 @@ from karapace.compatibility.jsonschema.utils import (
 )
 from typing import Any, List, Optional
 
-import logging
 import networkx as nx
-
-LOG = logging.getLogger(__name__)
 
 INTRODUCED_INCOMPATIBILITY_MSG_FMT = "Introduced incompatible assertion {assert_name} with value {introduced_value}"
 RESTRICTED_INCOMPATIBILITY_MSG_FMT = "More restrictive assertion {assert_name} from {writer_value} to {reader_value}"
@@ -248,7 +245,6 @@ def compatibility_rec(
     # reader has type `array` to represent a list, and the writer is either a
     # different type or it is also an `array` but now it representes a tuple.
     if reader_schema is None and writer_schema is not None:
-        LOG.debug("Schema removed reader_schema.type='%r'", get_type_of(reader_schema))
         return incompatible_schema(
             incompat_type=Incompatibility.schema_removed,
             message="schema removed",

--- a/karapace/compatibility/protobuf/checks.py
+++ b/karapace/compatibility/protobuf/checks.py
@@ -2,17 +2,10 @@ from avro.compatibility import SchemaCompatibilityResult, SchemaCompatibilityTyp
 from karapace.protobuf.compare_result import CompareResult
 from karapace.protobuf.schema import ProtobufSchema
 
-import logging
-
-log = logging.getLogger(__name__)
-
 
 def check_protobuf_schema_compatibility(reader: ProtobufSchema, writer: ProtobufSchema) -> SchemaCompatibilityResult:
     result = CompareResult()
-    log.debug("READER: %s", reader.to_schema())
-    log.debug("WRITER: %s", writer.to_schema())
     writer.compare(reader, result)
-    log.debug("IS_COMPATIBLE %s", result.is_compatible())
     if result.is_compatible():
         return SchemaCompatibilityResult(SchemaCompatibilityType.compatible)
 

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -19,7 +19,7 @@ import ujson
 Config = Dict[str, Union[None, str, int, bool, List[str], AccessLogger]]
 LOG = logging.getLogger(__name__)
 HOSTNAME = socket.gethostname()
-
+SASL_PLAIN_PASSWORD = "sasl_plain_password"
 DEFAULTS = {
     "access_logs_debug": False,
     "access_log_class": None,
@@ -53,7 +53,7 @@ DEFAULTS = {
     "ssl_password": None,
     "sasl_mechanism": None,
     "sasl_plain_username": None,
-    "sasl_plain_password": None,
+    SASL_PLAIN_PASSWORD: None,
     "topic_name": DEFAULT_SCHEMA_TOPIC,
     "metadata_max_age_ms": 60000,
     "admin_metadata_max_age": 5,
@@ -67,6 +67,7 @@ DEFAULTS = {
     "master_election_strategy": "lowest",
     "protobuf_runtime_directory": "runtime",
 }
+SECRET_CONFIG_OPTIONS = [SASL_PLAIN_PASSWORD]
 
 
 class InvalidConfiguration(Exception):
@@ -109,12 +110,20 @@ def set_settings_from_environment(config: Config) -> None:
         env_name = config_name_with_prefix.upper()
         env_val = os.environ.get(env_name)
         if env_val is not None:
-            LOG.debug(
-                "Populating config value %r from env var %r with %r instead of config file",
-                config_name,
-                env_name,
-                env_val,
-            )
+            if config_name not in SECRET_CONFIG_OPTIONS:
+                LOG.info(
+                    "Populating config value %r from env var %r with %r instead of config file",
+                    config_name,
+                    env_name,
+                    env_val,
+                )
+            else:
+                LOG.info(
+                    "Populating config value %r from env var %r instead of config file",
+                    config_name,
+                    env_name,
+                )
+
             config[config_name] = parse_env_value(env_val)
 
 

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -17,7 +17,6 @@ from typing import List, Optional, Tuple
 
 import asyncio
 import base64
-import logging
 import time
 import ujson
 
@@ -39,7 +38,6 @@ class KafkaRest(KarapaceBase):
         super().__init__(config=config)
         self._add_kafka_rest_routes()
         self.serializer = SchemaRegistrySerializer(config=config)
-        self.log = logging.getLogger("KarapaceRest")
         self._cluster_metadata = None
         self._metadata_birth = None
         self.metadata_max_age = self.config["admin_metadata_max_age"]

--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -9,12 +9,10 @@ from typing import List
 
 import logging
 
+LOG = logging.getLogger(__name__)
+
 
 class KafkaRestAdminClient(KafkaAdminClient):
-    def __init__(self, **configs):
-        super().__init__(**configs)
-        self.log = logging.getLogger("AdminClient")
-
     def get_topic_config(self, topic: str) -> dict:
         config_version = self._matching_api_version(DescribeConfigsRequest)
         req_cfgs = [ConfigResource(ConfigResourceType.TOPIC, topic)]
@@ -50,7 +48,7 @@ class KafkaRestAdminClient(KafkaAdminClient):
         except Cancelled:
             if retries > 3:
                 raise
-            self.log.debug("Retrying metadata with %d retires", retries)
+            LOG.debug("Retrying metadata with %d retires", retries)
             return self.cluster_metadata(topics, retries + 1)
         return self._make_metadata_response(future.value)
 

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -24,21 +24,20 @@ KNOWN_FORMATS = {"json", "avro", "binary", "jsonschema", "protobuf"}
 OFFSET_RESET_STRATEGIES = {"latest", "earliest"}
 
 TypedConsumer = namedtuple("TypedConsumer", ["consumer", "serialization_format", "config"])
+LOG = logging.getLogger(__name__)
+
+
+def new_name() -> str:
+    return str(uuid.uuid4())
 
 
 class ConsumerManager:
     def __init__(self, config: dict) -> None:
         self.config = config
         self.hostname = f"http://{self.config['advertised_hostname']}:{self.config['port']}"
-        self.log = logging.getLogger("RestConsumerManager")
         self.deserializer = SchemaRegistryDeserializer(config=config)
         self.consumers = {}
         self.consumer_locks = defaultdict(Lock)
-
-    def new_name(self) -> str:
-        name = str(uuid.uuid4())
-        self.log.debug("Generated new consumer name: %s", name)
-        return name
 
     @staticmethod
     def _assert(cond: bool, code: HTTPStatus, sub_code: int, message: str, content_type: str) -> None:
@@ -155,12 +154,15 @@ class ConsumerManager:
     # CONSUMER
     async def create_consumer(self, group_name: str, request_data: dict, content_type: str):
         group_name = group_name.strip("/")
-        self.log.info("Create consumer request for group  %s", group_name)
-        consumer_name = request_data.get("name") or self.new_name()
+        consumer_name = request_data.get("name") or new_name()
         internal_name = self.create_internal_name(group_name, consumer_name)
         async with self.consumer_locks[internal_name]:
             if internal_name in self.consumers:
-                self.log.error("Error creating duplicate consumer in group %s with id %s", group_name, consumer_name)
+                LOG.warning(
+                    "Error creating duplicate consumer in group %s with id %s",
+                    group_name,
+                    consumer_name,
+                )
                 KarapaceBase.r(
                     status=HTTPStatus.CONFLICT,
                     content_type=content_type,
@@ -170,11 +172,14 @@ class ConsumerManager:
                     },
                 )
             self._validate_create_consumer(request_data, content_type)
-            self.log.info(
-                "Creating new consumer in group %s with id %s and request_info %r", group_name, consumer_name, request_data
-            )
             for k in ["consumer.request.timeout.ms", "fetch_min_bytes"]:
                 convert_to_int(request_data, k, content_type)
+            LOG.info(
+                "Creating new consumer in group. group name: %s consumer name: %s request_data %r",
+                group_name,
+                consumer_name,
+                request_data,
+            )
             try:
                 enable_commit = request_data.get("auto.commit.enable", self.config["consumer_enable_auto_commit"])
                 if isinstance(enable_commit, str):
@@ -223,11 +228,11 @@ class ConsumerManager:
                 )
                 return c
             except:  # pylint: disable=bare-except
-                self.log.exception("Unable to create consumer, retrying")
+                LOG.exception("Unable to create consumer, retrying")
                 await asyncio.sleep(1)
 
     async def delete_consumer(self, internal_name: Tuple[str, str], content_type: str):
-        self.log.info("Deleting consumer for %s", internal_name)
+        LOG.info("Deleting consumer for %s", internal_name)
         self._assert_consumer_exists(internal_name, content_type)
         async with self.consumer_locks[internal_name]:
             try:
@@ -235,7 +240,7 @@ class ConsumerManager:
                 c.consumer.close()
                 self.consumer_locks.pop(internal_name)
             except:  # pylint: disable=bare-except
-                self.log.exception("Unable to properly dispose of consumer")
+                LOG.exception("Unable to properly dispose of consumer")
             finally:
                 empty_response()
 
@@ -243,7 +248,7 @@ class ConsumerManager:
     async def commit_offsets(
         self, internal_name: Tuple[str, str], content_type: str, request_data: dict, cluster_metadata: dict
     ):
-        self.log.info("Committing offsets for %s", internal_name)
+        LOG.info("Committing offsets for %s", internal_name)
         self._assert_consumer_exists(internal_name, content_type)
         if request_data:
             self._assert_has_key(request_data, "offsets", content_type)
@@ -266,7 +271,7 @@ class ConsumerManager:
         empty_response()
 
     async def get_offsets(self, internal_name: Tuple[str, str], content_type: str, request_data: dict):
-        self.log.info("Retrieving offsets for %s", internal_name)
+        LOG.info("Retrieving offsets for %s", internal_name)
         self._assert_consumer_exists(internal_name, content_type)
         self._assert_has_key(request_data, "partitions", content_type)
         response = {"offsets": []}
@@ -290,7 +295,7 @@ class ConsumerManager:
 
     # SUBSCRIPTION
     async def set_subscription(self, internal_name: Tuple[str, str], content_type: str, request_data: dict):
-        self.log.info("Updating subscription for %s", internal_name)
+        LOG.info("Updating subscription for %s", internal_name)
         self._assert_consumer_exists(internal_name, content_type)
         topics = request_data.get("topics", [])
         topics_pattern = request_data.get("topic_pattern")
@@ -307,10 +312,10 @@ class ConsumerManager:
             except IllegalStateError as e:
                 self._illegal_state_fail(str(e), content_type=content_type)
             finally:
-                self.log.info("Done updating subscription")
+                LOG.info("Done updating subscription")
 
     async def get_subscription(self, internal_name: Tuple[str, str], content_type: str):
-        self.log.info("Retrieving subscription for %s", internal_name)
+        LOG.info("Retrieving subscription for %s", internal_name)
         self._assert_consumer_exists(internal_name, content_type)
         async with self.consumer_locks[internal_name]:
             consumer = self.consumers[internal_name].consumer
@@ -321,7 +326,7 @@ class ConsumerManager:
             KarapaceBase.r(content_type=content_type, body={"topics": topics})
 
     async def delete_subscription(self, internal_name: Tuple[str, str], content_type: str):
-        self.log.info("Deleting subscription for %s", internal_name)
+        LOG.info("Deleting subscription for %s", internal_name)
         self._assert_consumer_exists(internal_name, content_type)
         async with self.consumer_locks[internal_name]:
             self.consumers[internal_name].consumer.unsubscribe()
@@ -329,7 +334,7 @@ class ConsumerManager:
 
     # ASSIGNMENTS
     async def set_assignments(self, internal_name: Tuple[str, str], content_type: str, request_data: dict):
-        self.log.info("Updating assignments for %s to %r", internal_name, request_data)
+        LOG.info("Updating assignments for %s to %r", internal_name, request_data)
         self._assert_consumer_exists(internal_name, content_type)
         self._assert_has_key(request_data, "partitions", content_type)
         partitions = []
@@ -346,10 +351,10 @@ class ConsumerManager:
             except IllegalStateError as e:
                 self._illegal_state_fail(message=str(e), content_type=content_type)
             finally:
-                self.log.info("Done updating assignment")
+                LOG.info("Done updating assignment")
 
     async def get_assignments(self, internal_name: Tuple[str, str], content_type: str):
-        self.log.info("Retrieving assignment for %s", internal_name)
+        LOG.info("Retrieving assignment for %s", internal_name)
         self._assert_consumer_exists(internal_name, content_type)
         async with self.consumer_locks[internal_name]:
             consumer = self.consumers[internal_name].consumer
@@ -360,7 +365,7 @@ class ConsumerManager:
 
     # POSITIONS
     async def seek_to(self, internal_name: Tuple[str, str], content_type: str, request_data: dict):
-        self.log.info("Resetting offsets for %s to %r", internal_name, request_data)
+        LOG.info("Resetting offsets for %s to %r", internal_name, request_data)
         self._assert_consumer_exists(internal_name, content_type)
         self._assert_has_key(request_data, "offsets", content_type)
         seeks = []
@@ -384,7 +389,7 @@ class ConsumerManager:
         self, internal_name: Tuple[str, str], content_type: str, request_data: dict, beginning: bool = True
     ):
         direction = "beginning" if beginning else "end"
-        self.log.info("Seeking %s offsets", direction)
+        LOG.info("Seeking %s offsets", direction)
         self._assert_consumer_exists(internal_name, content_type)
         self._assert_has_key(request_data, "partitions", content_type)
         resets = []
@@ -406,7 +411,7 @@ class ConsumerManager:
                 self._illegal_state_fail(f"Trying to reset unassigned partitions to {direction}", content_type)
 
     async def fetch(self, internal_name: Tuple[str, str], content_type: str, formats: dict, query_params: dict):
-        self.log.info("Running fetch for name %s with parameters %r and formats %r", internal_name, query_params, formats)
+        LOG.info("Running fetch for name %s with parameters %r and formats %r", internal_name, query_params, formats)
         self._assert_consumer_exists(internal_name, content_type)
         async with self.consumer_locks[internal_name]:
             consumer = self.consumers[internal_name].consumer
@@ -420,7 +425,7 @@ class ConsumerManager:
                 content_type=content_type,
                 message=f"Consumer format {serialization_format} does not match the embedded format {request_format}",
             )
-            self.log.info("Fetch request for %s with params %r", internal_name, query_params)
+            LOG.info("Fetch request for %s with params %r", internal_name, query_params)
             try:
                 timeout = (
                     int(query_params["timeout"]) if "timeout" in query_params else config["consumer.request.timeout.ms"]
@@ -438,7 +443,7 @@ class ConsumerManager:
                 if val <= 0:
                     KarapaceBase.internal_error(message=f"Invalid request parameter {val}", content_type=content_type)
             response = []
-            self.log.info(
+            LOG.info(
                 "Will poll multiple times for a single message with a total timeout of %dms, "
                 "until at least %d bytes have been fetched",
                 timeout,
@@ -451,14 +456,14 @@ class ConsumerManager:
             while read_bytes < max_bytes and start_time + timeout / 1000 > time.monotonic():
                 time_left = start_time + timeout / 1000 - time.monotonic()
                 bytes_left = max_bytes - read_bytes
-                self.log.info(
+                LOG.info(
                     "Polling with %r time left and %d bytes left, gathered %d messages so far",
                     time_left,
                     bytes_left,
                     message_count,
                 )
                 data = consumer.poll(timeout_ms=timeout, max_records=1)
-                self.log.debug("Successfully polled for messages")
+                LOG.debug("Successfully polled for messages")
                 for topic, records in data.items():
                     for rec in records:
                         message_count += 1
@@ -468,7 +473,7 @@ class ConsumerManager:
                             + max(0, rec.serialized_header_size)
                         )
                         poll_data[topic].append(rec)
-            self.log.info("Gathered %d total messages", message_count)
+            LOG.info("Gathered %d total messages", message_count)
             for tp in poll_data:
                 for msg in poll_data[tp]:
                     try:

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -11,8 +11,6 @@ from karapace.config import Config
 from karapace.rapu import HTTPResponse, RestApp
 from typing import NoReturn, Union
 
-import logging
-
 
 class KarapaceBase(RestApp):
     def __init__(self, config: Config) -> None:
@@ -20,9 +18,8 @@ class KarapaceBase(RestApp):
 
         self.kafka_timeout = 10
         self.route("/", callback=self.root_get, method="GET")
-        self.log = logging.getLogger("Karapace")
-        self.log.info("Karapace initialized")
         self.app.on_shutdown.append(self.close_by_app)
+        self.log.info("Karapace initialized")
 
     async def close_by_app(self, app):
         # pylint: disable=unused-argument

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -1,7 +1,7 @@
 from aiohttp.web_log import AccessLogger
 from contextlib import closing
 from karapace import version as karapace_version
-from karapace.config import Config, read_config
+from karapace.config import read_config
 from karapace.kafka_rest_apis import KafkaRest
 from karapace.rapu import RestApp
 from karapace.schema_registry_apis import KarapaceSchemaRegistry
@@ -13,9 +13,7 @@ import sys
 
 
 class KarapaceAll(KafkaRest, KarapaceSchemaRegistry):
-    def __init__(self, config: Config) -> None:
-        super().__init__(config=config)
-        self.log = logging.getLogger("KarapaceAll")
+    pass
 
 
 def main() -> int:

--- a/karapace/protobuf/io.py
+++ b/karapace/protobuf/io.py
@@ -10,11 +10,8 @@ from typing import Any, Dict, List
 import hashlib
 import importlib
 import importlib.util
-import logging
 import os
 import subprocess
-
-logger = logging.getLogger(__name__)
 
 
 def calculate_class_name(name: str) -> str:

--- a/karapace/schema_backup.py
+++ b/karapace/schema_backup.py
@@ -11,7 +11,7 @@ from karapace import constants
 from karapace.anonymize_schemas import anonymize_avro
 from karapace.config import Config, read_config
 from karapace.schema_reader import KafkaSchemaReader
-from karapace.utils import json_encode, KarapaceKafkaClient
+from karapace.utils import json_encode, KarapaceKafkaClient, Timeout
 from typing import Dict, List, Optional, Tuple
 
 import argparse
@@ -24,10 +24,6 @@ import ujson
 
 class BackupError(Exception):
     """Backup Error"""
-
-
-class Timeout(Exception):
-    """Timeout Error"""
 
 
 class SchemaBackup:

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -16,10 +16,7 @@ from karapace.utils import json_encode
 from typing import Any, Dict, Union
 
 import json
-import logging
 import ujson
-
-log = logging.getLogger(__name__)
 
 
 def parse_avro_schema_definition(s: str) -> AvroSchema:
@@ -146,7 +143,6 @@ class ValidatedTypedSchema(TypedSchema):
                 ProtobufException,
                 ProtobufSchemaParseException,
             ) as e:
-                log.exception("Unexpected error: %s \n schema:[%s]", e, schema_str)
                 raise InvalidSchema from e
         else:
             raise InvalidSchema(f"Unknown parser {schema_type} for {schema_str}")

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -13,11 +13,8 @@ import asyncio
 import avro
 import avro.schema
 import io
-import logging
 import struct
 import ujson
-
-log = logging.getLogger(__name__)
 
 START_BYTE = 0x0
 HEADER_FORMAT = ">bI"

--- a/karapace/statsd.py
+++ b/karapace/statsd.py
@@ -19,13 +19,13 @@ import time
 
 STATSD_HOST = "127.0.0.1"
 STATSD_PORT = 8125
+LOG = logging.getLogger(__name__)
 
 
 class StatsClient:
     def __init__(self, host: str = STATSD_HOST, port: int = STATSD_PORT, sentry_config: Dict = None) -> None:
         self.sentry_config: Dict
 
-        self.log = logging.getLogger("StatsClient")
         if sentry_config is None:
             self.sentry_config = {
                 "dsn": os.environ.get("SENTRY_DSN"),
@@ -73,7 +73,7 @@ class StatsClient:
                 self.raven_client = raven.Client(**self.sentry_config)
             except ImportError:
                 self.raven_client = None
-                self.log.warning("Cannot enable Sentry.io sending: importing 'raven' failed")
+                LOG.warning("Cannot enable Sentry.io sending: importing 'raven' failed")
         else:
             self.raven_client = None
 
@@ -125,8 +125,8 @@ class StatsClient:
                 parts.insert(1, ",{}={}".format(tag, tag_value).encode("utf-8"))
 
             self._socket.sendto(b"".join(parts), self._dest_addr)
-        except Exception as ex:  # pylint: disable=broad-except
-            self.log.error("Unexpected exception in statsd send: %s: %s", ex.__class__.__name__, ex)
+        except Exception:  # pylint: disable=broad-except
+            LOG.exception("Unexpected exception in statsd send")
 
     def close(self) -> None:
         self._socket.close()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pytest==6.2.5
 pytest-xdist[psutil]==2.2.1
 pytest-timeout==1.4.2
 pdbpp==0.10.2
+psutil==5.9.0
 
 # workflow
 pre-commit>=2.2.0

--- a/tests/integration/test_master_coordinator.py
+++ b/tests/integration/test_master_coordinator.py
@@ -8,7 +8,7 @@ from contextlib import closing
 from karapace.config import set_config_defaults
 from karapace.master_coordinator import MasterCoordinator
 from tests.integration.utils.kafka_server import KafkaServers
-from tests.integration.utils.network import get_random_port, TESTS_PORT_RANGE
+from tests.integration.utils.network import PortRangeInclusive
 from tests.utils import new_random_name
 
 import asyncio
@@ -16,10 +16,6 @@ import pytest
 import requests
 import time
 import ujson
-
-
-class Timeout(Exception):
-    pass
 
 
 def init_admin(config):
@@ -44,82 +40,82 @@ def has_master(mc: MasterCoordinator) -> bool:
 
 @pytest.mark.timeout(60)  # Github workflows need a bit of extra time
 @pytest.mark.parametrize("strategy", ["lowest", "highest"])
-def test_master_selection(kafka_servers: KafkaServers, strategy: str) -> None:
+def test_master_selection(port_range: PortRangeInclusive, kafka_servers: KafkaServers, strategy: str) -> None:
     # Use random port to allow for parallel runs.
-    port1 = get_random_port(port_range=TESTS_PORT_RANGE, blacklist=[])
-    port2 = get_random_port(port_range=TESTS_PORT_RANGE, blacklist=[port1])
-    port_aa, port_bb = sorted((port1, port2))
-    client_id_aa = new_random_name("master_selection_aa_")
-    client_id_bb = new_random_name("master_selection_bb_")
-    group_id = new_random_name("group_id")
+    with port_range.allocate_port() as port1, port_range.allocate_port() as port2:
+        port_aa, port_bb = sorted((port1, port2))
+        client_id_aa = new_random_name("master_selection_aa_")
+        client_id_bb = new_random_name("master_selection_bb_")
+        group_id = new_random_name("group_id")
 
-    config_aa = set_config_defaults(
-        {
-            "advertised_hostname": "127.0.0.1",
-            "bootstrap_uri": kafka_servers.bootstrap_servers,
-            "client_id": client_id_aa,
-            "group_id": group_id,
-            "port": port_aa,
-            "master_election_strategy": strategy,
-        }
-    )
-    config_bb = set_config_defaults(
-        {
-            "advertised_hostname": "127.0.0.1",
-            "bootstrap_uri": kafka_servers.bootstrap_servers,
-            "client_id": client_id_bb,
-            "group_id": group_id,
-            "port": port_bb,
-            "master_election_strategy": strategy,
-        }
-    )
+        config_aa = set_config_defaults(
+            {
+                "advertised_hostname": "127.0.0.1",
+                "bootstrap_uri": kafka_servers.bootstrap_servers,
+                "client_id": client_id_aa,
+                "group_id": group_id,
+                "port": port_aa,
+                "master_election_strategy": strategy,
+            }
+        )
+        config_bb = set_config_defaults(
+            {
+                "advertised_hostname": "127.0.0.1",
+                "bootstrap_uri": kafka_servers.bootstrap_servers,
+                "client_id": client_id_bb,
+                "group_id": group_id,
+                "port": port_bb,
+                "master_election_strategy": strategy,
+            }
+        )
 
-    with closing(init_admin(config_aa)) as mc_aa, closing(init_admin(config_bb)) as mc_bb:
-        if strategy == "lowest":
-            master = mc_aa
-            slave = mc_bb
-        else:
-            master = mc_bb
-            slave = mc_aa
+        with closing(init_admin(config_aa)) as mc_aa, closing(init_admin(config_bb)) as mc_bb:
+            if strategy == "lowest":
+                master = mc_aa
+                slave = mc_bb
+            else:
+                master = mc_bb
+                slave = mc_aa
 
-        # Wait for the election to happen
-        while not is_master(master):
-            time.sleep(0.3)
+            # Wait for the election to happen
+            while not is_master(master):
+                time.sleep(0.3)
 
-        while not has_master(slave):
-            time.sleep(0.3)
+            while not has_master(slave):
+                time.sleep(0.3)
 
-        # Make sure the end configuration is as expected
-        master_url = f'http://{master.config["host"]}:{master.config["port"]}'
-        assert master.sc.election_strategy == strategy
-        assert slave.sc.election_strategy == strategy
-        assert master.sc.master_url == master_url
-        assert slave.sc.master_url == master_url
+            # Make sure the end configuration is as expected
+            master_url = f'http://{master.config["host"]}:{master.config["port"]}'
+            assert master.sc.election_strategy == strategy
+            assert slave.sc.election_strategy == strategy
+            assert master.sc.master_url == master_url
+            assert slave.sc.master_url == master_url
 
 
-def test_no_eligible_master(kafka_servers: KafkaServers) -> None:
+def test_no_eligible_master(kafka_servers: KafkaServers, port_range: PortRangeInclusive) -> None:
     client_id = new_random_name("master_selection_")
     group_id = new_random_name("group_id")
 
-    config_aa = set_config_defaults(
-        {
-            "advertised_hostname": "127.0.0.1",
-            "bootstrap_uri": kafka_servers.bootstrap_servers,
-            "client_id": client_id,
-            "group_id": group_id,
-            "port": get_random_port(port_range=TESTS_PORT_RANGE, blacklist=[]),
-            "master_eligibility": False,
-        }
-    )
+    with port_range.allocate_port() as port:
+        config_aa = set_config_defaults(
+            {
+                "advertised_hostname": "127.0.0.1",
+                "bootstrap_uri": kafka_servers.bootstrap_servers,
+                "client_id": client_id,
+                "group_id": group_id,
+                "port": port,
+                "master_eligibility": False,
+            }
+        )
 
-    with closing(init_admin(config_aa)) as mc:
-        # Wait for the election to happen, ie. flag is not None
-        while not mc.sc or mc.sc.are_we_master is None:
-            time.sleep(0.3)
+        with closing(init_admin(config_aa)) as mc:
+            # Wait for the election to happen, ie. flag is not None
+            while not mc.sc or mc.sc.are_we_master is None:
+                time.sleep(0.3)
 
-        # Make sure the end configuration is as expected
-        assert mc.sc.are_we_master is False
-        assert mc.sc.master_url is None
+            # Make sure the end configuration is as expected
+            assert mc.sc.are_we_master is False
+            assert mc.sc.master_url is None
 
 
 async def test_schema_request_forwarding(registry_async_pair):

--- a/tests/integration/test_schema_backup_avro_export.py
+++ b/tests/integration/test_schema_backup_avro_export.py
@@ -8,6 +8,7 @@ from karapace.client import Client
 from karapace.config import set_config_defaults
 from karapace.schema_backup import SchemaBackup
 from pathlib import Path
+from tests.integration.utils.cluster import RegistryDescription
 from tests.integration.utils.kafka_server import KafkaServers
 from typing import Any, Dict
 
@@ -63,14 +64,22 @@ async def insert_data(c: Client, schemaType: str, subject: str, data: Dict[str, 
 
 
 async def test_export_anonymized_avro_schemas(
-    registry_async_client: Client, kafka_servers: KafkaServers, tmp_path: Path
+    registry_async_client: Client,
+    kafka_servers: KafkaServers,
+    tmp_path: Path,
+    registry_cluster: RegistryDescription,
 ) -> None:
     await insert_data(registry_async_client, "JSON", JSON_SUBJECT, JSON_SCHEMA)
     await insert_data(registry_async_client, "AVRO", AVRO_SUBJECT, AVRO_SCHEMA)
 
     # Get the backup
     export_location = tmp_path / "export.log"
-    config = set_config_defaults({"bootstrap_uri": kafka_servers.bootstrap_servers})
+    config = set_config_defaults(
+        {
+            "bootstrap_uri": kafka_servers.bootstrap_servers,
+            "topic_name": registry_cluster.schemas_topic,
+        }
+    )
     sb = SchemaBackup(config, str(export_location))
     sb.export_anonymized_avro_schemas()
 

--- a/tests/integration/utils/cluster.py
+++ b/tests/integration/utils/cluster.py
@@ -1,0 +1,97 @@
+from contextlib import asynccontextmanager, ExitStack
+from dataclasses import dataclass
+from karapace.config import Config, set_config_defaults, write_config
+from pathlib import Path
+from subprocess import Popen
+from tests.integration.utils.network import PortRangeInclusive
+from tests.integration.utils.process import stop_process, wait_for_port_subprocess
+from tests.utils import new_random_name
+from typing import AsyncIterator, List
+
+
+@dataclass(frozen=True)
+class RegistryEndpoint:
+    protocol: str
+    host: str
+    port: int
+
+    def to_url(self) -> str:
+        return f"{self.protocol}://{self.host}:{self.port}"
+
+
+@dataclass(frozen=True)
+class RegistryDescription:
+    endpoint: RegistryEndpoint
+    schemas_topic: str
+
+
+@asynccontextmanager
+async def start_schema_registry_cluster(
+    config_templates: List[Config],
+    data_dir: Path,
+    port_range: PortRangeInclusive,
+) -> AsyncIterator[List[RegistryDescription]]:
+    """Start a cluster of schema registries, one process per `config_templates`."""
+    for template in config_templates:
+        assert "bootstrap_uri" in template, "base_config must have the value `bootstrap_uri` set"
+
+    # None is considered a valid value, and it represents the lack of user
+    # configuration, so this will generate one for the cluster
+    group_ids = set(config.get("group_id") for config in config_templates)
+    assert len(group_ids) == 1, f"All configurations entries must have the same group_id value, got: {group_ids}"
+
+    group_id = new_random_name("group_id")
+    schemas_topic = new_random_name("_schemas")
+
+    all_processes = []
+    all_registries = []
+    with ExitStack() as stack:
+        for pos, template in enumerate(config_templates):
+            config = dict(template)
+            del template
+
+            # For testing we don't want to expose the hostname, usually the loopback interface is
+            # used (127.0.0.1), and the name resolution would instead return the machine's network
+            # address, (e.g. 192.168.0.1), which would cause connect failures
+            host = config.setdefault("host", "127.0.0.1")
+            assert isinstance(host, str), "host must be str"
+            config.setdefault("advertised_hostname", host)
+            config.setdefault("topic_name", schemas_topic)
+            config.setdefault("karapace_registry", True)
+            config.setdefault(
+                "log_format",
+                "%(asctime)s [%(threadName)s] %(filename)s:%(funcName)s:%(lineno)d %(message)s",
+            )
+            actual_group_id = config.setdefault("group_id", group_id)
+
+            port = config.setdefault("port", stack.enter_context(port_range.allocate_port()))
+            assert isinstance(port, int), "Port must be an integer"
+
+            group_dir = data_dir / str(actual_group_id)
+            group_dir.mkdir(parents=True, exist_ok=True)
+            config_path = group_dir / f"{pos}.config.json"
+            log_path = group_dir / f"{pos}.log"
+            error_path = group_dir / f"{pos}.error"
+
+            config = set_config_defaults(config)
+            write_config(config_path, config)
+
+            logfile = stack.enter_context(open(log_path, "w"))
+            errfile = stack.enter_context(open(error_path, "w"))
+            process = Popen(
+                args=["python", "-m", "karapace.karapace_all", str(config_path)],
+                stdout=logfile,
+                stderr=errfile,
+            )
+            stack.callback(stop_process, process)
+            all_processes.append(process)
+
+            protocol = "http" if config.get("server_tls_keyfile") is None else "https"
+            endpoint = RegistryEndpoint(protocol, host, port)
+            description = RegistryDescription(endpoint, schemas_topic)
+            all_registries.append(description)
+
+        for process in all_processes:
+            wait_for_port_subprocess(port, process, hostname=host)
+
+        yield all_registries

--- a/tests/integration/utils/network.py
+++ b/tests/integration/utils/network.py
@@ -2,68 +2,71 @@
 Copyright (c) 2022 Aiven Ltd
 See LICENSE for details
 """
-from dataclasses import dataclass
-from typing import List
+from contextlib import contextmanager
 
-import random
+import psutil
 import socket
 
 
-@dataclass(frozen=True)
-class PortRangeInclusive:
-    start: int
-    end: int
+def is_time_wait(port: int) -> bool:
+    """True if the port is still on TIME_WAIT state."""
+    return any(conn.laddr.port == port for conn in psutil.net_connections(kind="inet"))
 
+
+class PortRangeInclusive:
     PRIVILEGE_END = 2**10
     MAX_PORTS = 2**16 - 1
 
-    def __post_init__(self) -> None:
+    def __init__(
+        self,
+        start: int,
+        end: int,
+    ) -> None:
         # Make sure the range is valid and that we don't need to be root
-        assert self.end > self.start, "there must be at least one port available"
-        assert self.end <= self.MAX_PORTS, f"end must be lower than {self.MAX_PORTS}"
-        assert self.start > self.PRIVILEGE_END, "start must not be a privileged port"
+        assert end > start, "there must be at least one port available"
+        assert end <= self.MAX_PORTS, f"end must be lower than {self.MAX_PORTS}"
+        assert start > self.PRIVILEGE_END, "start must not be a privileged port"
+
+        self.start = start
+        self.end = end
+        self._maybe_available = list(range(start, end + 1))
 
     def next_range(self, number_of_ports: int) -> "PortRangeInclusive":
-        next_start = self.end + 1
-        next_end = next_start + number_of_ports - 1  # -1 because the range is inclusive
-
+        next_start = self.end
+        next_end = next_start + number_of_ports
         return PortRangeInclusive(next_start, next_end)
 
+    @contextmanager
+    def allocate_port(self) -> int:
+        """Find a random port in the range `PortRangeInclusive`.
 
-# To find a good port range use the following:
-#
-#   curl --silent 'https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt' | \
-#       egrep -i -e '^\s*[0-9]+-[0-9]+\s*unassigned' | \
-#       awk '{print $1}'
-#
-KAFKA_PORT_RANGE = PortRangeInclusive(48700, 48800)
-ZK_PORT_RANGE = KAFKA_PORT_RANGE.next_range(100)
-REGISTRY_PORT_RANGE = ZK_PORT_RANGE.next_range(100)
-TESTS_PORT_RANGE = REGISTRY_PORT_RANGE.next_range(100)
+        Note:
+            This function is *not* aware of the ports currently open in the system,
+            the blacklist only prevents two services of the same type to randomly
+            get the same ports for *a single test run*.
 
+            Because of that, the port range should be chosen such that there is no
+            system service in the range. Also note that running two sessions of the
+            tests with the same range is not supported and will lead to flakiness.
+        """
+        if len(self._maybe_available) == 0:
+            raise RuntimeError(f"No free ports available. start: {self.start} end: {self.end}")
 
-def get_random_port(*, port_range: PortRangeInclusive, blacklist: List[int]) -> int:
-    """Find a random port in the range `PortRangeInclusive`.
+        filtered_ports = ((pos, port) for pos, port in enumerate(self._maybe_available) if not is_time_wait(port))
 
-    Note:
-        This function is *not* aware of the ports currently open in the system,
-        the blacklist only prevents two services of the same type to randomly
-        get the same ports for *a single test run*.
+        try:
+            pos, port = next(filtered_ports)
+        except StopIteration as e:
+            raise RuntimeError(
+                f"No free ports available. start: {self.start} end: {self.end} time_wait: {self._maybe_available}"
+            ) from e
 
-        Because of that, the port range should be chosen such that there is no
-        system service in the range. Also note that running two sessions of the
-        tests with the same range is not supported and will lead to flakiness.
-    """
-    assert port_range.start <= port_range.end, f"{port_range.start} must be less-than-or-equal to {port_range.end}"
+        self._maybe_available.pop(pos)
+        yield port
 
-    # +1 because randint is inclusive for both ends
-    ports_in_range = (port_range.end - port_range.start) + 1
-    assert len(blacklist) < ports_in_range, f"no free ports available. Range {port_range}, blacklist: {blacklist}"
-
-    value = random.randint(port_range.start, port_range.end)
-    while value in blacklist:
-        value = random.randint(port_range.start, port_range.end)
-    return value
+        # Append the port at the end, this is a hack to give extra time for a TIME_WAIT socket to
+        # close, but it is not sufficient.
+        self._maybe_available.append(port)
 
 
 def port_is_listening(hostname: str, port: int, ipv6: bool) -> bool:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -176,6 +176,8 @@ async def new_consumer(c, group, fmt="avro", trail=""):
 
 
 def new_random_name(prefix: str) -> str:
+    # A hyphen is not a valid character for Avro identifiers. Use only the
+    # first 8 characters of the UUID.
     suffix = str(uuid.uuid4())[:8]
     return f"{prefix}{suffix}"
 
@@ -205,9 +207,7 @@ def create_id_factory(prefix: str) -> Callable[[], str]:
 
     def create_name() -> str:
         nonlocal index
-        random_name = str(uuid.uuid4())[:8]
-        name = f"{quote(prefix).replace('/', '_')}_{index}_{random_name}"
-        return name
+        return new_random_name(f"{quote(prefix).replace('/', '_')}_{index}_")
 
     return create_name
 


### PR DESCRIPTION
Merge after https://github.com/aiven/karapace/pull/391 (It fix port allocation for integration tests)

## Why?

Logging schemas has two problems (1) It is cpu intensive, and this is a problem while starting Karapace against a topic with a couple of thousands of schemas (2) Schemas are private information, and this changes the logging with them to `TRACE` level instead of `DEBUG`.

This also makes some logger instances private.