### PR TITLE
Init asyncio locks when event loop is available

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -232,6 +232,7 @@ async def fixture_rest_async(
     config = set_config_defaults({"bootstrap_uri": kafka_servers.bootstrap_servers, "admin_metadata_max_age": 2})
     write_config(config_path, config)
     rest = KafkaRest(config=config)
+    await rest.initialize_asyncio_locks(app=None)
 
     assert rest.serializer.registry_client
     assert rest.consumer_manager.deserializer.registry_client


### PR DESCRIPTION
# About this change - What it does

Asyncio locks need to be attached to correct thread. If locks are created in constructor the loop is not available, instead init locks from `aiohttp.web.Application` startup callback.

# Why this way

When calling produce API from REST proxy the first requests fail as the lock acquire future is attached to main loop.