### PR TITLE
Allow subjects/subject endpoint to be called by user with Read permissions

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -853,7 +853,7 @@ class KarapaceSchemaRegistry(KarapaceBase):
     async def subjects_schema_post(
         self, content_type: str, *, subject: str, request: HTTPRequest, user: Optional[User] = None
     ) -> None:
-        self._check_authorization(user, Operation.Write, f"Subject:{subject}")
+        self._check_authorization(user, Operation.Read, f"Subject:{subject}")
 
         body = request.json
         self._validate_schema_request_body(content_type, body)


### PR DESCRIPTION
# About this change - What it does
Basically, it allows readonly users to call subjects/subject endpoint. 

References: [#431](https://github.com/aiven/karapace/issues/431)

# Why this way
Not sure whether this is a proper way, but `subjects_schema_post` seems not to change anything. For me it looks like the reason why it requires `Write` permission is because the method goes through POST.