### PR TITLE
Fix ProtoBuf schema comparison

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,9 @@ Compatibility details
 
 Karapace is compatible with Schema Registry 6.1.1 on API level. When a new version of SR is released, the goal is
 to support it in a reasonable time. Karapace supports all operations in the API.
-The goal is that even the error messages are the same as in Schema Registry, which cannot be always fully guaranteed.
+
+There are some caveats regarding the schema normalization, and the error messages being the same as in Schema Registry, which
+cannot be always fully guaranteed.
 
 Setup
 =====

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -112,6 +112,10 @@ class ProtobufSchema:
             self.cache_string = self.to_schema()
         return self.cache_string
 
+    # str() does normalization of whitespaces and element ordering
+    def __eq__(self, other) -> bool:
+        return str(self) == str(other)
+
     def to_schema(self) -> str:
         strings = []
         shm: ProtoFileElement = self.proto_file_element

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -34,8 +34,10 @@ def add_slashes(text: str) -> str:
 log = logging.getLogger(__name__)
 
 
+# This test ProtoBuf schemas in subject registeration, compatibility of evolved version and querying the schema
+# w.r.t. normalization of whitespace and other minor differences to verify equality and inequality comparison of such schemas
 @pytest.mark.parametrize("trail", ["", "/"])
-async def test_protobuf_schema_compatibility(registry_async_client: Client, trail: str) -> None:
+async def test_protobuf_schema_normalization(registry_async_client: Client, trail: str) -> None:
     subject = create_subject_name_factory(f"test_protobuf_schema_compatibility-{trail}")()
 
     res = await registry_async_client.put(f"config/{subject}{trail}", json={"compatibility": "BACKWARD"})
@@ -56,11 +58,61 @@ async def test_protobuf_schema_compatibility(registry_async_client: Client, trai
 
     original_schema = trim_margin(original_schema)
 
+    # Same schema with different whitespaces to see API equality comparison works
+    original_schema_with_whitespace = trim_margin(
+        """
+            |syntax = "proto3";
+            |
+            |package a1;
+            |
+            |
+            |message TestMessage {
+            |    message Value {
+            |        string str2 = 1;
+            |      int32 x = 2;
+            |    }
+            |  string test = 1;
+            |      .a1.TestMessage.Value val = 2;
+            |}
+            |"""
+    )
+
     res = await registry_async_client.post(
         f"subjects/{subject}/versions{trail}", json={"schemaType": "PROTOBUF", "schema": original_schema}
     )
     assert res.status_code == 200
     assert "id" in res.json()
+    original_id = res.json()["id"]
+
+    res = await registry_async_client.post(
+        f"subjects/{subject}/versions{trail}", json={"schemaType": "PROTOBUF", "schema": original_schema}
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+    assert original_id == res.json()["id"], "No duplication"
+
+    res = await registry_async_client.post(
+        f"subjects/{subject}/versions{trail}", json={"schemaType": "PROTOBUF", "schema": original_schema_with_whitespace}
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+    assert original_id == res.json()["id"], "No duplication with whitespace differences"
+
+    res = await registry_async_client.post(
+        f"subjects/{subject}{trail}", json={"schemaType": "PROTOBUF", "schema": original_schema}
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+    assert "schema" in res.json()
+    assert original_id == res.json()["id"], "Check returns original id"
+
+    res = await registry_async_client.post(
+        f"subjects/{subject}{trail}", json={"schemaType": "PROTOBUF", "schema": original_schema_with_whitespace}
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+    assert "schema" in res.json()
+    assert original_id == res.json()["id"], "Check returns original id"
 
     evolved_schema = """
             |syntax = "proto3";
@@ -92,6 +144,8 @@ async def test_protobuf_schema_compatibility(registry_async_client: Client, trai
     )
     assert res.status_code == 200
     assert "id" in res.json()
+    assert original_id != res.json()["id"], "Evolved is not equal"
+    evolved_id = res.json()["id"]
 
     res = await registry_async_client.post(
         f"compatibility/subjects/{subject}/versions/latest{trail}",
@@ -104,3 +158,12 @@ async def test_protobuf_schema_compatibility(registry_async_client: Client, trai
     )
     assert res.status_code == 200
     assert "id" in res.json()
+    assert original_id == res.json()["id"], "Original id again"
+
+    res = await registry_async_client.post(
+        f"subjects/{subject}{trail}", json={"schemaType": "PROTOBUF", "schema": evolved_schema}
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+    assert "schema" in res.json()
+    assert evolved_id == res.json()["id"], "Check returns evolved id"


### PR DESCRIPTION
# About this change - What it does

Fix ProtoBuf schema duplication depending on whitespaces of definition. This was regression as explained on #442.

# Why this way

Compare ProtoBuf schema definitions as normalized strings instead of ProtobufSchema objects to correctly equalize ProtoBuf definitions with minor whitespace differences.  Also for hashing use canonized form of ProtoBuf definition.

Fixes #442

This is alternative approach to PR #445