### PR TITLE
fix: encode schema as str on anonymization

### DIFF
--- a/karapace/schema_backup.py
+++ b/karapace/schema_backup.py
@@ -261,7 +261,7 @@ def anonymize_avro_schema_message(key_bytes: bytes, value_bytes: bytes) -> str:
         if anonymized_schema:
             if "subject" in value:
                 value["subject"] = anonymize_avro.anonymize_name(value["subject"])
-            value["schema"] = anonymized_schema
+            value["schema"] = json_encode(anonymized_schema, sort_keys=False)
     # The schemas topic contain all changes to schema metadata.
     if key.get("subject", None):
         key["subject"] = anonymize_avro.anonymize_name(key["subject"])

--- a/tests/integration/test_schema_backup_avro_export.py
+++ b/tests/integration/test_schema_backup_avro_export.py
@@ -41,17 +41,20 @@ AVRO_SCHEMA = {
         },
     ],
 }
-EXPECTED_AVRO_SCHEMA = {
-    "type": "record",
-    "namespace": "aa258230180d9c643f761089d7e33b8b52288ed3.ae02f26b082c5f3bc7027f72335dd1186a2cd382",
-    "name": "afe8733e983101f1f4ff50d24152890d0da71418",
-    "fields": [
-        {
-            "type": "string",
-            "name": "a09bb890b096f7306f688cc6d1dad34e7e52a223",
-        },
-    ],
-}
+EXPECTED_AVRO_SCHEMA = json.dumps(
+    {
+        "type": "record",
+        "namespace": "aa258230180d9c643f761089d7e33b8b52288ed3.ae02f26b082c5f3bc7027f72335dd1186a2cd382",
+        "name": "afe8733e983101f1f4ff50d24152890d0da71418",
+        "fields": [
+            {
+                "type": "string",
+                "name": "a09bb890b096f7306f688cc6d1dad34e7e52a223",
+            },
+        ],
+    },
+    sort_keys=False,
+)
 
 COMPATIBILITY_SUBJECT = "compatibility_subject"
 COMPATIBILITY_SUBJECT_HASH = "a0765805d57daad3b08200d5be1c5adb6f3cff54"


### PR DESCRIPTION
# About this change - What it does

The JSON formatted schema in the message value must be encoded as string. The anonymized data is not parseable when restored by Karapace.
