### PR TITLE
feature: detect message key format to use

### DIFF
--- a/karapace/key_format.py
+++ b/karapace/key_format.py
@@ -1,0 +1,73 @@
+"""
+karapace - Key correction
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+from enum import Enum
+from karapace.typing import JsonData
+from karapace.utils import json_encode
+
+SCHEMA_KEY_ORDER = ["keytype", "subject", "version", "magic"]
+CONFIG_KEY_ORDER = ["keytype", "subject", "magic"]
+NOOP_KEY_ORDER = ["keytype", "magic"]
+
+CANONICAL_KEY_ORDERS = [SCHEMA_KEY_ORDER, CONFIG_KEY_ORDER, NOOP_KEY_ORDER]
+
+
+class KeyMode(Enum):
+    """Key modes supported by Karapace.
+
+    CANONICAL format is the format that Confluent Schema Registry produces.
+
+    DEPRECATED_KARAPACE format does not alter the order of JSON key properties. This is the deprecated
+    behaviour and is not bit perfect replication of key format used by Confluent Schema Registry.
+    """
+
+    CANONICAL = 1
+    DEPRECATED_KARAPACE = 2
+
+
+class KeyFormatter:
+    """Schema record key formatter.
+
+    Prefer the canonical format on new installations and migrations from Confluent Schema Registry.
+
+    Prefer Karapace key format on installations where this key format use is detected. This applies to
+    Karapace installations and installations that have migrated from Confluent Schema Registry to Karapace
+    and have mixed key formats in schemas topic.
+    """
+
+    def __init__(self) -> None:
+        self._keymode = KeyMode.CANONICAL
+
+    def set_keymode(self, keymode: KeyMode) -> None:
+        self._keymode = keymode
+
+    def get_keymode(self) -> KeyMode:
+        return self._keymode
+
+    def format_key(self, key: JsonData, keymode: KeyMode = KeyMode.CANONICAL, compact: bool = True) -> bytes:
+        """Format key by the given keymode.
+
+        :param key Key data as JsonData dict
+        :param keymode Key mode for selecting the format. Defaults to KeyMode.CANONICAL.
+        """
+        keymode = keymode or self._keymode
+        if keymode == KeyMode.DEPRECATED_KARAPACE:
+            # No alterations
+            return json_encode(key, sort_keys=False, binary=True, compact=compact)
+        corrected_key = {
+            "keytype": key["keytype"],
+        }
+        if "subject" in key:
+            corrected_key["subject"] = key["subject"]
+        if "version" in key:
+            corrected_key["version"] = key["version"]
+        # Magic is the last element
+        corrected_key["magic"] = key["magic"]
+        return json_encode(corrected_key, sort_keys=False, binary=True, compact=True)
+
+
+def is_key_in_canonical_format(key: JsonData) -> bool:
+    return list(key.keys()) in CANONICAL_KEY_ORDERS

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -70,11 +70,16 @@ def default_json_serialization(  # pylint: disable=inconsistent-return-statement
     assert_never("Object of type {!r} is not JSON serializable".format(obj.__class__.__name__))
 
 
-def json_encode(obj, *, sort_keys: bool = True, binary=False):
+SEPARATORS = (",", ":")
+
+
+def json_encode(obj, *, sort_keys: bool = True, binary=False, compact=False):
+    separators = SEPARATORS if compact else None
     res = json.dumps(
         obj,
         sort_keys=sort_keys,
         default=default_json_serialization,
+        separators=separators,
     )
     return res.encode("utf-8") if binary else res
 

--- a/tests/base_testcase.py
+++ b/tests/base_testcase.py
@@ -1,0 +1,15 @@
+"""
+karapace - Test base class
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BaseTestCase:
+    test_name: str
+
+    def __str__(self):
+        return self.test_name

--- a/tests/unit/test_key_format.py
+++ b/tests/unit/test_key_format.py
@@ -1,0 +1,246 @@
+"""
+karapace - Test key format
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+
+from dataclasses import dataclass
+from karapace.key_format import is_key_in_canonical_format, KeyFormatter, KeyMode
+from karapace.typing import JsonData
+from tests.base_testcase import BaseTestCase
+
+import pytest
+
+
+@dataclass
+class KeyFormatCase(BaseTestCase):
+    keymode: KeyMode
+    input: JsonData
+    expected: JsonData
+
+
+@dataclass
+class IsInCanonicalFormatCase(BaseTestCase):
+    input: JsonData
+    expected: bool
+
+
+def test_keymode_set_and_get() -> None:
+    key_formatter = KeyFormatter()
+    assert key_formatter.get_keymode() == KeyMode.CANONICAL
+    key_formatter.set_keymode(KeyMode.DEPRECATED_KARAPACE)
+    assert key_formatter.get_keymode() == KeyMode.DEPRECATED_KARAPACE
+    key_formatter.set_keymode(KeyMode.CANONICAL)
+    assert key_formatter.get_keymode() == KeyMode.CANONICAL
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    [
+        # Canonical format
+        KeyFormatCase(
+            test_name="Schema message, Karapace format to canonical",
+            keymode=KeyMode.CANONICAL,
+            input={
+                "subject": "test",
+                "version": 1,
+                "magic": 1,
+                "keytype": "SCHEMA",
+            },
+            expected=b'{"keytype":"SCHEMA","subject":"test","version":1,"magic":1}',
+        ),
+        KeyFormatCase(
+            test_name="Config message, has subject, Karapace format to canonical",
+            keymode=KeyMode.CANONICAL,
+            input={
+                "subject": "test",
+                "magic": 0,
+                "keytype": "CONFIG",
+            },
+            expected=b'{"keytype":"CONFIG","subject":"test","magic":0}',
+        ),
+        KeyFormatCase(
+            test_name="Config message, None subject, Karapace format to canonical",
+            keymode=KeyMode.CANONICAL,
+            input={
+                "subject": None,
+                "magic": 0,
+                "keytype": "CONFIG",
+            },
+            expected=b'{"keytype":"CONFIG","subject":null,"magic":0}',
+        ),
+        KeyFormatCase(
+            test_name="Delete subject message, Karapace format to canonical",
+            keymode=KeyMode.CANONICAL,
+            input={
+                "subject": "test",
+                "magic": 0,
+                "keytype": "DELETE_SUBJECT",
+            },
+            expected=b'{"keytype":"DELETE_SUBJECT","subject":"test","magic":0}',
+        ),
+        KeyFormatCase(
+            test_name="NOOP message, Karapace format to canonical",
+            keymode=KeyMode.CANONICAL,
+            input={
+                "magic": 0,
+                "keytype": "NOOP",
+            },
+            expected=b'{"keytype":"NOOP","magic":0}',
+        ),
+        # Karapace format
+        KeyFormatCase(
+            test_name="Schema message, Karapace format",
+            keymode=KeyMode.DEPRECATED_KARAPACE,
+            input={
+                "subject": "test",
+                "version": 1,
+                "magic": 1,
+                "keytype": "SCHEMA",
+            },
+            expected=b'{"subject":"test","version":1,"magic":1,"keytype":"SCHEMA"}',
+        ),
+        KeyFormatCase(
+            test_name="Config message, has subject, Karapace format",
+            keymode=KeyMode.DEPRECATED_KARAPACE,
+            input={
+                "subject": "test",
+                "magic": 0,
+                "keytype": "CONFIG",
+            },
+            expected=b'{"subject":"test","magic":0,"keytype":"CONFIG"}',
+        ),
+        KeyFormatCase(
+            test_name="Config message, None subject, Karapace format",
+            keymode=KeyMode.DEPRECATED_KARAPACE,
+            input={
+                "subject": None,
+                "magic": 0,
+                "keytype": "CONFIG",
+            },
+            expected=b'{"subject":null,"magic":0,"keytype":"CONFIG"}',
+        ),
+        KeyFormatCase(
+            test_name="Delete subject message, Karapace format",
+            keymode=KeyMode.DEPRECATED_KARAPACE,
+            input={
+                "subject": "test",
+                "magic": 0,
+                "keytype": "DELETE_SUBJECT",
+            },
+            expected=b'{"subject":"test","magic":0,"keytype":"DELETE_SUBJECT"}',
+        ),
+        KeyFormatCase(
+            test_name="NOOP message, Karapace format",
+            keymode=KeyMode.DEPRECATED_KARAPACE,
+            input={
+                "magic": 0,
+                "keytype": "NOOP",
+            },
+            expected=b'{"magic":0,"keytype":"NOOP"}',
+        ),
+    ],
+)
+def test_format_key(testcase: KeyFormatCase) -> None:
+    assert KeyFormatter().format_key(key=testcase.input, keymode=testcase.keymode) == testcase.expected
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    [
+        # Canonical format
+        IsInCanonicalFormatCase(
+            test_name="Schema message, canonical format",
+            input={
+                "keytype": "SCHEMA",
+                "subject": "test",
+                "version": 1,
+                "magic": 1,
+            },
+            expected=True,
+        ),
+        IsInCanonicalFormatCase(
+            test_name="Config message, canonical format",
+            input={
+                "keytype": "CONFIG",
+                "subject": "test",
+                "magic": 0,
+            },
+            expected=True,
+        ),
+        IsInCanonicalFormatCase(
+            test_name="Config message, canonical format",
+            input={
+                "keytype": "CONFIG",
+                "subject": None,
+                "magic": 0,
+            },
+            expected=True,
+        ),
+        IsInCanonicalFormatCase(
+            test_name="Delete subject message, canonical format",
+            input={
+                "keytype": "DELETE_SUBJECT",
+                "subject": "test",
+                "magic": 0,
+            },
+            expected=True,
+        ),
+        IsInCanonicalFormatCase(
+            test_name="NOOP message, canonical format",
+            input={
+                "keytype": "NOOP",
+                "magic": 0,
+            },
+            expected=True,
+        ),
+        # Karapace format
+        IsInCanonicalFormatCase(
+            test_name="Schema message, Karapace format",
+            input={
+                "subject": "test",
+                "version": 1,
+                "magic": 1,
+                "keytype": "SCHEMA",
+            },
+            expected=False,
+        ),
+        IsInCanonicalFormatCase(
+            test_name="Config message, has subject, Karapace format",
+            input={
+                "subject": "test",
+                "magic": 0,
+                "keytype": "CONFIG",
+            },
+            expected=False,
+        ),
+        IsInCanonicalFormatCase(
+            test_name="Config message, None subject, Karapace format",
+            input={
+                "subject": None,
+                "magic": 0,
+                "keytype": "CONFIG",
+            },
+            expected=False,
+        ),
+        IsInCanonicalFormatCase(
+            test_name="Delete subject message, Karapace format",
+            input={
+                "subject": "test",
+                "magic": 0,
+                "keytype": "DELETE_SUBJECT",
+            },
+            expected=False,
+        ),
+        IsInCanonicalFormatCase(
+            test_name="NOOP message, Karapace format",
+            input={
+                "magic": 0,
+                "keytype": "NOOP",
+            },
+            expected=False,
+        ),
+    ],
+)
+def test_is_in_canonical_format(testcase: IsInCanonicalFormatCase) -> None:
+    assert is_key_in_canonical_format(testcase.input) == testcase.expected


### PR DESCRIPTION
# About this change - What it does

Prefer the canonical format on new installations and migrations from
Confluent Schema Registry.
Prefer Karapace key format on installations where this key format use
is detected. This applies to Karapace installations and installations
that have migrated from Confluent Schema Registry to Karapace and have
mixed key formats in schemas topic.

