### PR TITLE
Fix JSON schema comparison when posting to subject

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -752,10 +752,11 @@ class KarapaceSchemaRegistryController(KarapaceBase):
             )
         for schema in subject_data["schemas"].values():
             validated_typed_schema = ValidatedTypedSchema.parse(schema["schema"].schema_type, schema["schema"].schema_str)
-            if (
-                validated_typed_schema.schema_type == new_schema.schema_type
-                and validated_typed_schema.schema == new_schema.schema
-            ):
+            if schema_type is SchemaType.JSONSCHEMA:
+                schema_valid = validated_typed_schema.to_dict() == new_schema.to_dict()
+            else:
+                schema_valid = validated_typed_schema.schema == new_schema.schema
+            if validated_typed_schema.schema_type == new_schema.schema_type and schema_valid:
                 ret = {
                     "subject": subject,
                     "version": schema["version"],


### PR DESCRIPTION
Fix for issue #428

JSON schema comparison was not validated correctly and threw a  “Schema not found” error when posting to a subject.
Posting a JSON schema
```
curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
  --data '{"schemaType": "JSON", "schema": "{\"type\": \"string\"}"}' \
  http://localhost:8081/subjects/local/versions http://localhost:8081/subjects/local

{"id": 1}{"id": 1, "schema": "{\"type\": \"string\"}", "schemaType": "JSON", "subject": "local", "version": 1}
```
Before
```
curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
--data '{"schemaType": "JSON", "schema": "{\"type\": \"string\"}"}' \
[http://localhost:8081/subjects/jsontype-string/](http://localhost:8081/subjects/jsontype-string/)
{"error_code": 40403, "message": "Schema not found"}
```
