### PR TITLE
Use Sentry SDK

### DIFF
--- a/karapace/config.py
+++ b/karapace/config.py
@@ -105,6 +105,10 @@ def set_config_defaults(config: Config) -> Config:
     new_config = DEFAULTS.copy()
     new_config.update(config)
 
+    # Tag app should always be karapace
+    new_config.setdefault("tags", {})
+    new_config["tags"]["app"] = "Karapace"
+
     set_settings_from_environment(new_config)
     set_sentry_dsn_from_environment(new_config)
     validate_config(new_config)
@@ -142,10 +146,6 @@ def set_sentry_dsn_from_environment(config: Config) -> None:
     sentry_dsn = os.environ.get("SENTRY_DSN")
     if sentry_dsn is not None:
         sentry_config["dsn"] = sentry_dsn
-
-    # Tag app should always be karapace
-    sentry_config.setdefault("tags", {})
-    sentry_config["tags"]["app"] = "Karapace"
 
 
 def validate_config(config: Config) -> None:

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -60,9 +60,8 @@ def main() -> int:
     try:
         # `close` will be called by the callback `close_by_app` set by `KarapaceBase`
         app.run()
-    except Exception:  # pylint: disable-broad-except
-        if app.raven_client:
-            app.raven_client.captureException(tags={"where": "karapace"})
+    except Exception as ex:  # pylint: disable-broad-except
+        app.stats.unexpected_exception(ex=ex, where="karapace")
         raise
     return 0
 

--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -165,8 +165,7 @@ class RestApp:
         self.app_request_metric = "{}_request".format(app_name)
         self.app = aiohttp.web.Application()
         self.log = logging.getLogger(self.app_name)
-        self.stats = StatsClient(sentry_config=config["sentry"])
-        self.raven_client = self.stats.raven_client
+        self.stats = StatsClient(config=config)
         self.app.on_cleanup.append(self.close_by_app)
 
     async def close_by_app(self, app: aiohttp.web.Application) -> None:  # pylint: disable=unused-argument

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -143,9 +143,7 @@ class KafkaSchemaReader(Thread):
         self.consumer: Optional[KafkaConsumer] = None
         self.offset_watcher = OffsetsWatcher()
         self.id_lock = Lock()
-        self.stats = StatsClient(
-            sentry_config=config.get("sentry"),  # type: ignore[arg-type]
-        )
+        self.stats = StatsClient(config=config)
 
         # Thread synchronization objects
         # - offset is used by the REST API to wait until this thread has

--- a/karapace/sentry/__init__.py
+++ b/karapace/sentry/__init__.py
@@ -1,0 +1,29 @@
+from karapace.sentry.sentry_client_api import SentryClientAPI, SentryNoOpClient
+from typing import Dict, Optional
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+def _get_sentry_noop_client(sentry_config: Optional[Dict]) -> SentryClientAPI:
+    return SentryNoOpClient(sentry_config=sentry_config)
+
+
+_get_sentry_client = _get_sentry_noop_client
+
+
+try:
+    from karapace.sentry.sentry_client import SentryClient
+
+    # If Sentry SDK can be imported in SentryClient the Sentry SDK can be initialized.
+    def _get_actual_sentry_client(sentry_config: Optional[Dict]) -> SentryClientAPI:
+        return SentryClient(sentry_config=sentry_config)
+
+    _get_sentry_client = _get_actual_sentry_client
+except ImportError:
+    LOG.warning("Cannot enable Sentry.io sending: importing 'sentry_sdk' failed")
+
+
+def get_sentry_client(sentry_config: Optional[Dict]) -> SentryClientAPI:
+    return _get_sentry_client(sentry_config=sentry_config)

--- a/karapace/sentry/sentry_client.py
+++ b/karapace/sentry/sentry_client.py
@@ -1,0 +1,42 @@
+from karapace.sentry.sentry_client_api import SentryClientAPI
+from typing import Dict, Optional
+
+# The Sentry SDK is optional, omit pylint import error
+import sentry_sdk  # pylint: disable=import-error
+
+
+class SentryClient(SentryClientAPI):
+    def __init__(self, sentry_config: Optional[Dict]) -> None:
+        super().__init__(sentry_config=sentry_config)
+        self._initialize_sentry()
+
+    def _initialize_sentry(self) -> None:
+        sentry_config = (
+            self.sentry_config.copy()
+            if self.sentry_config is not None
+            else {
+                "ignore_errors": [
+                    "ClientConnectorError",  # aiohttp
+                    "ClientPayloadError",  # aiohttp
+                    "ConnectionRefusedError",  # kafka (asyncio)
+                    "ConnectionResetError",  # kafka, requests
+                    "IncompleteReadError",  # kafka (asyncio)
+                    "ServerDisconnectedError",  # aiohttp
+                    "ServerTimeoutError",  # aiohttp
+                    "TimeoutError",  # kafka
+                ]
+            }
+        )
+
+        # If the DSN is not in the config or in SENTRY_DSN environment variable
+        # the Sentry client does not send any events.
+        sentry_sdk.init(**sentry_config)
+
+    def unexpected_exception(self, error: Exception, where: str, tags: Optional[Dict] = None) -> None:
+        scope_args = {"tags": {"where": where, **(tags or {})}}
+        sentry_sdk.Hub.current.capture_exception(error=error, scope=None, **scope_args)
+
+    def close(self) -> None:
+        client = sentry_sdk.Hub.current.client
+        if client is not None:
+            client.close(timeout=2.0)

--- a/karapace/sentry/sentry_client_api.py
+++ b/karapace/sentry/sentry_client_api.py
@@ -1,0 +1,16 @@
+from typing import Dict, Optional
+
+
+class SentryClientAPI:
+    def __init__(self, sentry_config: Optional[Dict]) -> None:
+        self.sentry_config = sentry_config or {}
+
+    def unexpected_exception(self, error: Exception, where: str, tags: Optional[Dict] = None) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class SentryNoOpClient(SentryClientAPI):
+    pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,5 +19,8 @@ pre-commit>=2.2.0
 # performance test
 locust==2.9.0
 
+# Sentry SDK
+sentry-sdk==1.6.0
+
 # runtime requirements
 -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         # compression algorithms supported by KafkaConsumer
         "lz4": ["lz4"],
         "zstd": ["python-zstandard"],
+        "sentry-sdk": ["sentry-sdk>=1.6.0"],
     },
     dependency_links=[],
     package_data={},


### PR DESCRIPTION
# About this change - What it does

The Raven client is obsolete. Some refactoring is included to
separate the Sentry usage from StatsClient. StatsClient will use
either no-op Sentry client or actual Sentry client is Sentry SDK
is installed.

The Sentry SDK version to be greater than or equal to 1.6.0.

