### PR TITLE
Fix REST producing using AVRO primitive schema

### DIFF
--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -149,7 +149,8 @@ class SchemaRegistrySerializerDeserializer:
         schema_typed = ValidatedTypedSchema.parse(schema_type, schema)
         namespace = "dummy"
         if schema_type is SchemaType.AVRO:
-            namespace = schema_typed.schema.namespace
+            if isinstance(schema_typed.schema, avro.schema.NamedSchema):
+                namespace = schema_typed.schema.namespace
         if schema_type is SchemaType.JSONSCHEMA:
             namespace = schema_typed.to_dict().get("namespace", "dummy")
         #  Protobuf does not use namespaces in terms of AVRO


### PR DESCRIPTION
# About this change - What it does

Fix REST producing using AVRO primitive schema

# Why this way

In AVRO primitive schemas don't have namespace.  Fix producing AVRO message with REST API when using primitive schema.
