### PR TITLE
karapace: using context manager to ensure all resources are closed

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -2,6 +2,7 @@ from aiokafka import AIOKafkaProducer
 from aiokafka.errors import KafkaConnectionError
 from binascii import Error as B64DecodeError
 from collections import namedtuple
+from contextlib import AsyncExitStack, closing
 from http import HTTPStatus
 from kafka.errors import BrokerResponseError, KafkaTimeoutError, NodeNotReadyError, UnknownTopicOrPartitionError
 from karapace.config import Config, create_client_ssl_context
@@ -327,18 +328,20 @@ class KafkaRest(KarapaceBase):
                 time.sleep(1)
 
     async def close(self) -> None:
-        await super().close()
+        async with AsyncExitStack() as stack, self._async_producer_lock:
+            stack.push_async_callback(super().close)
 
-        async with self._async_producer_lock:
             if self._async_producer is not None:
                 self.log.info("Disposing async producer")
-                await self._async_producer.stop()
+                stack.push_async_callback(self._async_producer.stop)
 
-        if self.admin_client:
-            self.admin_client.close()
+            if self.admin_client is not None:
+                stack.enter_context(closing(self.admin_client))
+
+            if self.consumer_manager is not None:
+                stack.enter_context(closing(self.consumer_manager))
+
             self.admin_client = None
-        if self.consumer_manager:
-            self.consumer_manager.close()
             self.consumer_manager = None
 
     async def publish(self, topic: str, partition_id: Optional[str], content_type: str, formats: dict, data: dict):

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -18,15 +18,7 @@ class KarapaceBase(RestApp):
 
         self.kafka_timeout = 10
         self.route("/", callback=self.root_get, method="GET")
-        self.app.on_shutdown.append(self.close_by_app)
         self.log.info("Karapace initialized")
-
-    async def close_by_app(self, app):
-        # pylint: disable=unused-argument
-        await self.close()
-
-    async def close(self) -> None:
-        pass
 
     @staticmethod
     def r(body: Union[dict, list], content_type: str, status: HTTPStatus = HTTPStatus.OK) -> NoReturn:

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -51,6 +51,7 @@ def main() -> int:
     logging.log(logging.INFO, "\n%s\nStarting %s\n%s", info_str_separator, info_str, info_str_separator)
 
     try:
+        # `close` will be called by the callback `close_by_app` set by `KarapaceBase`
         app.run()
     except Exception:  # pylint: disable-broad-except
         if app.raven_client:

--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -167,9 +167,18 @@ class RestApp:
         self.log = logging.getLogger(self.app_name)
         self.stats = StatsClient(sentry_config=config["sentry"])
         self.raven_client = self.stats.raven_client
-        self.app.on_cleanup.append(self.cleanup_stats_client)
+        self.app.on_cleanup.append(self.close_by_app)
 
-    async def cleanup_stats_client(self, app):  # pylint: disable=unused-argument
+    async def close_by_app(self, app: aiohttp.web.Application) -> None:  # pylint: disable=unused-argument
+        await self.close()
+
+    async def close(self) -> None:
+        """Method used to free all the resources allocated by the applicaiton.
+
+        This will be called as a callback by the aiohttp server. It needs to be
+        set as hook because the awaitables have to run inside the event loop
+        created by the aiohttp library.
+        """
         self.stats.close()
 
     @staticmethod

--- a/tests/integration/test_karapace.py
+++ b/tests/integration/test_karapace.py
@@ -1,0 +1,44 @@
+from contextlib import ExitStack
+from karapace.config import set_config_defaults
+from pathlib import Path
+from subprocess import Popen
+from tests.integration.utils.network import PortRangeInclusive
+from tests.integration.utils.process import stop_process
+
+import socket
+import ujson
+
+
+def test_regression_server_must_exit_on_exception(
+    port_range: PortRangeInclusive,
+    tmp_path: Path,
+) -> None:
+    """Regression test for Karapace properly exiting.
+
+    Karapace was not closing all its background threads, so when an exception
+    was raised an reached the top-level, the webserver created by asyncio would
+    be stopped but the threads would keep the server running.
+    """
+    with ExitStack() as stack:
+        port = stack.enter_context(port_range.allocate_port())
+        sock = stack.enter_context(socket.socket())
+
+        config = set_config_defaults(
+            {
+                "karapace_registry": True,
+                "port": port,
+            }
+        )
+        config_path = tmp_path / "karapace.json"
+
+        logfile = stack.enter_context((tmp_path / "karapace.log").open("w"))
+        errfile = stack.enter_context((tmp_path / "karapace.err").open("w"))
+        config_path.write_text(ujson.dumps(config))
+        sock.bind(("127.0.0.1", port))
+        process = Popen(
+            args=["python", "-m", "karapace.karapace_all", str(config_path)],
+            stdout=logfile,
+            stderr=errfile,
+        )
+        stack.callback(stop_process, process)  # make sure to stop the process if the test fails
+        assert process.wait(timeout=10) != 0, "Process should have exited with an error, port is already is use"


### PR DESCRIPTION
~Review after https://github.com/aiven/karapace/pull/389 (It does a bit of refactoring to the cleanup code), and https://github.com/aiven/karapace/pull/391 (It fix port allocation for integration tests)~

Just like https://github.com/aiven/karapace/pull/389 I found this while investigating the CI failures.

The test `tests/integration/test_master_coordinator.py::test_schema_request_forwarding`  had a server failures, where one server couldn't bind to the socket because of `address already in use` (I assume it was a linger socket). Because of that the main thread died, but the other threads kept running, and the worst one was the master coordinator, eventually the dead server became leader. The result was a leader node without a server, and when the follower forwarded the request to the master it failed with a connection error.

fixes #138