### PR TITLE
fix: Use `--tags` to find last version from Git repository

### DIFF
--- a/version.py
+++ b/version.py
@@ -27,7 +27,9 @@ def get_project_version(version_file: str) -> str:
 
     os.chdir(os.path.dirname(__file__) or ".")
     try:
-        git_out = subprocess.check_output(["git", "describe", "--always"], stderr=getattr(subprocess, "DEVNULL", None))
+        git_out = subprocess.check_output(
+            ["git", "describe", "--always", "--tags"], stderr=getattr(subprocess, "DEVNULL", None)
+        )
     except (OSError, subprocess.CalledProcessError):
         pass
     else:


### PR DESCRIPTION
# About this change - What it does
Karapace releases are lightweight tags. Without `--tags` switch only annotated tags are searched.
Current version is always `2.0.1-747-g3e554f0`, after using `--tags` the version uses correctly the last release tag.
E.g. after the change `3.3.2-5-g9516d08`.
