### PR TITLE
Performance: schema string hash to schema id

### DIFF
--- a/performance-test/README.rst
+++ b/performance-test/README.rst
@@ -7,12 +7,16 @@ Requires Kafka and Zookeeper running in the containers::
   cd ../container
   docker-compose start zookeeper kafka
 
+Create if necessary the `_schemas` topic to Kafka::
+  docker exec -it <KAFKA_POD_ID> bash
+  kafka-topics --bootstrap-server localhost:9092 --create --topic _schemas --config cleanup.policy=compact
+
 Run Karapace from repository root::
   cd ..
   python -m karapace.karapace_all karapace.config.json
 
 Performance test is run from the shell script::
-  ./rest-proxy-post-topic-test.sh
+  ./run-locust-test.sh
 
 Script supports some environment variables:
  * `BASE_URL` for setting Karapace address and port.
@@ -20,3 +24,4 @@ Script supports some environment variables:
  * `DURATION` for setting how long the test runs.
  * `CONCURRENCY` for setting how many concurrent users are emulated.
  * `LOCUST_GUI` for enabling the Locust web user interface.
+ * `LOCUST_FILE` for selecting the Locust test script.

--- a/performance-test/run-locust-test.sh
+++ b/performance-test/run-locust-test.sh
@@ -7,6 +7,7 @@ TOPIC=${TOPIC:-test-topic}
 
 DURATION=${DURATION:-1m}
 CONCURRENCY=${CONCURRENCY:-50}
+LOCUST_FILE=${LOCUST_FILE:-"rest-proxy-post-topic-test.py"}
 
 GUI_PARAMS="--headless"
 if [ ! -z $LOCUST_GUI ]; then
@@ -17,6 +18,6 @@ TOPIC="${TOPIC}" locust "${GUI_PARAMS}" \
      --run-time "${DURATION}" \
      --users "${CONCURRENCY}" \
      -H "${BASE_URL}" \
-     --spawn-rate 4 \
+     --spawn-rate 0.50 \
      --stop-timeout 5 \
-     --locustfile rest-proxy-post-topic-test.py
+     --locustfile "${LOCUST_FILE}"

--- a/performance-test/schema-registry-schema-post.py
+++ b/performance-test/schema-registry-schema-post.py
@@ -1,0 +1,47 @@
+from locust import FastHttpUser, task
+
+import json
+import random
+import uuid
+
+SUBJECTS = ["test-subject-1", "test-subject-2"]
+UUIDS = {
+    "test-subject-1": {"count": 0, "uuids": []},
+    "test-subject-2": {"count": 0, "uuids": []},
+}
+
+
+def _get_new_schema(alias: uuid.UUID):
+    return {
+        "schema": json.dumps(
+            {
+                "type": "record",
+                "name": "CpuUsage",
+                "alias": alias,
+                "fields": [
+                    {"name": "pct", "type": "int"},
+                ],
+            }
+        )
+    }
+
+
+class NewSchemaCreateUser(FastHttpUser):
+    @task
+    def post_new_schema(self) -> None:
+        added = False
+        for subject in SUBJECTS:
+            if UUIDS[subject]["count"] < 2000:
+                alias = str(uuid.uuid4())
+                UUIDS[subject]["uuids"].append(alias)
+                UUIDS[subject]["count"] = UUIDS[subject]["count"] + 1
+                new_schema = _get_new_schema(alias)
+                path = f"/subjects/{subject}/versions?NEW"
+                self.client.post(path, json=new_schema)
+                added = True
+        if not added:
+            subject = random.choice(SUBJECTS)
+            alias = random.choice(UUIDS[subject]["uuids"])
+            new_schema = _get_new_schema(alias)
+            path = f"/subjects/{subject}/versions?EXISTING"
+            self.client.post(path, json=new_schema)


### PR DESCRIPTION
# About this change - What it does

Fast path check of schema existence on subject, based on hash of subject and schema string.

Why this way
==========

* The schema, subject pairs are hashed to key for getting schema id, this avoids version list iteration and comparison of input schema to each one in the list like in the original code.
* The schema existence on subject can be done without locking, this is the fast path.
 * If schema is not found a lock is acquired and existence is rechecked.
 * If schema is found the id is returned, concurrently another request has POSTed the schema.
 * If schema is not found after second round of checks it is a new schema.

The round-trip to wait the schema message to be sent to Kafka and receiving it in the schema reader is the longest path and during this time the schema write operation is locked. No optimization is done to it.

Performance test comparison
=======================

The following graphs have both versions run sequantially with the same test scenario on development laptop. The `_schemas` topic is deleted and recreated between the test runs.
Numbers in clustered environment are likely different, but this shows the performance difference of original and modified code.

Test creates 2000 schemas to two subjects, total is 4000. Detailed response time statistics are below.

The original code can achieve 10-13 RPS constantly when unique new schema is POSTed.
The modified code can achieve 20-25 RPS constantly when unique new schema is POSTed.

The original code can achieve 60 RPS constantly when existing schema is POSTed.
The modified code can achieve 2200 RPS quite consistently when existing schema is POSTed. The cause RPS drops in the graphs is unknown, low point of the drop is 1200 RPS.

![modified-vs-original-schema-post](https://user-images.githubusercontent.com/91882676/174596713-d91cc7c7-07fd-4ab4-8cad-08937024fa59.png)

Stats for code before the change, no fast path, with list iteration and locking
----------------------------------------------------------------------------------------------------

Locust report:

    Response time percentiles (approximated)
    Type     Name                                                                                  50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
    --------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
    POST     /subjects/test-subject-1/versions?EXISTING                                            170    190    200    220    250    290    330    350    410    560    710  19928
    POST     /subjects/test-subject-1/versions?NEW                                                 420    540    660    760    860   1000   1300   1700   2200   2200   2200   2000
    POST     /subjects/test-subject-2/versions?EXISTING                                            170    190    200    210    250    290    330    350    400    650    790  19207
    POST     /subjects/test-subject-2/versions?NEW                                                 430    550    660    770    850   1000   1300   1700   2100   2200   2200   2000
    --------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
             Aggregated                                                                            180    200    210    230    300    400    750    850   1600   2200   2200  43135


Stats for code with schema hash to schema id, locking only if not found
-----------------------------------------------------------------------------------------------

Locust report:

    Response time percentiles (approximated)
    Type     Name                                                                                  50%    66%    75%    80%    90%    95%    98%    99%  99.9% 99.99%   100% # reqs
    --------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
    POST     /subjects/test-subject-1/versions?EXISTING                                              4      4      4      5      6      7      8      9     13     24    550 803315
    POST     /subjects/test-subject-1/versions?NEW                                                 280    360    490    520    600    680    900   1100   1100   1100   1100   2000
    POST     /subjects/test-subject-2/versions?EXISTING                                              4      4      4      5      6      7      8      9     13     23    370 802742
    POST     /subjects/test-subject-2/versions?NEW                                                 280    360    490    520    600    680    900   1100   1100   1100   1100   2000
    --------|--------------------------------------------------------------------------------|--------|------|------|------|------|------|------|------|------|------|------|------
             Aggregated                                                                              4      4      4      5      6      7      8     10    330    720   1100 1610057
