### PR TITLE
bump avro to 1.11.1

### DIFF
--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -222,6 +222,8 @@ class SchemaRegistrySerializer:
                 raise InvalidPayload("Data does not contain a valid message") from e
             except avro.errors.SchemaResolutionException as e:
                 raise InvalidPayload("Data cannot be decoded with provided schema") from e
+            except avro.errors.InvalidAvroBinaryEncoding as e:
+                raise InvalidPayload("Data is not a valid Avro binary representation") from e
 
 
 def flatten_unions(schema: avro.schema.Schema, value: Any) -> Any:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 accept-types==0.4.1
 aiohttp==3.8.1
 aiokafka==0.7.2
-avro==1.11.0
+avro==1.11.1
 jsonschema==3.2.0
 networkx==2.5
 protobuf==3.19.5

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -2828,11 +2828,3 @@ async def test_invalid_schema_should_provide_good_error_messages(registry_async_
         res.json()["message"]
         == "Invalid AVRO schema. Error: Enum symbols must be a sequence of strings, but it is <class 'dict'>"
     )
-
-    # This is an upstream bug in the python AVRO library, until the bug is fixed we should at least have a nice error message
-    schema_str = json.dumps({"type": "enum", "name": "error", "symbols": ["A", "B"]})
-    res = await registry_async_client.post(
-        f"subjects/{test_subject}/versions",
-        json={"schema": schema_str},
-    )
-    assert res.json()["message"] == "Invalid AVRO schema. Error: error is a reserved type name."

--- a/tests/unit/test_avro_compatibility.py
+++ b/tests/unit/test_avro_compatibility.py
@@ -36,11 +36,11 @@ badDefaultNullString = parse_avro_schema_definition(
     '{"type":"record","name":"myrecord","fields":[{"type":["null","string"],"name":"f1","default":'
     '"null"},{"type":"string","name":"f2","default":"foo"},{"type":"string","name":"f3","default":"bar"}]}'
 )
-invalidEnumDefaultValue = parse_avro_schema_definition(
-    '{"type": "enum", "name": "test_default", "symbols": ["A"], "default": "B"}'
+incorrectEnumDefaultValue = parse_avro_schema_definition(
+    '{"type": "enum", "name": "test_default", "symbols": ["A", "B"], "default": "B"}'
 )
 correctEnumDefaultValue = parse_avro_schema_definition(
-    '{"type": "enum", "name": "test_default", "symbols": ["A"], "default": "A"}'
+    '{"type": "enum", "name": "test_default", "symbols": ["A", "B"], "default": "A"}'
 )
 
 
@@ -87,7 +87,7 @@ def test_schemaregistry_basic_backwards_compatibility():
     assert not schemas_are_compatible(res, SchemaCompatibilityResult(SchemaCompatibilityType.compatible)), msg
 
     msg = "changing a default value in enum is a backward compatible change"
-    res = ReaderWriterCompatibilityChecker().get_compatibility(invalidEnumDefaultValue, correctEnumDefaultValue)
+    res = ReaderWriterCompatibilityChecker().get_compatibility(incorrectEnumDefaultValue, correctEnumDefaultValue)
     assert schemas_are_compatible(res, SchemaCompatibilityResult(SchemaCompatibilityType.compatible)), msg
 
 


### PR DESCRIPTION


<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

* enum default value must be an element of enum symbols
* Invalid binary representations trigger a different exception
* removed test for "reserved" names

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #439 

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
