### PR TITLE
Improve deserialization error message

### DIFF
--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -486,9 +486,18 @@ class ConsumerManager:
                 for msg in poll_data[tp]:
                     try:
                         key = await self.deserialize(msg.key, request_format) if msg.key else None
+                    except (UnpackError, InvalidMessageHeader, InvalidPayload) as e:
+                        KarapaceBase.internal_error(
+                            message=f"key deserialization error for format {request_format}: {e}",
+                            content_type=content_type,
+                        )
+                    try:
                         value = await self.deserialize(msg.value, request_format) if msg.value else None
                     except (UnpackError, InvalidMessageHeader, InvalidPayload) as e:
-                        KarapaceBase.internal_error(message=f"deserialization error: {e}", content_type=content_type)
+                        KarapaceBase.internal_error(
+                            message=f"value deserialization error for format {request_format}: {e}",
+                            content_type=content_type,
+                        )
                     element = {
                         "topic": tp.topic,
                         "partition": tp.partition,


### PR DESCRIPTION
The error message tell whether the failure was when deserializing key or value. Log the requested format.

Add a dedicated error message for key and value deserialization error and log the requested type. This helps the end user to see what exactly failed.

