### PR TITLE
schema_registry: made lock private

### DIFF
--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -11,7 +11,6 @@ from karapace.config import Config
 from karapace.rapu import HTTPResponse, RestApp
 from typing import NoReturn, Union
 
-import asyncio
 import logging
 
 
@@ -23,7 +22,6 @@ class KarapaceBase(RestApp):
         self.route("/", callback=self.root_get, method="GET")
         self.log = logging.getLogger("Karapace")
         self.app.on_startup.append(self.create_http_client)
-        self.master_lock = asyncio.Lock()
         self.log.info("Karapace initialized")
         self.app.on_shutdown.append(self.close_by_app)
 

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -57,6 +57,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.ksr = KafkaSchemaReader(config=self.config, master_coordinator=self.mc)
         self.ksr.start()
         self.schema_lock = asyncio.Lock()
+        self._master_lock = asyncio.Lock()
 
     def _create_producer(self) -> KafkaProducer:
         while True:
@@ -643,7 +644,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.r(list(subject_data["schemas"]), content_type, status=HTTPStatus.OK)
 
     async def get_master(self) -> Tuple[bool, Optional[str]]:
-        async with self.master_lock:
+        async with self._master_lock:
             while True:
                 are_we_master, master_url = self.mc.get_master_info()
                 if are_we_master is None:


### PR DESCRIPTION
The lock is used only internally by the schema_registry