### PR TITLE
Fix setup py to use avro instead of avro-python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "networkx",
         "protobuf",
         "requests",
+        "ujson",
     ],
     extras_require={
         # compression algorithms supported by AioKafka and KafkaConsumer

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "aiohttp",
         "aiohttp_socks",
         "aiokafka",
-        "avro-python3",
+        "avro",
         "jsonschema",
         "kafka-python",
         "networkx",


### PR DESCRIPTION
# About this change - What it does

After Avro version bump the library name is `avro`.
Also `ujson` is missing from the required libraries in `setup.py`.

# Why this way

Karapace uses both, `requirements.txt` and `setup.py`.