### PR TITLE
[FIX] producer sasl support

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -187,6 +187,9 @@ class KafkaRest(KarapaceBase):
                 producer = AIOKafkaProducer(
                     bootstrap_servers=self.config["bootstrap_uri"],
                     security_protocol=self.config["security_protocol"],
+                    sasl_mechanism=self.config["sasl_mechanism"],
+                    sasl_plain_username=self.config["sasl_plain_username"],
+                    sasl_plain_password=self.config["sasl_plain_password"],
                     ssl_context=ssl_context,
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
                     acks=acks,


### PR DESCRIPTION

add support for SASL options 


```log
Starting Karapace REST API
2022-07-07T23:43:07.483936981Z karapace            	MainThread	ERROR   	Internal server error
2022-07-07T23:43:07.483987048Z Traceback (most recent call last):
2022-07-07T23:43:07.483996815Z   File "/usr/local/lib/python3.9/dist-packages/karapace/rapu.py", line 324, in _handle_request
2022-07-07T23:43:07.484010202Z     data = await callback(**callback_kwargs)
2022-07-07T23:43:07.484017155Z   File "/usr/local/lib/python3.9/dist-packages/karapace/kafka_rest_apis/__init__.py", line 414, in topic_publish
2022-07-07T23:43:07.484024820Z     await self.publish(topic, None, content_type, request.content_type, request.json)
2022-07-07T23:43:07.484031988Z   File "/usr/local/lib/python3.9/dist-packages/karapace/kafka_rest_apis/__init__.py", line 401, in publish
2022-07-07T23:43:07.484038903Z     publish_results = await self.produce_messages(topic=topic, prepared_records=prepared_records)
2022-07-07T23:43:07.484045736Z   File "/usr/local/lib/python3.9/dist-packages/karapace/kafka_rest_apis/__init__.py", line 612, in produce_messages
2022-07-07T23:43:07.484053297Z     producer = await self._maybe_create_async_producer()
2022-07-07T23:43:07.484060028Z   File "/usr/local/lib/python3.9/dist-packages/karapace/kafka_rest_apis/__init__.py", line 187, in _maybe_create_async_producer
2022-07-07T23:43:07.484067143Z     producer = AIOKafkaProducer(
2022-07-07T23:43:07.484073403Z   File "/usr/local/lib/python3.9/dist-packages/aiokafka/producer/producer.py", line 250, in __init__
2022-07-07T23:43:07.484080257Z     self.client = AIOKafkaClient(
2022-07-07T23:43:07.484086520Z   File "/usr/local/lib/python3.9/dist-packages/aiokafka/client.py", line 122, in __init__
2022-07-07T23:43:07.484093534Z     raise ValueError(
2022-07-07T23:43:07.484100166Z ValueError: sasl_plain_username and sasl_plain_password required for PLAIN sasl
```

#299


```yaml
  aiven-rest-proxy-local:
    image: ghcr.io/aiven/karapace:3.3.0
    entrypoint:
      - /bin/bash
      - /opt/karapace/start.sh
      - rest
    environment:
      KARAPACE_PORT: 8082
      KARAPACE_HOST: 0.0.0.0
      KARAPACE_ADVERTISED_HOSTNAME: aiven-rest-proxy-local
      KARAPACE_BOOTSTRAP_URI: kXXXXXXXXXXXX.aivencloud.com:21298
      KARAPACE_SECURITY_PROTOCOL: SASL_SSL
      KARAPACE_SASL_MECHANISM: SCRAM-SHA-256
      KARAPACE_SASL_PLAIN_USERNAME: avnadmin
      KARAPACE_SASL_PLAIN_PASSWORD: XXXXXXXXXXXX
      KARAPACE_SSL_CAFILE: "/opt/conf/ca.pem"
      KARAPACE_REGISTRY_HOST: localhost
      KARAPACE_REGISTRY_PORT: 9002
      KARAPACE_ADMIN_METADATA_MAX_AGE: 0
      KARAPACE_LOG_LEVEL: WARNING
    volumes:
      - ../conf/ca.pem:/opt/conf/ca.pem
    network_mode: "host"
```

