### PR TITLE
Remove the compatibility level information from the GET API response.

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -544,6 +544,8 @@ class KarapaceSchemaRegistryController(KarapaceBase):
 
         try:
             subject_data = await self.schema_registry.subject_version_get(subject, version)
+            if "compatibility" in subject_data:
+                del subject_data["compatibility"]
             self.r(subject_data, content_type)
         except (SubjectNotFoundException, SchemasNotFoundException):
             self.r(


### PR DESCRIPTION
[PM-2036]

Fix for issue #435

The issue only occurs when we change the compatibility level for a subject. The fix is to remove the compatibility information from the GET API response.

[PM-2036]: https://aiven.atlassian.net/browse/PM-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ