### PR TITLE
fix: Schema registry message key field format correction

### DIFF
--- a/karapace/key_format_corrector.py
+++ b/karapace/key_format_corrector.py
@@ -1,0 +1,219 @@
+"""
+karapace - Key correction
+
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+from aiokafka.structs import TopicPartition
+from asyncio import Future
+from karapace.config import Config
+from karapace.typing import JsonData
+from karapace.utils import json_encode
+from typing import List, Optional
+
+import asyncio
+import json
+import logging
+import threading
+import time
+
+LOG = logging.getLogger(__name__)
+
+SCHEMA_KEY_ORDER = ["keytype", "subject", "version", "magic"]
+CONFIG_KEY_ORDER = ["keytype", "subject", "magic"]
+NOOP_KEY_ORDER = ["keytype", "magic"]
+
+CORRECT_KEY_ORDERS = [SCHEMA_KEY_ORDER, CONFIG_KEY_ORDER, NOOP_KEY_ORDER]
+
+
+def _get_key_in_correct_order(key: JsonData) -> bytes:
+    corrected_key = {
+        "keytype": key["keytype"],
+    }
+    if "subject" in key:
+        corrected_key["subject"] = key["subject"]
+    if "version" in key:
+        corrected_key["version"] = key["version"]
+    # Magic is the last element
+    corrected_key["magic"] = key["magic"]
+    return json_encode(corrected_key, sort_keys=False, binary=True, compact=True)
+
+
+class KeyFormatCorrector:
+    """Correct message key format to use "keytype, subject, version, magic" order of keys.
+
+    Karapace has used "subject, version, magic, keytype". This can cause issues when migrating from
+    Confluent Schema Registry to Karapace. Kafka log compaction compares the key as bytes and using different
+    order of keys in the contained JSON does not produce same byte output.
+    """
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+        self.timeout_ms = 1000
+        self.running = False
+        self.key_correction_done = False
+        self.failed = False
+
+        self.total_msgs = 0
+        self.corrected_msgs = 0
+
+    def stop(self) -> None:
+        LOG.info("[KeyCorrector] Stopping key correction.")
+        self.running = False
+
+    def start(self) -> None:
+        if not self.running and not self.key_correction_done:
+            LOG.info("[KeyCorrector] Starting key correction.")
+            thread = threading.Thread(target=self._run, daemon=True)
+            self.running = True
+            thread.start()
+
+    def _run(self) -> None:
+        asyncio.run(self.run_correction())
+
+    async def run_correction(self) -> None:
+
+        if self.failed:
+            LOG.warning("[KeyCorrector] Correction marked failed, not attempting again.")
+            return
+
+        latest_offset = 0
+        start_time = time.monotonic()
+        producer = AIOKafkaProducer(
+            bootstrap_servers=self.config["bootstrap_uri"],
+            linger_ms=50,
+        )
+        consumer = AIOKafkaConsumer(
+            self.config["topic_name"],
+            bootstrap_servers=self.config["bootstrap_uri"],
+            group_id="key-corrector",
+            auto_offset_reset="earliest",
+            enable_auto_commit=False,
+            max_poll_records=5000,
+        )
+
+        try:
+            await producer.start()
+            await consumer.start()
+
+            # Get the offset up to run
+            partitions = consumer.partitions_for_topic(self.config["topic_name"])
+            if len(partitions) != 1:
+                # The key correction process must be stopped so it won't be tried again when configuration
+                # of schemas topic is invalid. The process can be retried by restarting Karapace.
+                self.failed = True
+                LOG.error(
+                    ("The schema topic %s has %s partitions, expected one partition. Aborting key correction."),
+                    self.config["topic_name"],
+                    len(partitions),
+                )
+                return
+
+            # The partitions is a set, cannot access with index.
+            for partition in partitions:
+                break
+            tp = TopicPartition(self.config["topic_name"], partition)  # pylint: disable=undefined-loop-variable
+
+            end_offsets = await consumer.end_offsets([tp])
+            end_offset = end_offsets[tp]
+            LOG.info("[KeyCorrector] Start to consume up to offset %s.", end_offset)
+            if latest_offset == end_offset:
+                # On empty topic the latest offset and end offset are the same.
+                self.key_correction_done = True
+
+            while self.running and latest_offset < end_offset:
+                raw_msgs = await consumer.getmany(timeout_ms=self.timeout_ms)
+                # All done if no more messages
+                if not raw_msgs:
+                    LOG.info("[KeyCorrector] No more messages, done for today.")
+                    # All done if no more messages
+                    self.key_correction_done = True
+                    break
+
+                for _, messages in raw_msgs.items():
+                    futures = []
+                    for message in messages:
+                        self.total_msgs += 1
+                        latest_offset = max(message.offset, latest_offset)
+                        if message.offset < end_offset:
+                            maybe_futures = await self.check_and_store(producer, message.key, message.value)
+                            if maybe_futures:
+                                futures += maybe_futures
+                        else:
+                            LOG.debug("[KeyCorrector] Message after end_offset.")
+                            break
+                    if futures:
+                        await asyncio.wait(futures, timeout=30000)
+                    LOG.info(
+                        "Processed %s messages, messages/s %s",
+                        self.total_msgs,
+                        (self.total_msgs / (time.monotonic() - start_time)),
+                    )
+                if latest_offset >= end_offset:
+                    LOG.info("[KeyCorrector] latest_offset greater or equal to end_offset, done for today.")
+                    self.key_correction_done = True
+
+            LOG.info("[KeyCorrector] Key correction took %s seconds.", time.monotonic() - start_time)
+            LOG.info("[KeyCorrector] Total: %s - Corrected: %s.", self.total_msgs, self.corrected_msgs)
+            LOG.info("[KeyCorrector] Handled to offset of %s.", latest_offset)
+        except Exception as e:
+            # Log status of key correction in case of unexpected exception
+            self.failed = True
+            LOG.error("Key correction failed")
+            LOG.error("[KeyCorrector] Key correction took %s seconds.", time.monotonic() - start_time)
+            LOG.error("[KeyCorrector] Total: %s - Corrected: %s.", self.total_msgs, self.corrected_msgs)
+            LOG.error("[KeyCorrector] Handled to offset of %s.", latest_offset)
+            raise e
+        finally:
+            if self.key_correction_done:
+                await self._send_key_correction_done_marker(producer)
+            self.running = False
+            await producer.flush()
+            await producer.stop()
+            await consumer.stop()
+
+    async def check_and_store(
+        self, producer: AIOKafkaProducer, original_key: Optional[bytes], value: Optional[bytes]
+    ) -> Optional[List[Future]]:
+        if original_key is None:
+            LOG.warning("Invalid key 'None'.")
+            return None
+        try:
+            original_key_dict = json.loads(original_key)
+        except (json.JSONDecodeError) as e:
+            LOG.warning("Invalid key data", exc_info=e)
+            return None
+        if list(original_key_dict.keys()) not in CORRECT_KEY_ORDERS:
+            try:
+                return await self.correct(producer, _get_key_in_correct_order(original_key_dict), original_key, value)
+            except KeyError as e:
+                LOG.warning("Invalid message in schema topic.", exc_info=e)
+                return None
+        else:
+            # Send message also to retain the order in topic.
+            return await self.correct(producer, original_key, original_key, value)
+
+    async def correct(
+        self, producer: AIOKafkaProducer, corrected_key: bytes, original_key: bytes, value: Optional[bytes]
+    ) -> List[Future]:
+        futures: List[Future] = []
+
+        # Send delete with invalid key, compaction will remove eventually
+        future = await producer.send(self.config["topic_name"], key=original_key, value=None)
+        futures.append(future)
+
+        # Send with corrected key after the tombstone as tombstone is a delete event
+        future = await producer.send(self.config["topic_name"], key=corrected_key, value=value)
+        futures.append(future)
+
+        self.corrected_msgs += 1
+        return futures
+
+    async def _send_key_correction_done_marker(self, producer: AIOKafkaProducer) -> None:
+        key = '{"keytype":"KEY_CORRECTION_DONE","magic":0}'.encode("utf-8")
+        value = b""
+        await producer.send_and_wait(self.config["topic_name"], key=key, value=value)
+        LOG.info("[KeyCorrector] Key correction done message sent.")

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -70,10 +70,12 @@ def default_json_serialization(  # pylint: disable=inconsistent-return-statement
     assert_never("Object of type {!r} is not JSON serializable".format(obj.__class__.__name__))
 
 
-def json_encode(obj, *, sort_keys: bool = True, binary=False):
+def json_encode(obj, *, sort_keys: bool = True, binary=False, compact=False):
+    separators = (",", ":") if compact else None
     res = json.dumps(
         obj,
         sort_keys=sort_keys,
+        separators=separators,
         default=default_json_serialization,
     )
     return res.encode("utf-8") if binary else res

--- a/tests/integration/test_key_correction.py
+++ b/tests/integration/test_key_correction.py
@@ -1,0 +1,560 @@
+"""
+karapace - Test key correction
+
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+from kafka import KafkaConsumer, KafkaProducer
+from kafka.admin import KafkaAdminClient, NewTopic
+from kafka.admin.config_resource import ConfigResource, ConfigResourceType
+from kafka.consumer.fetcher import ConsumerRecord
+from karapace.config import set_config_defaults
+from karapace.schema_registry import KarapaceSchemaRegistry
+from karapace.utils import json_encode
+from tests.integration.utils.kafka_server import KafkaServers
+from tests.schemas.json_schemas import FALSE_SCHEMA, TRUE_SCHEMA
+from tests.utils import create_group_name_factory, new_random_name
+from typing import Dict, List, Optional, Union
+
+import asyncio
+import json
+import time
+
+
+class SchemaMessage:
+    def __init__(
+        self,
+        key: Dict[str, Union[int, str]],
+        value: Optional[Dict[str, Union[int, str]]],
+    ):
+        # No key sorting for the key, allows to test with incorrect order of properties in the key.
+        self.key = json_encode(key, binary=True, sort_keys=False, compact=True)
+        if value:
+            self.value = json_encode(value, binary=True, sort_keys=False, compact=True)
+        else:
+            self.value = None
+
+
+def _wait_for_data_available_in_kafka(
+    topic: str,
+    kafka_servers: KafkaServers,
+    expected_msgs: int = 0,
+) -> List[ConsumerRecord]:
+    group_id = create_group_name_factory("test-data-waiter")()
+    consumer = KafkaConsumer(
+        topic,
+        group_id=group_id,
+        enable_auto_commit=False,
+        api_version=(1, 0, 0),
+        bootstrap_servers=kafka_servers.bootstrap_servers,
+        auto_offset_reset="earliest",
+    )
+    max_time_ms = 30_000
+    start_time = time.monotonic()
+
+    try:
+        while time.monotonic() - start_time < max_time_ms:
+            raw_msgs = consumer.poll()
+            if raw_msgs:
+                all_msgs = []
+                for _, msgs in raw_msgs.items():
+                    all_msgs += msgs
+                    if expected_msgs == 0 or len(all_msgs) == expected_msgs:
+                        return all_msgs
+            consumer.seek_to_beginning()
+    finally:
+        consumer.close()
+    return []
+
+
+def _produce_test_data(
+    topic: str,
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+    producer: KafkaProducer,
+    test_records: List[SchemaMessage],
+) -> None:
+    admin_client.create_topics(
+        new_topics=[
+            NewTopic(name=topic, num_partitions=1, replication_factor=1, topic_configs={"cleanup.policy": "compact"})
+        ]
+    )
+
+    record_count = len(test_records)
+
+    for record in test_records:
+        future = producer.send(
+            topic,
+            key=record.key,
+            value=record.value,
+        )
+        future.get()
+
+    producer.flush()
+    msgs = _wait_for_data_available_in_kafka(topic=topic, kafka_servers=kafka_servers)
+    assert len(msgs) == record_count, "Data consumed is less than produced."
+
+
+def _create_basic_test_data(
+    topic: str,
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+    producer: KafkaProducer,
+) -> None:
+    test_records = [
+        SchemaMessage(
+            key={
+                "keytype": "SCHEMA",
+                "subject": "test-schema-subject",
+                "version": 1,
+                "magic": 0,
+            },
+            value={
+                "deleted": False,
+                "id": 1,
+                "subject": "test-schema-subject",
+                "version": 1,
+                "schema": json_encode(TRUE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={  # Schema with invalid key order
+                "magic": 0,
+                "subject": "test-schema-subject",
+                "version": 2,
+                "keytype": "SCHEMA",
+            },
+            value={
+                "deleted": False,
+                "id": 2,
+                "subject": "test-schema-subject",
+                "version": 2,
+                "schema": json_encode(FALSE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={  # Send config change to test-schema-subject
+                "magic": 0,
+                "subject": "test-schema-subject",
+                "keytype": "CONFIG",
+            },
+            value={"compatibilityLevel": "NONE"},
+        ),
+        SchemaMessage(
+            key={  # Send NOOP, spec completeness
+                "magic": 0,
+                "subject": "test-noop-subject",
+                "keytype": "NOOP",
+            },
+            value={"noop": "for spec completeness"},
+        ),
+        SchemaMessage(
+            key={  # Send schema to create a subject for deletion
+                "magic": 0,
+                "subject": "test-delete-subject",
+                "version": 1,
+                "keytype": "SCHEMA",
+            },
+            value={
+                "deleted": False,
+                "id": 1,
+                "subject": "test-delete-subject",
+                "version": 1,
+                "schema": json_encode(TRUE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={  # Send subject delete
+                "magic": 0,
+                "subject": "test-delete-subject",
+                "keytype": "DELETE_SUBJECT",
+            },
+            value={"subject": "test-delete-subject", "version": 1},
+        ),
+    ]
+    _produce_test_data(
+        topic=topic, kafka_servers=kafka_servers, admin_client=admin_client, producer=producer, test_records=test_records
+    )
+
+
+async def test_empty_initial_schema_registry(kafka_servers: KafkaServers) -> None:
+    """Test key correction with empty initial schemas topic"""
+    topic_name = new_random_name("topic")
+    test_name = "test_key_correction_with_schema_registry"
+    group_id = create_group_name_factory(test_name)()
+
+    config = set_config_defaults(
+        {
+            "bootstrap_uri": kafka_servers.bootstrap_servers,
+            "admin_metadata_max_age": 2,
+            "group_id": group_id,
+            "topic_name": topic_name,
+        }
+    )
+    schema_registry = KarapaceSchemaRegistry(config=config)
+
+    def run_registry():
+        nonlocal schema_registry
+        schema_registry.start()
+
+    try:
+        run_registry()
+        while schema_registry.schema_reader._kfc.key_correction_done is False:  # pylint: disable=protected-access
+            await asyncio.sleep(0.5)
+
+    finally:
+        # Schema registry can be closed at this point.
+        await schema_registry.close()
+
+    msgs = _wait_for_data_available_in_kafka(topic=topic_name, kafka_servers=kafka_servers, expected_msgs=0)
+    assert len(msgs) == 1
+    key_correction_done_msg = msgs[0]
+    assert key_correction_done_msg.key == b'{"keytype":"KEY_CORRECTION_DONE","magic":0}'
+    assert key_correction_done_msg.value == b""
+
+
+async def test_schema_registry(
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+    producer: KafkaProducer,
+) -> None:
+    """Test the whole schema reader and schema registry integration when correcting keys."""
+    topic_name = new_random_name("topic")
+    _create_basic_test_data(topic=topic_name, kafka_servers=kafka_servers, admin_client=admin_client, producer=producer)
+    test_name = "test_key_correction_with_schema_registry"
+    group_id = create_group_name_factory(test_name)()
+
+    config = set_config_defaults(
+        {
+            "bootstrap_uri": kafka_servers.bootstrap_servers,
+            "admin_metadata_max_age": 2,
+            "group_id": group_id,
+            "topic_name": topic_name,
+        }
+    )
+    schema_registry = KarapaceSchemaRegistry(config=config)
+
+    def run_registry():
+        nonlocal schema_registry
+        schema_registry.start()
+
+    try:
+        run_registry()
+        while schema_registry.schema_reader._kfc.key_correction_done is False:  # pylint: disable=protected-access
+            await asyncio.sleep(0.5)
+
+    finally:
+        # Schema registry can be closed at this point.
+        await schema_registry.close()
+
+    # To run the compaction, some trickery is needed
+    # See KIP-354 and documentation of related configuration entries below.
+    config_resources = []
+    config_resources.append(
+        ConfigResource(
+            resource_type=ConfigResourceType.BROKER,
+            name=1,
+            configs={
+                "log.cleaner.min.cleanable.dirty.ratio": 0,
+                "log.cleaner.max.compaction.lag.ms": 1000,
+                "log.cleaner.delete.retention.ms": 1000,
+                "log.roll.ms": 100,
+            },
+        )
+    )
+    admin_client.alter_configs(config_resources=config_resources)
+
+    # Give some time for config change to stick
+    await asyncio.sleep(5)
+
+    # Send NOOP, to create a new segment
+    key = {
+        "keytype": "NOOP",
+        "subject": "test-roll-segment-noop",
+        "magic": 0,
+    }
+    value = {"noop": "payload-1"}
+    future = producer.send(
+        topic_name,
+        key=json_encode(key, binary=True, sort_keys=False, compact=True),
+        value=json_encode(value, binary=True, sort_keys=False, compact=True),
+    )
+    future.get()
+
+    # In total there is sixteen messages sent to Kafka, five entries with invalid key that shall be compacted.
+    # After compaction there should be twelve messages.
+    # One unfixed correct entry (republished), five corrected entries, five tombstones
+    # and key correction done message.
+    msgs = _wait_for_data_available_in_kafka(topic=topic_name, kafka_servers=kafka_servers, expected_msgs=12)
+    assert len(msgs) == 12
+    tombstones = [msg for msg in msgs if msg.value is None]
+
+    list(filter(lambda msg: msg.value is None, msgs))
+    assert len(tombstones) == 5
+
+    def correct_key_order(msg) -> bool:
+        key_data = json.loads(msg.key)
+        if key_data.get("keytype") == "SCHEMA":
+            return list(key_data.keys()) == ["keytype", "subject", "version", "magic"]
+        return list(key_data.keys()) == ["keytype", "subject", "magic"]
+
+    entries = [msg for msg in msgs if msg.value is not None and correct_key_order(msg)]
+    assert len(entries) == 6
+
+    # Assert key correction message is last in the expected data.
+    key_correction_done_msg = msgs[-1]
+    assert key_correction_done_msg.key == b'{"keytype":"KEY_CORRECTION_DONE","magic":0}'
+    assert key_correction_done_msg.value == b""
+
+
+def _create_test_data_for_ordering_check(
+    topic: str,
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+    producer: KafkaProducer,
+) -> None:
+    test_records = [
+        SchemaMessage(
+            key={
+                "subject": "test-ordering",
+                "version": 1,
+                "magic": 1,
+                "keytype": "SCHEMA",
+            },
+            value={
+                "deleted": False,
+                "id": 1,
+                "version": 1,
+                "subject": "test-ordering",
+                "schema": json_encode(TRUE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={
+                "subject": "test-ordering",
+                "version": 2,
+                "magic": 1,
+                "keytype": "SCHEMA",
+            },
+            value={
+                "deleted": False,
+                "id": 6,
+                "version": 2,
+                "subject": "test-ordering",
+                "schema": json_encode(FALSE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={
+                "keytype": "SCHEMA",
+                "subject": "test-ordering",
+                "version": 4,
+                "magic": 1,
+            },
+            value={
+                "deleted": False,
+                "id": 6,
+                "version": 4,
+                "subject": "test-ordering",
+                "schema": json_encode(FALSE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={
+                "keytype": "SCHEMA",
+                "subject": "test-ordering",
+                "version": 2,
+                "magic": 1,
+            },
+            value=None,
+        ),
+        SchemaMessage(
+            key={
+                "subject": "test-ordering",
+                "version": 5,
+                "magic": 1,
+                "keytype": "SCHEMA",
+            },
+            value={
+                "deleted": False,
+                "id": 106,
+                "version": 5,
+                "subject": "test-ordering",
+                "schema": json_encode(TRUE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={
+                "keytype": "SCHEMA",
+                "subject": "test-ordering",
+                "version": 3,
+                "magic": 1,
+            },
+            value=None,
+        ),
+    ]
+
+    _produce_test_data(
+        topic=topic, kafka_servers=kafka_servers, admin_client=admin_client, producer=producer, test_records=test_records
+    )
+
+
+async def test_schema_and_subject_data_ordering(
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+    producer: KafkaProducer,
+) -> None:
+    topic_name = new_random_name("topic")
+    _create_test_data_for_ordering_check(
+        topic=topic_name, kafka_servers=kafka_servers, admin_client=admin_client, producer=producer
+    )
+    test_name = "test_key_correction_with_schema_registry"
+    group_id = create_group_name_factory(test_name)()
+
+    config = set_config_defaults(
+        {
+            "bootstrap_uri": kafka_servers.bootstrap_servers,
+            "admin_metadata_max_age": 2,
+            "group_id": group_id,
+            "topic_name": topic_name,
+        }
+    )
+    schema_registry = KarapaceSchemaRegistry(config=config)
+
+    def run_registry():
+        nonlocal schema_registry
+        schema_registry.start()
+
+    try:
+        run_registry()
+        while schema_registry.schema_reader._kfc.key_correction_done is False:  # pylint: disable=protected-access
+            await asyncio.sleep(0.5)
+
+    finally:
+        # Schema registry can be closed at this point.
+        await schema_registry.close()
+
+    assert len(schema_registry.schema_reader.schemas) == 3
+    # Schema order
+    assert list(schema_registry.schema_reader.schemas.keys()) == [1, 6, 106]
+
+    assert len(schema_registry.schema_reader.subjects["test-ordering"]["schemas"]) == 3
+    # Version order
+    assert list(schema_registry.schema_reader.subjects["test-ordering"]["schemas"].keys()) == [1, 4, 5]
+
+    version = await schema_registry.subject_version_get("test-ordering", "latest")
+    assert version["version"] == 5
+
+
+def _create_test_data_for_ordering_edge_case_that_changes_insertion_order(
+    topic: str,
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+    producer: KafkaProducer,
+) -> None:
+    test_records = [
+        SchemaMessage(
+            key={
+                "keytype": "SCHEMA",
+                "subject": "test-ordering",
+                "version": 1,
+                "magic": 1,
+            },
+            value={
+                "deleted": False,
+                "id": 1,
+                "version": 1,
+                "subject": "test-ordering",
+                "schema": json_encode(TRUE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={
+                "keytype": "SCHEMA",
+                "subject": "test-ordering",
+                "version": 2,
+                "magic": 1,
+            },
+            value={
+                "deleted": False,
+                "id": 2,
+                "version": 2,
+                "subject": "test-ordering",
+                "schema": json_encode(FALSE_SCHEMA.schema),
+            },
+        ),
+        SchemaMessage(
+            key={
+                "keytype": "SCHEMA",
+                "subject": "test-ordering",
+                "version": 1,
+                "magic": 1,
+            },
+            value={
+                "deleted": False,
+                "id": 1,
+                "version": 1,
+                "subject": "test-ordering",
+                "schema": json_encode(TRUE_SCHEMA.schema),
+            },
+        ),
+    ]
+
+    _produce_test_data(
+        topic=topic, kafka_servers=kafka_servers, admin_client=admin_client, producer=producer, test_records=test_records
+    )
+
+
+async def test_schema_version_ordering_edge_case_that_changes_insertion_order(
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+    producer: KafkaProducer,
+) -> None:
+    """Test edge case when schema version is inserted, new version inserted and reverted back to first version.
+
+    This case causes the insertion order in the schema reader subject data dictionary to change from the original
+    as the version reverting back to first version is first deleted and reinserted.
+    """
+    topic_name = new_random_name("topic")
+    _create_test_data_for_ordering_edge_case_that_changes_insertion_order(
+        topic=topic_name,
+        kafka_servers=kafka_servers,
+        admin_client=admin_client,
+        producer=producer,
+    )
+    test_name = "test_key_correction_with_schema_registry"
+    group_id = create_group_name_factory(test_name)()
+
+    config = set_config_defaults(
+        {
+            "bootstrap_uri": kafka_servers.bootstrap_servers,
+            "admin_metadata_max_age": 2,
+            "group_id": group_id,
+            "topic_name": topic_name,
+        }
+    )
+    schema_registry = KarapaceSchemaRegistry(config=config)
+
+    def run_registry():
+        nonlocal schema_registry
+        schema_registry.start()
+
+    try:
+        run_registry()
+        while schema_registry.schema_reader._kfc.key_correction_done is False:  # pylint: disable=protected-access
+            await asyncio.sleep(0.5)
+
+        assert len(schema_registry.schema_reader.schemas) == 2
+        # Schema order
+        assert list(schema_registry.schema_reader.schemas.keys()) == [1, 2]
+
+        assert len(schema_registry.schema_reader.subjects["test-ordering"]["schemas"]) == 2
+        # Version order
+        assert list(schema_registry.schema_reader.subjects["test-ordering"]["schemas"].keys()) == [2, 1]
+
+    finally:
+        # Schema registry can be closed at this point.
+        await schema_registry.close()
+
+    version = await schema_registry.subject_version_get("test-ordering", "latest")
+    assert version["version"] == 2

--- a/tests/unit/test_key_corrector.py
+++ b/tests/unit/test_key_corrector.py
@@ -1,0 +1,574 @@
+"""
+karapace - Key correction unit tests
+
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+from aiokafka.structs import TopicPartition
+from dataclasses import dataclass
+from karapace import key_format_corrector
+from typing import Any, Dict, Optional, Union
+from unittest.mock import call, MagicMock, Mock, patch
+
+import asyncio
+import collections
+import json
+import pytest
+
+
+def _key_bytes(key: Dict[str, Union[str, int]]) -> bytes:
+    return json.dumps(key, sort_keys=False, separators=(",", ":")).encode("utf-8")
+
+
+@dataclass
+class CheckAndStoreTestCase:
+    name: str
+    original_key: Optional[bytes]
+    corrected_key: Optional[bytes]
+    expected_futures_count: int
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        CheckAndStoreTestCase(
+            name="Happy case of corrected schema record key.",
+            original_key=_key_bytes(
+                {
+                    "magic": 1,
+                    "subject": "test-subject",
+                    "version": 1,
+                    "keytype": "SCHEMA",
+                }
+            ),
+            corrected_key=_key_bytes(
+                {
+                    "keytype": "SCHEMA",
+                    "subject": "test-subject",
+                    "version": 1,
+                    "magic": 1,
+                }
+            ),
+            expected_futures_count=2,
+        ),
+        CheckAndStoreTestCase(
+            name="Happy case of corrected delete subject record key.",
+            original_key=_key_bytes(
+                {
+                    "magic": 0,
+                    "subject": "test-subject",
+                    "keytype": "DELETE_SUBJECT",
+                }
+            ),
+            corrected_key=_key_bytes(
+                {
+                    "keytype": "DELETE_SUBJECT",
+                    "subject": "test-subject",
+                    "magic": 0,
+                }
+            ),
+            expected_futures_count=2,
+        ),
+        CheckAndStoreTestCase(
+            name="Happy case of corrected subject config record key.",
+            original_key=_key_bytes(
+                {
+                    "magic": 0,
+                    "subject": "test-subject",
+                    "keytype": "CONFIG",
+                }
+            ),
+            corrected_key=_key_bytes(
+                {
+                    "keytype": "CONFIG",
+                    "subject": "test-subject",
+                    "magic": 0,
+                }
+            ),
+            expected_futures_count=2,
+        ),
+        CheckAndStoreTestCase(
+            name="Happy case of corrected config record key.",
+            original_key=_key_bytes(
+                {
+                    "magic": 0,
+                    "subject": None,
+                    "keytype": "CONFIG",
+                }
+            ),
+            corrected_key=_key_bytes(
+                {
+                    "keytype": "CONFIG",
+                    "subject": None,
+                    "magic": 0,
+                }
+            ),
+            expected_futures_count=2,
+        ),
+        CheckAndStoreTestCase(
+            name="Happy case of existing correct key.",
+            original_key=_key_bytes(
+                {
+                    "keytype": "SCHEMA",
+                    "subject": "test-subject",
+                    "version": 1,
+                    "magic": 1,
+                }
+            ),
+            corrected_key=_key_bytes(
+                {
+                    "keytype": "SCHEMA",
+                    "subject": "test-subject",
+                    "version": 1,
+                    "magic": 1,
+                }
+            ),
+            expected_futures_count=2,
+        ),
+        CheckAndStoreTestCase(
+            name="Happy case of correction with unknown keytype.",
+            original_key=_key_bytes(
+                {
+                    "magic": 1,
+                    "version": 1,
+                    "keytype": "UNKNOWN_KEY_TYPE",
+                    "subject": "test-subject",
+                }
+            ),
+            corrected_key=_key_bytes(
+                {
+                    "keytype": "UNKNOWN_KEY_TYPE",
+                    "subject": "test-subject",
+                    "version": 1,
+                    "magic": 1,
+                }
+            ),
+            expected_futures_count=2,
+        ),
+        CheckAndStoreTestCase(
+            name="Invalid record, missing mandatory keytype property.",
+            original_key=_key_bytes(
+                {
+                    "magic": 1,
+                    "subject": "test-subject",
+                    "version": 1,
+                }
+            ),
+            corrected_key=None,
+            expected_futures_count=0,
+        ),
+        CheckAndStoreTestCase(
+            name="Invalid record, missing mandatory magic property.",
+            original_key=_key_bytes(
+                {
+                    "subject": "test-subject",
+                    "keytype": "SCHEMA",
+                    "version": 1,
+                }
+            ),
+            corrected_key=None,
+            expected_futures_count=0,
+        ),
+        CheckAndStoreTestCase(
+            name="Invalid record, key is none",
+            original_key=None,
+            corrected_key=None,
+            expected_futures_count=0,
+        ),
+        CheckAndStoreTestCase(
+            name="Invalid JSON as key.",
+            original_key=b'{"invalid":"json"}',
+            corrected_key=None,
+            expected_futures_count=0,
+        ),
+    ],
+)
+async def test_check_and_store(test_case: CheckAndStoreTestCase) -> None:
+    config = {
+        "topic_name": "_schemas",
+    }
+    kfc = key_format_corrector.KeyFormatCorrector(config=config)
+
+    producer_mock = Mock()
+    producer_mock.send = Mock()
+    returned_future = asyncio.Future()
+    producer_mock.send.return_value = returned_future
+    test_value = b"Test value"
+
+    if test_case.expected_futures_count > 0:
+        returned_future.set_result(True)
+    else:
+        returned_future.set_result(None)
+
+    futures = await kfc.check_and_store(producer=producer_mock, original_key=test_case.original_key, value=test_value)
+    if test_case.expected_futures_count == 2:
+        assert futures is not None
+        assert len(futures) == test_case.expected_futures_count
+        producer_mock.send.assert_has_calls(
+            (
+                call("_schemas", key=test_case.original_key, value=None),
+                call("_schemas", key=test_case.corrected_key, value=test_value),
+            )
+        )
+    else:
+        assert futures is None
+        producer_mock.send.assert_not_called()
+
+
+def mock_async_response(result: Any = None) -> asyncio.Future:
+    """Python 3.7 is supported and no AsyncMock available. Use this for mocking async responses."""
+    future = asyncio.Future()
+    if result is None:
+        result = asyncio.Future()
+        result.set_result(True)
+    future.set_result(result)
+    return future
+
+
+async def test_run_correction_invalid_schemas_topic_partitioning() -> None:
+    with patch.object(key_format_corrector, "AIOKafkaProducer", return_value=None) as mock_producer, patch.object(
+        key_format_corrector, "AIOKafkaConsumer", return_value=None
+    ) as mock_consumer:
+        mock_producer_instance = MagicMock()
+        mock_consumer_instance = MagicMock()
+        mock_producer.return_value = mock_producer_instance
+        mock_consumer.return_value = mock_consumer_instance
+
+        mock_consumer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.flush.return_value = mock_async_response()
+        mock_consumer_instance.stop.return_value = mock_async_response()
+        mock_producer_instance.stop.return_value = mock_async_response()
+
+        mock_consumer_instance.partitions_for_topic = Mock()
+        mock_consumer_instance.partitions_for_topic.return_value = set([1, 2])
+
+        config = {
+            "topic_name": "_schemas",
+            "bootstrap_uri": "localhost:1234",
+        }
+        kfc = key_format_corrector.KeyFormatCorrector(config=config)
+        await kfc.run_correction()
+
+        # Start called
+        mock_producer_instance.start.assert_called_once()
+        mock_consumer_instance.start.assert_called_once()
+
+        # Invalid partitioning, nothing produced
+        mock_consumer_instance.getmany.assert_not_called()
+        mock_producer_instance.send.assert_not_called()
+        mock_producer_instance.send_and_wait.assert_not_called()
+
+        # Finally block
+        assert not kfc.running
+        mock_producer_instance.flush.assert_called_once()
+        mock_producer_instance.stop.assert_called_once()
+        mock_consumer_instance.stop.assert_called_once()
+
+        # Test case of failed key correction and re-try of running the correction
+        mock_producer.reset_mock()
+        mock_consumer.reset_mock()
+        await kfc.run_correction()
+        mock_producer.assert_not_called()
+        mock_consumer.assert_not_called()
+
+
+async def test_run_correction_latest_offset_is_end_offset() -> None:
+    with patch.object(key_format_corrector, "AIOKafkaProducer", return_value=None) as mock_producer, patch.object(
+        key_format_corrector, "AIOKafkaConsumer", return_value=None
+    ) as mock_consumer:
+        mock_producer_instance = MagicMock()
+        mock_consumer_instance = MagicMock()
+        mock_producer.return_value = mock_producer_instance
+        mock_consumer.return_value = mock_consumer_instance
+
+        mock_consumer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.flush.return_value = mock_async_response()
+        mock_consumer_instance.stop.return_value = mock_async_response()
+        mock_producer_instance.stop.return_value = mock_async_response()
+
+        mock_consumer_instance.partitions_for_topic = Mock()
+        mock_consumer_instance.partitions_for_topic.return_value = set([0])
+        topic_partition = TopicPartition("_schemas", 0)
+        mock_consumer_instance.end_offsets.return_value = mock_async_response({topic_partition: 0})
+        mock_producer_instance.send_and_wait.return_value = mock_async_response()
+
+        config = {
+            "topic_name": "_schemas",
+            "bootstrap_uri": "localhost:1234",
+        }
+        kfc = key_format_corrector.KeyFormatCorrector(config=config)
+        await kfc.run_correction()
+        assert kfc.key_correction_done
+
+        # Start called
+        mock_producer_instance.start.assert_called_once()
+        mock_consumer_instance.start.assert_called_once()
+
+        # Offset already satisfied, nothing produced
+        mock_consumer_instance.getmany.assert_not_called()
+        mock_producer_instance.send.assert_not_called()
+        mock_producer_instance.send_and_wait.assert_called_once()
+
+        # Finally block
+        assert not kfc.running
+        mock_producer_instance.flush.assert_called_once()
+        mock_producer_instance.stop.assert_called_once()
+        mock_consumer_instance.stop.assert_called_once()
+
+
+async def test_run_correction_no_messages() -> None:
+    with patch.object(key_format_corrector, "AIOKafkaProducer", return_value=None) as mock_producer, patch.object(
+        key_format_corrector, "AIOKafkaConsumer", return_value=None
+    ) as mock_consumer:
+        mock_producer_instance = MagicMock()
+        mock_consumer_instance = MagicMock()
+        mock_producer.return_value = mock_producer_instance
+        mock_consumer.return_value = mock_consumer_instance
+
+        mock_consumer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.flush.return_value = mock_async_response()
+        mock_consumer_instance.stop.return_value = mock_async_response()
+        mock_producer_instance.stop.return_value = mock_async_response()
+
+        mock_consumer_instance.partitions_for_topic = Mock()
+        mock_consumer_instance.partitions_for_topic.return_value = set([0])
+        topic_partition = TopicPartition("_schemas", 0)
+        mock_consumer_instance.end_offsets.return_value = mock_async_response({topic_partition: 10})
+        mock_producer_instance.send_and_wait.return_value = mock_async_response()
+        mock_consumer_instance.getmany.return_value = mock_async_response({})
+
+        config = {
+            "topic_name": "_schemas",
+            "bootstrap_uri": "localhost:1234",
+        }
+        kfc = key_format_corrector.KeyFormatCorrector(config=config)
+        kfc.running = True
+        await kfc.run_correction()
+        assert kfc.key_correction_done
+
+        # Start called
+        mock_producer_instance.start.assert_called_once()
+        mock_consumer_instance.start.assert_called_once()
+
+        # No messages, nothing produced
+        mock_consumer_instance.getmany.assert_called_once()
+        mock_producer_instance.send.assert_not_called()
+        mock_producer_instance.send_and_wait.assert_called_once()
+
+        # Finally block
+        assert not kfc.running
+        mock_producer_instance.flush.assert_called_once()
+        mock_producer_instance.stop.assert_called_once()
+        mock_consumer_instance.stop.assert_called_once()
+
+
+async def test_run_correction_getmany_fails() -> None:
+    with patch.object(key_format_corrector, "AIOKafkaProducer", return_value=None) as mock_producer, patch.object(
+        key_format_corrector, "AIOKafkaConsumer", return_value=None
+    ) as mock_consumer:
+        mock_producer_instance = MagicMock()
+        mock_consumer_instance = MagicMock()
+        mock_producer.return_value = mock_producer_instance
+        mock_consumer.return_value = mock_consumer_instance
+
+        mock_consumer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.flush.return_value = mock_async_response()
+        mock_consumer_instance.stop.return_value = mock_async_response()
+        mock_producer_instance.stop.return_value = mock_async_response()
+
+        mock_consumer_instance.partitions_for_topic = Mock()
+        mock_consumer_instance.partitions_for_topic.return_value = set([0])
+        topic_partition = TopicPartition("_schemas", 0)
+        mock_consumer_instance.end_offsets.return_value = mock_async_response({topic_partition: 10})
+        mock_producer_instance.send_and_wait.return_value = mock_async_response()
+        mock_consumer_instance.getmany.side_effect = Exception("Except")
+
+        config = {
+            "topic_name": "_schemas",
+            "bootstrap_uri": "localhost:1234",
+        }
+        kfc = key_format_corrector.KeyFormatCorrector(config=config)
+        kfc.running = True
+
+        with pytest.raises(Exception, match="Except"):
+            await kfc.run_correction()
+        assert not kfc.key_correction_done
+
+        # Start called
+        mock_producer_instance.start.assert_called_once()
+        mock_consumer_instance.start.assert_called_once()
+
+        mock_consumer_instance.getmany.assert_called_once()
+        mock_producer_instance.send.assert_not_called()
+        mock_producer_instance.send_and_wait.assert_not_called()
+
+        # Finally block
+        assert not kfc.running
+        mock_producer_instance.flush.assert_called_once()
+        mock_producer_instance.stop.assert_called_once()
+        mock_consumer_instance.stop.assert_called_once()
+
+        # Test case of failed key correction and re-try of running the correction
+        mock_producer.reset_mock()
+        mock_consumer.reset_mock()
+        await kfc.run_correction()
+        mock_producer.assert_not_called()
+        mock_consumer.assert_not_called()
+
+
+async def test_run_correction_msg_offset_after() -> None:
+    with patch.object(key_format_corrector, "AIOKafkaProducer", return_value=None) as mock_producer, patch.object(
+        key_format_corrector, "AIOKafkaConsumer", return_value=None
+    ) as mock_consumer:
+        mock_producer_instance = MagicMock()
+        mock_consumer_instance = MagicMock()
+        mock_producer.return_value = mock_producer_instance
+        mock_consumer.return_value = mock_consumer_instance
+
+        mock_consumer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.flush.return_value = mock_async_response()
+        mock_consumer_instance.stop.return_value = mock_async_response()
+        mock_producer_instance.stop.return_value = mock_async_response()
+
+        mock_consumer_instance.partitions_for_topic = Mock()
+        mock_consumer_instance.partitions_for_topic.return_value = set([0])
+        topic_partition = TopicPartition("_schemas", 0)
+        mock_consumer_instance.end_offsets.return_value = mock_async_response({topic_partition: 1})
+        mock_producer_instance.send_and_wait.return_value = mock_async_response()
+
+        ConsumerRecord = collections.namedtuple("ConsumerRecord", ["offset", "key", "value"])
+        invalid_key = json.dumps(
+            {
+                "magic": 1,
+                "subject": "test-subject",
+                "version": 1,
+                "keytype": "SCHEMA",
+            },
+            sort_keys=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+        mock_consumer_instance.getmany.return_value = mock_async_response(
+            {topic_partition: [ConsumerRecord(offset=2, key=invalid_key, value=b"v_one")]}
+        )
+
+        config = {
+            "topic_name": "_schemas",
+            "bootstrap_uri": "localhost:1234",
+        }
+        kfc = key_format_corrector.KeyFormatCorrector(config=config)
+        kfc.running = True
+        await kfc.run_correction()
+        assert kfc.key_correction_done
+
+        # Start called
+        mock_producer_instance.start.assert_called_once()
+        mock_consumer_instance.start.assert_called_once()
+
+        # Nothing sent as the sole message offset is after
+        mock_consumer_instance.getmany.assert_called_once()
+        mock_producer_instance.send.assert_not_called()
+        mock_producer_instance.send_and_wait.assert_called_once()
+
+        # Finally block
+        assert not kfc.running
+        mock_producer_instance.flush.assert_called_once()
+        mock_producer_instance.stop.assert_called_once()
+        mock_consumer_instance.stop.assert_called_once()
+
+
+async def test_run_correction() -> None:
+    with patch.object(key_format_corrector, "AIOKafkaProducer", return_value=None) as mock_producer, patch.object(
+        key_format_corrector, "AIOKafkaConsumer", return_value=None
+    ) as mock_consumer:
+        mock_producer_instance = MagicMock()
+        mock_consumer_instance = MagicMock()
+        mock_producer.return_value = mock_producer_instance
+        mock_consumer.return_value = mock_consumer_instance
+
+        mock_consumer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.start.return_value = mock_async_response()
+        mock_producer_instance.flush.return_value = mock_async_response()
+        mock_consumer_instance.stop.return_value = mock_async_response()
+        mock_producer_instance.stop.return_value = mock_async_response()
+
+        mock_consumer_instance.partitions_for_topic = Mock()
+        mock_consumer_instance.partitions_for_topic.return_value = set([0])
+        topic_partition = TopicPartition("_schemas", 0)
+        mock_consumer_instance.end_offsets.return_value = mock_async_response({topic_partition: 1})
+        mock_producer_instance.send.return_value = mock_async_response()
+        mock_producer_instance.send_and_wait.return_value = mock_async_response()
+
+        ConsumerRecord = collections.namedtuple("ConsumerRecord", ["offset", "key", "value"])
+        invalid_key = json.dumps(
+            {
+                "magic": 1,
+                "subject": "test-subject",
+                "version": 1,
+                "keytype": "SCHEMA",
+            },
+            sort_keys=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        corrected_key = json.dumps(
+            {
+                "keytype": "SCHEMA",
+                "subject": "test-subject",
+                "version": 1,
+                "magic": 1,
+            },
+            sort_keys=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        good_key = json.dumps(
+            {
+                "keytype": "SCHEMA",
+                "subject": "test-subject",
+                "version": 2,
+                "magic": 1,
+            },
+            sort_keys=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+        mock_consumer_instance.getmany.return_value = mock_async_response(
+            {
+                topic_partition: [
+                    ConsumerRecord(offset=0, key=invalid_key, value=b"v_one"),
+                    ConsumerRecord(offset=1, key=good_key, value=b"v_two"),
+                ]
+            }
+        )
+
+        config = {
+            "topic_name": "_schemas",
+            "bootstrap_uri": "localhost:1234",
+        }
+        kfc = key_format_corrector.KeyFormatCorrector(config=config)
+        kfc.running = True
+        await kfc.run_correction()
+        assert kfc.key_correction_done
+
+        # Start called
+        mock_producer_instance.start.assert_called_once()
+        mock_consumer_instance.start.assert_called_once()
+
+        # Producer sends one corrected and tombstone
+        mock_consumer_instance.getmany.assert_called_once()
+
+        mock_producer_instance.send.assert_has_calls(
+            (call("_schemas", key=invalid_key, value=None), call("_schemas", key=corrected_key, value=b"v_one"))
+        )
+
+        mock_producer_instance.send_and_wait.assert_called_once()
+
+        # Finally block
+        assert not kfc.running
+        mock_producer_instance.flush.assert_called_once()
+        mock_producer_instance.stop.assert_called_once()
+        mock_consumer_instance.stop.assert_called_once()


### PR DESCRIPTION
# About this change - What it does

References: #347

Confluent Schema Registry message key uses field order of `keytype, subject, version, magic` and Karapace has used order of `subject, version, magic, keytype`. Kafka won't compact the topic correctly as the key field byte contents are different.

Confluent Schema Registry uses the most compact format of the JSON in the key, for example `{"keytype":"SCHEMA","subject":"foo","version":1,"magic":0}`. There is no whitespaces, indent nor linebreaks.

# Why this way

*First approach*
On Karapace startup the schema message topic is consumed and each key format checked. If format is not correct a tombstone message and corrected message is sent to the topic.

I used the approach @hackaugusto suggested in the ticket but decided to use the schema reader thread.
The limitation is that it cannot call the schema writing functions as those will trigger offset watching and would cause deadlock.
Another issue is with registries that have a lot of records and this has a significant memory pressure as invalid entries are first collected in memory and then processed. This was rejected and next approach taken.

*Second approach, current solution*
The correction processing is moved to background thread which is started when Karapace leader is ready. The correction is run per record and consumed from start. There is a special marker record sent to schemas topic when correction is run. This allows to identify if correction has already been run.


# Notes
 * Backup restore could also correct the keys for records.