### PR TITLE
Rest proxy produce future handling fix

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -397,8 +397,9 @@ class KafkaRest(KarapaceBase):
             "value_schema_id": data.get("value_schema_id"),
             "offsets": [],
         }
-        for key, value, partition in prepared_records:
-            publish_result = await self.produce_message(topic=topic, key=key, value=value, partition=partition)
+
+        publish_results = await self.produce_messages(topic=topic, prepared_records=prepared_records)
+        for publish_result in publish_results:
             if "error" in publish_result and status == HTTPStatus.OK:
                 status = HTTPStatus.INTERNAL_SERVER_ERROR
             response["offsets"].append(publish_result)
@@ -607,36 +608,72 @@ class KafkaRest(KarapaceBase):
                         sub_code=RESTErrorCodes.INVALID_DATA.value,
                     )
 
-    async def produce_message(self, *, topic: str, key: bytes, value: bytes, partition: int = None) -> dict:
-        try:
-            producer = await self._maybe_create_async_producer()
+    async def produce_messages(self, *, topic: str, prepared_records: List) -> List:
+        producer = await self._maybe_create_async_producer()
 
+        produce_futures = []
+        for key, value, partition in prepared_records:
             # Cancelling the returned future **will not** stop event from being sent, but cancelling
             # the ``send`` coroutine itself **will**.
             coroutine = producer.send(topic, key=key, value=value, partition=partition)
 
-            # Schedule the co-routine, it will be cancelled if the it is not complete in
+            # Schedule the co-routine, it will be cancelled if is not complete in
             # `self.kafka_timeout` seconds.
-            future = await asyncio.wait_for(fut=coroutine, timeout=self.kafka_timeout)
+            future = asyncio.wait_for(fut=coroutine, timeout=self.kafka_timeout)
+            produce_futures.append(future)
 
-            result = await future
-            return {
-                "offset": result.offset if result else -1,
-                "partition": result.topic_partition.partition if result else 0,
-            }
-        except AssertionError as e:
-            self.log.exception("Invalid data")
-            return {"error_code": 1, "error": str(e)}
-        except (KafkaTimeoutError, asyncio.TimeoutError):
-            self.log.exception("Timed out waiting for publisher")
-            # timeouts are retriable
-            return {"error_code": 1, "error": "timed out waiting to publish message"}
-        except BrokerResponseError as e:
-            self.log.exception(e)
-            resp = {"error_code": 1, "error": e.description}
-            if hasattr(e, "retriable") and e.retriable:
-                resp["error_code"] = 2
-            return resp
+        # Gather the results of `asyncio.wait_for`
+        send_results = []
+        for result in await asyncio.gather(*produce_futures, return_exceptions=True):
+            if not isinstance(result, Exception):
+                send_results.append(result)
+            else:
+                completed_exception_future = asyncio.Future()
+                completed_exception_future.set_exception(result)
+                send_results.append(completed_exception_future)
+
+        # Gather the results from Kafka producer `send`
+        produce_results = []
+        for result in await asyncio.gather(*send_results, return_exceptions=True):
+            if not isinstance(result, Exception):
+                produce_results.append(
+                    {
+                        "offset": result.offset if result else -1,
+                        "partition": result.topic_partition.partition if result else 0,
+                    }
+                )
+
+            # Exceptions below are raised before data is sent to Kafka
+            elif isinstance(result, asyncio.TimeoutError):
+                self.log.exception("Timed out waiting for publisher buffer")
+                # timeouts are retriable
+                produce_results.append(
+                    {"error_code": 1, "error": "timed out waiting to publish message, producer buffer full"}
+                )
+            elif isinstance(result, AssertionError):
+                self.log.exception("Invalid data")
+                produce_results.append({"error_code": 1, "error": str(result)})
+
+            # Exceptions below are raised after data is sent to Kafka
+            elif isinstance(result, KafkaTimeoutError):
+                self.log.exception("Timed out waiting for publisher")
+                # timeouts are retriable
+                produce_results.append({"error_code": 1, "error": "timed out waiting to publish message"})
+            elif isinstance(result, asyncio.CancelledError):
+                self.log.exception("Async task cancelled")
+                # cancel is retriable
+                produce_results.append({"error_code": 1, "error": "Publish message cancelled"})
+            elif isinstance(result, BrokerResponseError):
+                self.log.exception(result)
+                resp = {"error_code": 1, "error": result.description}
+                if hasattr(result, "retriable") and result.retriable:
+                    resp["error_code"] = 2
+                produce_results.append(resp)
+            else:
+                self.log.exception("Unexpected exception")
+                produce_results.append({"error_code": 1, "error": str(result)})
+
+        return produce_results
 
     async def list_topics(self, content_type: str):
         metadata = await self.cluster_metadata()

--- a/performance-test/README.rst
+++ b/performance-test/README.rst
@@ -1,0 +1,22 @@
+Performance tests
+=================
+
+Install development requirements per instructions from `README.rst <../README.rst>`_
+
+Requires Kafka and Zookeeper running in the containers::
+  cd ../container
+  docker-compose start zookeeper kafka
+
+Run Karapace from repository root::
+  cd ..
+  python -m karapace.karapace_all karapace.config.json
+
+Performance test is run from the shell script::
+  ./rest-proxy-post-topic-test.sh
+
+Script supports some environment variables:
+ * `BASE_URL` for setting Karapace address and port.
+ * `TOPIC` for setting the topic name where data is produced.
+ * `DURATION` for setting how long the test runs.
+ * `CONCURRENCY` for setting how many concurrent users are emulated.
+ * `LOCUST_GUI` for enabling the Locust web user interface.

--- a/performance-test/rest-proxy-post-topic-test.py
+++ b/performance-test/rest-proxy-post-topic-test.py
@@ -1,0 +1,51 @@
+#!/bin/env python3
+
+from kafka.admin import KafkaAdminClient, NewTopic
+from kafka.errors import TopicAlreadyExistsError
+from locust import HttpUser, task
+
+import json
+import os
+
+BOOTSTRAP_SERVER = os.environ.get("BOOTSTRAP_SERVER", "localhost:9092")
+TOPIC = os.environ.get("TOPIC", "test-topic")
+POST_PATH = "/topics/" + TOPIC
+
+SCHEMA_STR = json.dumps(
+    {
+        "type": "record",
+        "name": "CpuUsage",
+        "fields": [
+            {"name": "pct", "type": "int"},
+        ],
+    },
+)
+INPUT_RECORDS_COUNT = 50
+RECORDS = [{"key": "MQ==", "value": "MQ=="}] * INPUT_RECORDS_COUNT
+
+BODY = {
+    "value_schema": SCHEMA_STR,
+    "value_schema_id": 1,
+    "key_schema": SCHEMA_STR,
+    "key_schema_id": 1,
+    "records": RECORDS,
+}
+
+
+class RESTProxyPublish(HttpUser):
+    def on_test_start(self):  # pylint: disable=no-self-use
+        admin_client = KafkaAdminClient(bootstrap_servers=BOOTSTRAP_SERVER, client_id="locust-performance-test")
+
+        topic_list = [NewTopic(name=TOPIC, num_partitions=3, replication_factor=1)]
+        try:
+            admin_client.create_topics(topic_list)
+        except TopicAlreadyExistsError:
+            pass
+        admin_client.close()
+
+    @task
+    def post_rest_proxy(self) -> None:
+        with self.client.post(POST_PATH, json=BODY, catch_response=True) as response:
+            error_count = sum(record_response.get("error") is not None for record_response in response.json()["offsets"])
+            if error_count > 0:
+                response.failure(f"Response contains {error_count} errors for {INPUT_RECORDS_COUNT} input records.")

--- a/performance-test/rest-proxy-post-topic-test.sh
+++ b/performance-test/rest-proxy-post-topic-test.sh
@@ -1,0 +1,22 @@
+#!/bin/env bash
+set -eo pipefail
+
+# The REST proxy address params
+BASE_URL=${BASE_URL:-http://localhost:8082}
+TOPIC=${TOPIC:-test-topic}
+
+DURATION=${DURATION:-1m}
+CONCURRENCY=${CONCURRENCY:-50}
+
+GUI_PARAMS="--headless"
+if [ ! -z $LOCUST_GUI ]; then
+    GUI_PARAMS="--autostart"
+fi
+
+TOPIC="${TOPIC}" locust "${GUI_PARAMS}" \
+     --run-time "${DURATION}" \
+     --users "${CONCURRENCY}" \
+     -H "${BASE_URL}" \
+     --spawn-rate 4 \
+     --stop-timeout 5 \
+     --locustfile rest-proxy-post-topic-test.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,5 +15,8 @@ psutil==5.9.0
 # workflow
 pre-commit>=2.2.0
 
+# performance test
+locust==2.9.0
+
 # runtime requirements
 -r requirements.txt


### PR DESCRIPTION
# About this change - What it does

The original implementation waited asynchronously the result of a single producer send. The HTTP request may contains multiple records to be sent in a list. After this change records are sent first and results collected in subsequent loop.

The send function may block until there is free buffer in Kafka producer.

The first commit contains a performance test with Locust to measure the difference of the original implementation and new.
Test creates a HTTP request with 50 records with small payload to be produced to Kafka.

Results from a local test run:
* *Original* -> 12 RPS (12 * 50 records = 600 records / second)
* *New* -> 240 RPS (240 * 50 records = 12000 records / second)
