### PR TITLE
build: Add Python 3.11 to CI build matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v1
 
@@ -21,6 +21,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Install libsnappy-dev (python-snappy legacy-install-failure on Python 3.11)
+      run: sudo apt install libsnappy-dev
 
     - name: Install dependencies
       run: python -m pip install -r requirements-dev.txt

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -938,7 +938,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.INVALID_SCHEMA.value,
-                    "message": f"Invalid {schema_type} schema. Error: {human_error}",
+                    "message": f"Invalid {schema_type.value} schema. Error: {human_error}",
                 },
                 content_type=content_type,
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
@@ -968,7 +968,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 self.r(
                     body={
                         "error_code": SchemaErrorCodes.INVALID_SCHEMA.value,
-                        "message": f"Invalid {schema_type} schema. Error: {str(ex)}",
+                        "message": f"Invalid {schema_type.value} schema. Error: {str(ex)}",
                     },
                     content_type=content_type,
                     status=HTTPStatus.UNPROCESSABLE_ENTITY,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ requests==2.27.1
 pre-commit>=2.2.0
 
 # performance test
-locust==2.9.0
+locust==2.13.0
 
 # Sentry SDK
 sentry-sdk==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # PyPI dependencies
 accept-types==0.4.1
-aiohttp==3.8.1
+aiohttp==3.8.3
 aiokafka==0.7.2
 avro==1.11.0
 jsonschema==3.2.0
@@ -26,7 +26,7 @@ certifi==2021.10.8 # requests, urllib3
 chardet==3.0.4 # requests
 charset-normalizer==2.0.11 # aiohttp, requests
 decorator==5.1.1 # networkx
-frozenlist==1.3.0 # aiohttp, aiosignal
+frozenlist==1.3.1 # aiohttp, aiosignal
 idna==3.3 # aiohttp, requests, urllib3
 lz4==3.0.2 # kafka
 multidict==6.0.2 # aiohttp, yarl
@@ -35,5 +35,5 @@ pyrsistent==0.18.1 # jsonschema
 requests==2.27.1 # jsonschema
 six==1.16.0 # dateutil
 urllib3==1.26.8 # requests
-yarl==1.7.2 # aiohttp
+yarl==1.8.1 # aiohttp
 zstandard==0.18.0 # kafka


### PR DESCRIPTION
# About this change - What it does

Python 3.11 released, add it to tested Python versions.
https://github.com/actions/runner-images/issues/6459

Github Action test workflow will install `libsnappy-dev` as `python-snappy` with Python 3.11 will fail buildin, no wheel available yet.

Changed to use the value of `SchemaType` enum as Python 3.11 will render `SchemaType.AVRO` instead of `AVRO`.

Dependencies upgraded with Python 3.11 compatible versions. No major changes apart of Python 3.11 compatibility based on the release notes of the libraries.
 * aiohttp 3.8.3 (was 3.8.1)
 * frozenlist 1.3.1 (was 1.3.0)
 * yarl 1.8.1 (was 1.7.2)
 * locust 2.13.0 (was 2.9.0) (used in perfomance tests)
