### PR TITLE
Kafka authorization over REST proxy

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [MASTER]
 jobs=4
+init-hook='import sys; sys.path.append(".")'
 
 [MESSAGES CONTROL]
 enable=

--- a/README.rst
+++ b/README.rst
@@ -332,6 +332,9 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
    * - ``consumer_request_max_bytes``
      - ``67108864``
      - Rest proxy consumers maximum bytes to be fetched per request
+   * - ``consumer_idle_disconnect_timeout``
+     - ``0``
+     - Disconnect idle consumers after timeout seconds if not used.  Inactivity leads to consumer leaving consumer group and consumer state.  0 (default) means no auto-disconnect.
    * - ``fetch_min_bytes``
      - ``-1``
      - Rest proxy consumers minimum bytes to be fetched per request. ``-1`` means no limit

--- a/README.rst
+++ b/README.rst
@@ -314,6 +314,9 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
      - ``localhost:9092``
      - The URI to the Kafka service where to store the schemas and to run
        coordination among the Karapace instances.
+   * - ``sasl_bootstrap_uri``
+     - ``None``
+     - The URI to the Kafka service to use with the Kafka REST API when SASL authorization with REST is used.
    * - ``client_id``
      - ``sr-1``
      - The ``client_id`` Karapace will use when coordinating with
@@ -413,6 +416,9 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
      - ``/path/to/authfile.json``
      - Filename to specify users and access control rules for Karapace Schema Registry.
        If this is set, Schema Segistry requires authentication for most of the endpoints and applies per endpoint authorization rules.
+   * - ``rest_authorization``
+     - ``false``
+     - Use REST API's calling authorization credentials to invoke Kafka operations over SASL authentication of ``sasl_bootstrap_uri`` to delegate REST proxy authorization to Kafka.  If false, then use configured common credentials for all Kafka connections of REST proxy operations.
    * - ``metadata_max_age_ms``
      - ``60000``
      - Period of time in milliseconds after Kafka metadata is force refreshed.

--- a/karapace.config.json
+++ b/karapace.config.json
@@ -2,6 +2,8 @@
     "access_logs_debug": false,
     "advertised_hostname": "localhost",
     "bootstrap_uri": "127.0.0.1:9092",
+    "sasl_bootstrap_uri": "127.0.0.1:9094",
+    "rest_authorization": false,
     "client_id": "sr-1",
     "compatibility": "FULL",
     "group_id": "schema-registry",

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -27,6 +27,7 @@ DEFAULTS = {
     "advertised_port": None,
     "advertised_protocol": "http",
     "bootstrap_uri": "127.0.0.1:9092",
+    "sasl_bootstrap_uri": None,
     "client_id": "sr-1",
     "compatibility": "BACKWARD",
     "connections_max_idle_ms": 15000,
@@ -45,6 +46,7 @@ DEFAULTS = {
     "registry_password": None,
     "registry_ca": None,
     "registry_authfile": None,
+    "rest_authorization": False,
     "log_level": "DEBUG",
     "log_format": "%(name)-20s\t%(threadName)s\t%(levelname)-8s\t%(message)s",
     "master_eligibility": True,
@@ -155,6 +157,11 @@ def validate_config(config: Config) -> None:
             f"Invalid master election strategy: {master_election_strategy}, valid values are {valid_strategies}"
         ) from None
 
+    if config["rest_authorization"] and config["sasl_bootstrap_uri"] is None:
+        raise InvalidConfiguration(
+            "Using 'rest_authorization' requires configuration value for 'sasl_bootstrap_uri' to be set"
+        )
+
 
 def write_config(config_path: Path, custom_values: Config) -> None:
     config_path.write_text(json.dumps(custom_values))
@@ -171,7 +178,7 @@ def read_config(config_handler: IO) -> Config:
 
 def create_client_ssl_context(config: Config) -> Optional[ssl.SSLContext]:
     # taken from conn.py, as it adds a lot more logic to the context configuration than the initial version
-    if config["security_protocol"] == "PLAINTEXT":
+    if config["security_protocol"] in ("PLAINTEXT", "SASL_PLAINTEXT"):
         return None
     ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     ssl_context.options |= ssl.OP_NO_SSLv2

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -34,6 +34,7 @@ DEFAULTS = {
     "consumer_enable_auto_commit": True,
     "consumer_request_timeout_ms": 11000,
     "consumer_request_max_bytes": 67108864,
+    "consumer_idle_disconnect_timeout": 0,
     "fetch_min_bytes": -1,
     "group_id": "schema-registry",
     "host": "127.0.0.1",

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -1050,6 +1050,8 @@ class UserRestProxy:
         partition_id = self.validate_partition_id(partition_id, content_type)
         try:
             KafkaRest.r(await self.get_offsets(topic, partition_id), content_type)
+        except TopicAuthorizationFailedError:
+            KafkaRest.r(body={"message": "Forbidden"}, content_type=JSON_CONTENT_TYPE, status=HTTPStatus.FORBIDDEN)
         except UnknownTopicOrPartitionError as e:
             # Do a topics request on failure, figure out faster ways once we get correctness down
             metadata = await self.cluster_metadata()

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -635,7 +635,7 @@ class UserRestProxy:
         publish_results = await self.produce_messages(topic=topic, prepared_records=prepared_records)
         for publish_result in publish_results:
             if "error" in publish_result and status == HTTPStatus.OK:
-                status = HTTPStatus.INTERNAL_SERVER_ERROR
+                status = HTTPStatus.UNPROCESSABLE_ENTITY
             response["offsets"].append(publish_result)
         KafkaRest.r(body=response, content_type=content_type, status=status)
 

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -563,7 +563,7 @@ class UserRestProxy:
                 stack.enter_context(closing(self.admin_client))
 
             if self.consumer_manager is not None:
-                stack.enter_context(closing(self.consumer_manager))
+                stack.push_async_callback(self.consumer_manager.aclose)
 
             self.admin_client = None
             self.consumer_manager = None

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -736,7 +736,7 @@ class KafkaRest(KarapaceBase):
                 sub_code=RESTErrorCodes.UNKNOWN_TOPIC_OR_PARTITION.value,
             )
 
-    async def list_partitions(self, content_type: str, *, topic: Optional[str]):
+    async def list_partitions(self, content_type: str, *, topic: str):
         self.log.info("Retrieving partition details for topic %s", topic)
         try:
             metadata = await self.cluster_metadata([topic])

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -47,7 +47,7 @@ class KafkaRest(KarapaceBase):
         self.admin_lock = None
         self.metadata_cache = None
         self.schemas_cache = {}
-        self.consumer_manager = ConsumerManager(config=config)
+        self.consumer_manager = ConsumerManager(config=config, deserializer=self.serializer)
         self.init_admin_client()
 
         self._async_producer_lock = None

--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -129,6 +129,11 @@ class KafkaRestAdminClient(KafkaAdminClient):
                 "end_offset": end_partitions[0][2][0],
             }
         else:
+            start_err = beginning_partitions[0][1]
+            end_err = beginning_partitions[0][1]
+            for e in [start_err, end_err]:
+                if e != 0:
+                    raise for_code(e)
             rv = {
                 "beginning_offset": beginning_partitions[0][3],
                 "end_offset": end_partitions[0][3],

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -7,7 +7,7 @@ from kafka.errors import IllegalStateError, KafkaConfigurationError, KafkaError
 from kafka.structs import OffsetAndMetadata, TopicPartition
 from karapace.kafka_rest_apis.error_codes import RESTErrorCodes
 from karapace.karapace import empty_response, KarapaceBase
-from karapace.serialization import InvalidMessageHeader, InvalidPayload, SchemaRegistryDeserializer
+from karapace.serialization import InvalidMessageHeader, InvalidPayload, SchemaRegistrySerializer
 from karapace.utils import convert_to_int
 from struct import error as UnpackError
 from typing import Tuple
@@ -32,7 +32,7 @@ def new_name() -> str:
 
 
 class ConsumerManager:
-    def __init__(self, config: dict) -> None:
+    def __init__(self, config: dict, deserializer: SchemaRegistrySerializer) -> None:
         self.config = config
         if self.config["advertised_port"] is None:
             self.hostname = (
@@ -43,7 +43,7 @@ class ConsumerManager:
                 f"{self.config['advertised_protocol']}://"
                 f"{self.config['advertised_hostname']}:{self.config['advertised_port']}"
             )
-        self.deserializer = SchemaRegistryDeserializer(config=config)
+        self.deserializer = deserializer
         self.consumers = {}
         self.consumer_locks = defaultdict(Lock)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -234,12 +234,9 @@ async def fixture_rest_async(
     config = set_config_defaults({"bootstrap_uri": kafka_servers.bootstrap_servers, "admin_metadata_max_age": 2})
     write_config(config_path, config)
     rest = KafkaRest(config=config)
-    await rest.initialize_asyncio_locks(app=None)
 
     assert rest.serializer.registry_client
-    assert rest.consumer_manager.deserializer.registry_client
     rest.serializer.registry_client.client = registry_async_client
-    rest.consumer_manager.deserializer.registry_client.client = registry_async_client
     try:
         yield rest
     finally:

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -208,7 +208,8 @@ async def test_internal(rest_async, admin_client):
         [b"key", b"value", 0],
         [b"key", b"value", None],
     ]
-    results = await rest_async.produce_messages(topic=topic_name, prepared_records=prepared_records)
+    rest_async_proxy = rest_async.get_user_proxy(None)
+    results = await rest_async_proxy.produce_messages(topic=topic_name, prepared_records=prepared_records)
     assert len(results) == 2
     for result in results:
         assert "error" not in result, "Valid result should not contain 'error' key"
@@ -221,7 +222,7 @@ async def test_internal(rest_async, admin_client):
         [b"key", b"value", 100],
     ]
 
-    results = await rest_async.produce_messages(topic=topic_name, prepared_records=prepared_records)
+    results = await rest_async_proxy.produce_messages(topic=topic_name, prepared_records=prepared_records)
     assert len(results) == 1
     for result in results:
         assert "error" in result, "Invalid result missing 'error' key"
@@ -229,9 +230,9 @@ async def test_internal(rest_async, admin_client):
         assert "error_code" in result, "Invalid result missing 'error_code' key"
         assert result["error_code"] == 1
 
-    assert rest_async.all_empty({"records": [{"key": {"foo": "bar"}}]}, "key") is False
-    assert rest_async.all_empty({"records": [{"value": {"foo": "bar"}}]}, "value") is False
-    assert rest_async.all_empty({"records": [{"value": {"foo": "bar"}}]}, "key") is True
+    assert rest_async_proxy.all_empty({"records": [{"key": {"foo": "bar"}}]}, "key") is False
+    assert rest_async_proxy.all_empty({"records": [{"value": {"foo": "bar"}}]}, "value") is False
+    assert rest_async_proxy.all_empty({"records": [{"value": {"foo": "bar"}}]}, "key") is True
 
 
 async def test_topics(rest_async_client, admin_client):

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -209,7 +209,7 @@ async def test_internal(rest_async, admin_client):
         [b"key", b"value", 0],
         [b"key", b"value", None],
     ]
-    rest_async_proxy = rest_async.get_user_proxy(None)
+    rest_async_proxy = await rest_async.get_user_proxy(None)
     results = await rest_async_proxy.produce_messages(topic=topic_name, prepared_records=prepared_records)
     assert len(results) == 2
     for result in results:

--- a/tests/unit/test_rest_auth.py
+++ b/tests/unit/test_rest_auth.py
@@ -1,0 +1,78 @@
+# pylint: disable=protected-access
+from karapace.config import set_config_defaults
+from karapace.kafka_rest_apis import KafkaRest
+
+import time
+
+
+class MockUserRestProxy:
+    def __init__(self, num_consumers=0, last_used=0):
+        self._last_used = last_used
+        self._num_consumers = num_consumers
+
+    @property
+    def last_used(self) -> int:
+        return self._last_used
+
+    def num_consumers(self) -> int:
+        return self._num_consumers
+
+    async def aclose(self):
+        pass
+
+
+async def test_rest_proxy_janitor_default():
+    config = set_config_defaults(
+        {
+            "rest_authorization": True,
+            "sasl_bootstrap_uri": "localhost:9094",
+        }
+    )
+    instance = KafkaRest(config=config)
+
+    instance.proxies["active_proxy_without_consumers"] = MockUserRestProxy(num_consumers=0, last_used=time.monotonic())
+    instance.proxies["active_proxy_with_consumers"] = MockUserRestProxy(num_consumers=99, last_used=time.monotonic())
+
+    instance.proxies["unused_proxy_without_consumers"] = MockUserRestProxy(num_consumers=0, last_used=time.monotonic() - 600)
+    await instance._disconnect_idle_proxy_if_any()
+    assert instance.proxies.get("unused_proxy_without_consumers") is None
+    assert instance.proxies.get("active_proxy_with_consumers") is not None
+    assert instance.proxies.get("active_proxy_without_consumers") is not None
+    assert len(instance.proxies) == 2
+
+    # Proxy with consumers is not deleted without explicit config
+    instance.proxies["unused_proxy_with_consumers"] = MockUserRestProxy(num_consumers=99, last_used=time.monotonic() - 600)
+    await instance._disconnect_idle_proxy_if_any()
+    assert instance.proxies.get("unused_proxy_with_consumers") is not None
+    assert instance.proxies.get("active_proxy_with_consumers") is not None
+    assert instance.proxies.get("active_proxy_without_consumers") is not None
+    assert len(instance.proxies) == 3
+
+
+async def test_rest_proxy_janitor_destructive():
+    config = set_config_defaults(
+        {
+            "rest_authorization": True,
+            "sasl_bootstrap_uri": "localhost:9094",
+            "consumer_idle_disconnect_timeout": 120,
+        }
+    )
+    instance = KafkaRest(config=config)
+
+    instance.proxies["active_proxy_without_consumers"] = MockUserRestProxy(num_consumers=0, last_used=time.monotonic())
+    instance.proxies["active_proxy_with_consumers"] = MockUserRestProxy(num_consumers=99, last_used=time.monotonic())
+
+    instance.proxies["unused_proxy_without_consumers"] = MockUserRestProxy(num_consumers=0, last_used=time.monotonic() - 600)
+    await instance._disconnect_idle_proxy_if_any()
+    assert instance.proxies.get("unused_proxy_without_consumers") is None
+    assert instance.proxies.get("active_proxy_with_consumers") is not None
+    assert instance.proxies.get("active_proxy_without_consumers") is not None
+    assert len(instance.proxies) == 2
+
+    # Proxy with consumers gets deleted after enough time has passed
+    instance.proxies["unused_proxy_with_consumers"] = MockUserRestProxy(num_consumers=99, last_used=time.monotonic() - 600)
+    await instance._disconnect_idle_proxy_if_any()
+    assert instance.proxies.get("unused_proxy_with_consumers") is None
+    assert instance.proxies.get("active_proxy_with_consumers") is not None
+    assert instance.proxies.get("active_proxy_without_consumers") is not None
+    assert len(instance.proxies) == 2

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -6,7 +6,6 @@ from karapace.serialization import (
     InvalidMessageHeader,
     InvalidMessageSchema,
     InvalidPayload,
-    SchemaRegistryDeserializer,
     SchemaRegistrySerializer,
     START_BYTE,
     write_value,
@@ -24,28 +23,23 @@ import struct
 log = logging.getLogger(__name__)
 
 
-async def make_ser_deser(config_path, mock_client):
+async def make_ser_deser(config_path: str, mock_client) -> SchemaRegistrySerializer:
     with open(config_path, encoding="utf8") as handler:
         config = read_config(handler)
     serializer = SchemaRegistrySerializer(config_path=config_path, config=config)
-    deserializer = SchemaRegistryDeserializer(config_path=config_path, config=config)
     await serializer.registry_client.close()
-    await deserializer.registry_client.close()
     serializer.registry_client = mock_client
-    deserializer.registry_client = mock_client
-    return serializer, deserializer
+    return serializer
 
 
-async def test_happy_flow(default_config_path, mock_registry_client):
-    serializer, deserializer = await make_ser_deser(default_config_path, mock_registry_client)
-    for o in serializer, deserializer:
-        assert len(o.ids_to_schemas) == 0
+async def test_happy_flow(default_config_path: str, mock_registry_client) -> None:
+    serializer = await make_ser_deser(default_config_path, mock_registry_client)
+    assert len(serializer.ids_to_schemas) == 0
     schema = await serializer.get_schema_for_subject("top")
     for o in test_objects_avro:
-        assert o == await deserializer.deserialize(await serializer.serialize(schema, o))
-    for o in serializer, deserializer:
-        assert len(o.ids_to_schemas) == 1
-        assert 1 in o.ids_to_schemas
+        assert o == await serializer.deserialize(await serializer.serialize(schema, o))
+    assert len(serializer.ids_to_schemas) == 1
+    assert 1 in serializer.ids_to_schemas
 
 
 def test_flatten_unions_record() -> None:
@@ -235,15 +229,15 @@ def test_avro_json_write_accepts_json_encoded_data_without_tagged_unions() -> No
     assert buffer_a.getbuffer() == buffer_b.getbuffer()
 
 
-async def test_serialization_fails(default_config_path, mock_registry_client):
-    serializer, _ = await make_ser_deser(default_config_path, mock_registry_client)
+async def test_serialization_fails(default_config_path: str, mock_registry_client) -> None:
+    serializer = await make_ser_deser(default_config_path, mock_registry_client)
     with pytest.raises(InvalidMessageSchema):
         schema = await serializer.get_schema_for_subject("topic")
         await serializer.serialize(schema, {"foo": "bar"})
 
 
-async def test_deserialization_fails(default_config_path, mock_registry_client):
-    _, deserializer = await make_ser_deser(default_config_path, mock_registry_client)
+async def test_deserialization_fails(default_config_path: str, mock_registry_client) -> None:
+    deserializer = await make_ser_deser(default_config_path, mock_registry_client)
     invalid_header_payload = struct.pack(">bII", 1, 500, 500)
     with pytest.raises(InvalidMessageHeader):
         await deserializer.deserialize(invalid_header_payload)


### PR DESCRIPTION
# About this change - What it does

Delegates REST caller principal to Kafka for authorization inside Kafka.

# Why this way

Delegation of caller makes it possible for Kafka to check authorization of REST API caller using already existing Kafka ACL entries & principals.