### PR TITLE
Fix JSON schema comparison when posting to subject

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -187,6 +187,9 @@ class KafkaRest(KarapaceBase):
                 producer = AIOKafkaProducer(
                     bootstrap_servers=self.config["bootstrap_uri"],
                     security_protocol=self.config["security_protocol"],
+                    sasl_mechanism=self.config["sasl_mechanism"],
+                    sasl_plain_username=self.config["sasl_plain_username"],
+                    sasl_plain_password=self.config["sasl_plain_password"],
                     ssl_context=ssl_context,
                     metadata_max_age_ms=self.config["metadata_max_age_ms"],
                     acks=acks,

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -123,7 +123,7 @@ class ValidatedTypedSchema(TypedSchema):
 
         elif schema_type is SchemaType.JSONSCHEMA:
             try:
-                parsed_schema = parse_jsonschema_definition(schema_str)
+                parsed_schema = parse_jsonschema_definition(schema_str).schema
                 # TypeError - Raised when the user forgets to encode the schema as a string.
             except (TypeError, json.JSONDecodeError, SchemaError, AssertionError) as e:
                 raise InvalidSchema from e


### PR DESCRIPTION
Fix for issue #428

JSON schema comparison was not validated correctly and threw a “Schema not found” error when posting to a subject.
Now parse_jsonschema_definition returns the schema and makes the comparison.

Posting a JSON schema
```
curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
  --data '{"schemaType": "JSON", "schema": "{\"type\": \"string\"}"}' \
  http://localhost:8081/subjects/local/versions http://localhost:8081/subjects/local
```
`{"id": 1}{"id": 1, "schema": "{\"type\": \"string\"}", "schemaType": "JSON", "subject": "local", "version": 1}`

Before
```
curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
--data '{"schemaType": "JSON", "schema": "{\"type\": \"string\"}"}' \
[http://localhost:8081/subjects/jsontype-string/](http://localhost:8081/subjects/jsontype-string/)
{"error_code": 40403, "message": "Schema not found"}
```
