### PR TITLE
fix: return 404 when compatibility check done to non-existent version

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -286,7 +286,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 content_type=content_type,
                 status=HTTPStatus.NOT_FOUND,
             )
-        except VersionNotFoundException:
+        except (VersionNotFoundException, SchemasNotFoundException):
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.VERSION_NOT_FOUND.value,


### PR DESCRIPTION
# About this change - What it does

There was no mapping to `SchemasNotFoundException` in the compatibility check API controller.