### PR TITLE
Cleanup rest app

### DIFF
--- a/karapace/config.py
+++ b/karapace/config.py
@@ -41,6 +41,7 @@ DEFAULTS = {
     "registry_port": 8081,
     "registry_ca": None,
     "log_level": "DEBUG",
+    "log_format": "%(name)-20s\t%(threadName)s\t%(levelname)-8s\t%(message)s",
     "master_eligibility": True,
     "replication_factor": 1,
     "security_protocol": "PLAINTEXT",
@@ -66,7 +67,6 @@ DEFAULTS = {
     "master_election_strategy": "lowest",
     "protobuf_runtime_directory": "runtime",
 }
-DEFAULT_LOG_FORMAT_JOURNAL = "%(name)-20s\t%(threadName)s\t%(levelname)-8s\t%(message)s"
 
 
 class InvalidConfiguration(Exception):

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -22,6 +22,7 @@ HOSTNAME = socket.gethostname()
 
 DEFAULTS = {
     "access_logs_debug": False,
+    "access_log_class": None,
     "advertised_hostname": HOSTNAME,
     "bootstrap_uri": "127.0.0.1:9092",
     "client_id": "sr-1",

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -21,7 +21,6 @@ class KarapaceBase(RestApp):
         self.kafka_timeout = 10
         self.route("/", callback=self.root_get, method="GET")
         self.log = logging.getLogger("Karapace")
-        self.app.on_startup.append(self.create_http_client)
         self.log.info("Karapace initialized")
         self.app.on_shutdown.append(self.close_by_app)
 

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -1,7 +1,7 @@
 from aiohttp.web_log import AccessLogger
 from contextlib import closing
 from karapace import version as karapace_version
-from karapace.config import Config, DEFAULT_LOG_FORMAT_JOURNAL, read_config
+from karapace.config import Config, read_config
 from karapace.kafka_rest_apis import KafkaRest
 from karapace.rapu import RestApp
 from karapace.schema_registry_apis import KarapaceSchemaRegistry
@@ -27,7 +27,7 @@ def main() -> int:
     with closing(arg.config_file):
         config = read_config(arg.config_file)
 
-    logging.basicConfig(level=logging.INFO, format=DEFAULT_LOG_FORMAT_JOURNAL)
+    logging.basicConfig(level=logging.INFO, format=config["log_format"])
     logging.getLogger().setLevel(config["log_level"])
     if config.get("access_logs_debug") is True:
         config["access_log_class"] = DebugAccessLogger

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -7,12 +7,14 @@ from karapace.compatibility.jsonschema.checks import is_incompatible
 from karapace.config import Config
 from karapace.karapace import KarapaceBase
 from karapace.master_coordinator import MasterCoordinator
-from karapace.rapu import HTTPRequest
+from karapace.rapu import HTTPRequest, JSON_CONTENT_TYPE, SERVER_NAME
 from karapace.schema_models import InvalidSchema, InvalidSchemaType, ValidatedTypedSchema
 from karapace.schema_reader import KafkaSchemaReader, SchemaType, TypedSchema
 from karapace.utils import json_encode, KarapaceKafkaClient
 from typing import Any, Dict, Optional, Tuple
 
+import aiohttp
+import async_timeout
 import asyncio
 import time
 
@@ -58,6 +60,17 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.ksr.start()
         self.schema_lock = asyncio.Lock()
         self._master_lock = asyncio.Lock()
+
+        self._forward_client = None
+        self.app.on_startup.append(self._create_forward_client)
+        self.app.on_cleanup.append(self._cleanup_forward_client)
+
+    async def _create_forward_client(self, app):  # pylint: disable=unused-argument
+        self._forward_client = aiohttp.ClientSession(headers={"User-Agent": SERVER_NAME})
+
+    async def _cleanup_forward_client(self, app):  # pylint: disable=unused-argument
+        if self._forward_client:
+            await self._forward_client.close()
 
     def _create_producer(self) -> KafkaProducer:
         while True:
@@ -893,9 +906,19 @@ class KarapaceSchemaRegistry(KarapaceBase):
         self.r({"id": schema_id}, content_type)
 
     async def forward_request_remote(self, *, body, url, content_type, method="POST"):
+        assert self._forward_client is not None, "Server must be initialized"
+
         self.log.info("Writing new schema to remote url: %r since we're not the master", url)
-        response = await self.http_request(url=url, method=method, json=body, timeout=60.0)
-        self.r(body=response.body, content_type=content_type, status=HTTPStatus(response.status))
+        timeout = 60.0
+        func = getattr(self._forward_client, method.lower())
+        with async_timeout.timeout(timeout):
+            async with func(url, json=body) as response:
+                if response.headers.get("content-type", "").startswith(JSON_CONTENT_TYPE):
+                    resp_content = await response.json()
+                else:
+                    resp_content = await response.text()
+
+        self.r(body=resp_content, content_type=content_type, status=HTTPStatus(response.status))
 
     def no_master_error(self, content_type):
         self.r(

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -429,7 +429,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/config"
-            await self.forward_request_remote(body=body, url=url, content_type=content_type, method="PUT")
+            await self._forward_request_remote(body=body, url=url, content_type=content_type, method="PUT")
 
         self.r({"compatibility": self.ksr.config["compatibility"]}, content_type)
 
@@ -480,7 +480,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/config/{subject}"
-            await self.forward_request_remote(body=request.json, url=url, content_type=content_type, method="PUT")
+            await self._forward_request_remote(body=request.json, url=url, content_type=content_type, method="PUT")
 
         self.r({"compatibility": compatibility_level.value}, content_type)
 
@@ -527,7 +527,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}?permanent={permanent}"
-            await self.forward_request_remote(body={}, url=url, content_type=content_type, method="DELETE")
+            await self._forward_request_remote(body={}, url=url, content_type=content_type, method="DELETE")
 
     async def subject_version_get(self, content_type, *, subject, version, return_dict=False):
         self._validate_version(content_type, version)
@@ -630,7 +630,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}/versions/{version}?permanent={permanent}"
-            await self.forward_request_remote(body={}, url=url, content_type=content_type, method="DELETE")
+            await self._forward_request_remote(body={}, url=url, content_type=content_type, method="DELETE")
 
     async def subject_version_schema_get(self, content_type, *, subject, version):
         self._validate_version(content_type, version)
@@ -777,7 +777,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
             self.no_master_error(content_type)
         else:
             url = f"{master_url}/subjects/{subject}/versions"
-            await self.forward_request_remote(body=body, url=url, content_type=content_type, method="POST")
+            await self._forward_request_remote(body=body, url=url, content_type=content_type, method="POST")
 
     def write_new_schema_local(self, subject, body, content_type):
         """Since we're the master we get to write the new schema"""
@@ -905,7 +905,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
         )
         self.r({"id": schema_id}, content_type)
 
-    async def forward_request_remote(self, *, body, url, content_type, method="POST"):
+    async def _forward_request_remote(self, *, body, url, content_type, method="POST"):
         assert self._forward_client is not None, "Server must be initialized"
 
         self.log.info("Writing new schema to remote url: %r since we're not the master", url)

--- a/tests/integration/utils/process.py
+++ b/tests/integration/utils/process.py
@@ -37,8 +37,12 @@ def wait_for_port_subprocess(
 
 def stop_process(proc: Optional[Popen]) -> None:
     if proc:
-        os.kill(proc.pid, signal.SIGKILL)
-        proc.wait(timeout=10.0)
+        try:
+            os.kill(proc.pid, signal.SIGKILL)
+            proc.wait(timeout=10.0)
+        # ProcessLookupError: Raised when the process is already gone
+        except ProcessLookupError:
+            pass
 
 
 def get_java_process_configuration(java_args: List[str]) -> List[str]:


### PR DESCRIPTION
This PR has a few varied changes for issues I found while fixing the tests.

The biggest change is to remove the dead code from RestApp. It currently supports SOCKS requests, which is never used, and it contains two sessions, one with SSL validation and another without, only the one with validation is used.

I'm not sure if this was introduced while working on a feature but it was not finished. For now I'm removing it because I'm seeing SSL validation errors, and that reduces the number of things I need to check to fix that.

There is also some other small changes, for issues I found while debugging.