### PR TITLE
Schema reader loop improvements

### DIFF
--- a/karapace/schema_backup.py
+++ b/karapace/schema_backup.py
@@ -10,7 +10,7 @@ from kafka.errors import NoBrokersAvailable, NodeNotReadyError, TopicAlreadyExis
 from karapace import constants
 from karapace.anonymize_schemas import anonymize_avro
 from karapace.config import Config, read_config
-from karapace.schema_reader import KafkaSchemaReader
+from karapace.schema_reader import new_schema_topic_from_config
 from karapace.utils import json_encode, KarapaceKafkaClient, Timeout
 from typing import Dict, List, Optional, Tuple
 
@@ -108,7 +108,7 @@ class SchemaBackup:
             if time.monotonic() - start_time > wait_time:
                 raise Timeout(f"Timeout ({wait_time}) on creating admin client")
 
-            schema_topic = KafkaSchemaReader.get_new_schema_topic(self.config)
+            schema_topic = new_schema_topic_from_config(self.config)
             try:
                 LOG.info("Creating schema topic: %r", schema_topic)
                 self.admin_client.create_topics([schema_topic], timeout_ms=constants.TOPIC_CREATION_TIMEOUT_MS)

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -58,6 +58,21 @@ def _create_consumer_from_config(config: Config) -> KafkaConsumer:
     )
 
 
+def _create_admin_client_from_config(config: Config) -> KafkaAdminClient:
+    return KafkaAdminClient(
+        api_version_auto_timeout_ms=constants.API_VERSION_AUTO_TIMEOUT_MS,
+        bootstrap_servers=config["bootstrap_uri"],
+        client_id=config["client_id"],
+        security_protocol=config["security_protocol"],
+        ssl_cafile=config["ssl_cafile"],
+        ssl_certfile=config["ssl_certfile"],
+        ssl_keyfile=config["ssl_keyfile"],
+        sasl_mechanism=config["sasl_mechanism"],
+        sasl_plain_username=config["sasl_plain_username"],
+        sasl_plain_password=config["sasl_plain_password"],
+    )
+
+
 class OffsetsWatcher:
     """Synchronization container for threads to wait until an offset is seen.
 
@@ -140,18 +155,7 @@ class KafkaSchemaReader(Thread):
 
     def init_admin_client(self) -> bool:
         try:
-            self.admin_client = KafkaAdminClient(
-                api_version_auto_timeout_ms=constants.API_VERSION_AUTO_TIMEOUT_MS,
-                bootstrap_servers=self.config["bootstrap_uri"],
-                client_id=self.config["client_id"],
-                security_protocol=self.config["security_protocol"],
-                ssl_cafile=self.config["ssl_cafile"],
-                ssl_certfile=self.config["ssl_certfile"],
-                ssl_keyfile=self.config["ssl_keyfile"],
-                sasl_mechanism=self.config["sasl_mechanism"],
-                sasl_plain_username=self.config["sasl_plain_username"],
-                sasl_plain_password=self.config["sasl_plain_password"],
-            )
+            self.admin_client = _create_admin_client_from_config(self.config)
             return True
         except (NodeNotReadyError, NoBrokersAvailable, AssertionError):
             LOG.warning("No Brokers available yet, retrying init_admin_client()")


### PR DESCRIPTION
Review after https://github.com/aiven/karapace/pull/391 (It fix port allocation for integration tests)

These are the main changes here:

- If creating the `Consumer` fails, the loop should wait a bit, just like it was done for the `AdminClient`.
   - The motivation for this was a hot loop where Karapace was constantly failing to run inside docker, because it could not resolve the hostname. I'm not sure what caused that bug, but I wanted to remove the hot loop (I have the feeling the hotloop is inside kafka-python library, but this one should be fixed anyways)
- The `close` of the consumer should be called even if the `close` of admin client fails
- Instead of using a flag now it uses an Event to stop the thread. It will be faster to stop an uninitialized thread that is doing a retry.

Also:

- I moved the instantiation out of the schema reader class. I tried to consolidate this before, but it is a lot of changes to get all the clients created by the same util (there are some inconsistencies in our flags because of this). This is just a small change that should make it easier to share utils to instantiate the clients from the config.
- This is a bit of ground work to isolate the thread initialization from the processing of messages. My idea is to move the complete state and the handling of message to a separate class, so that we can unit test it without using threads which is painful to use with a debugger and to properly assert on.