### PR TITLE
Fix PROTOBUF schema comparison when posting to subject

### DIFF
--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -143,5 +143,5 @@ class ValidatedTypedSchema(TypedSchema):
 
     def __str__(self) -> str:
         if self.schema_type == SchemaType.PROTOBUF:
-            return str(self.schema)
+            return self.schema.to_schema()
         return super().__str__()

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -393,7 +393,7 @@ class KarapaceSchemaRegistry:
         self,
         *,
         subject: Subject,
-        schema: Optional[TypedSchema],
+        schema: Optional[ValidatedTypedSchema],
         schema_id: int,
         version: int,
         deleted: bool,
@@ -409,6 +409,8 @@ class KarapaceSchemaRegistry:
             }
             if schema.schema_type is not SchemaType.AVRO:
                 valuedict["schemaType"] = schema.schema_type
+            if schema.schema_type is SchemaType.PROTOBUF:
+                valuedict["schema"] = schema.schema.to_schema()
             value = json_encode(valuedict)
         else:
             value = ""

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -19,6 +19,7 @@ from karapace.errors import (
     VersionNotFoundException,
 )
 from karapace.karapace import KarapaceBase
+from karapace.protobuf.compare_result import CompareResult
 from karapace.rapu import HTTPRequest, JSON_CONTENT_TYPE, SERVER_NAME
 from karapace.schema_models import SchemaType, TypedSchema, ValidatedTypedSchema
 from karapace.schema_registry import KarapaceSchemaRegistry
@@ -756,6 +757,10 @@ class KarapaceSchemaRegistryController(KarapaceBase):
             validated_typed_schema = ValidatedTypedSchema.parse(schema["schema"].schema_type, schema["schema"].schema_str)
             if schema_type is SchemaType.JSONSCHEMA:
                 schema_valid = validated_typed_schema.to_dict() == new_schema.to_dict()
+            elif schema_type is SchemaType.PROTOBUF:
+                result = CompareResult()
+                validated_typed_schema.schema.compare(new_schema.schema, result)
+                schema_valid = result.is_compatible()
             else:
                 schema_valid = validated_typed_schema.schema == new_schema.schema
             if validated_typed_schema.schema_type == new_schema.schema_type and schema_valid:


### PR DESCRIPTION
fix for issue #442
[PM-2111]

PROTOBUF schema comparison was not validated correctly and threw 40403 “Schema not found” errors when posting to a subject.




[PM-2111]: https://aiven.atlassian.net/browse/PM-2111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ