### PR TITLE
feature: forward requests to primary node when not ready

### DIFF
--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -8,13 +8,13 @@ See LICENSE for details
 from functools import partial
 from http import HTTPStatus
 from karapace.config import Config
-from karapace.rapu import HTTPResponse, RestApp
-from typing import NoReturn, Union
+from karapace.rapu import HTTPRequest, HTTPResponse, RestApp
+from typing import Callable, NoReturn, Optional, Union
 
 
 class KarapaceBase(RestApp):
-    def __init__(self, config: Config) -> None:
-        super().__init__(app_name="karapace", config=config)
+    def __init__(self, config: Config, not_ready_handler: Optional[Callable[[HTTPRequest], None]] = None) -> None:
+        super().__init__(app_name="karapace", config=config, not_ready_handler=not_ready_handler)
 
         self.kafka_timeout = 10
         self.route("/", callback=self.root_get, method="GET")

--- a/tests/unit/test_schema_registry_api.py
+++ b/tests/unit/test_schema_registry_api.py
@@ -1,0 +1,50 @@
+from aiohttp.test_utils import TestClient, TestServer
+from karapace.config import DEFAULTS
+from karapace.rapu import HTTPResponse
+from karapace.schema_registry_apis import KarapaceSchemaRegistryController
+from unittest.mock import ANY, Mock, patch, PropertyMock
+
+import asyncio
+
+
+async def test_forward_when_not_ready():
+    with patch("karapace.schema_registry_apis.aiohttp.ClientSession") as client_session_class, patch(
+        "karapace.schema_registry_apis.KarapaceSchemaRegistry"
+    ) as schema_registry_class:
+        client_session = Mock()
+        client_session_class.return_value = client_session
+
+        schema_reader_mock = Mock()
+        ready_property_mock = PropertyMock(return_value=False)
+        schema_registry = Mock()
+        type(schema_reader_mock).ready = ready_property_mock
+        schema_registry.schema_reader = schema_reader_mock
+        schema_registry_class.return_value = schema_registry
+
+        get_master_future = asyncio.Future()
+        get_master_future.set_result((False, "http://primary-url"))
+        schema_registry.get_master.return_value = get_master_future
+
+        close_future_result = asyncio.Future()
+        close_future_result.set_result(True)
+        close_func = Mock()
+        close_func.return_value = close_future_result
+        schema_registry.close = close_func
+        client_session.close = close_func
+
+        controller = KarapaceSchemaRegistryController(config=DEFAULTS)
+        mock_forward_func_future = asyncio.Future()
+        mock_forward_func_future.set_exception(HTTPResponse({"mock": "response"}))
+        mock_forward_func = Mock()
+        mock_forward_func.return_value = mock_forward_func_future
+        controller._forward_request_remote = mock_forward_func  # pylint: disable=protected-access
+
+        test_server = TestServer(controller.app)
+        async with TestClient(test_server) as client:
+            await client.get("/schemas/ids/1", headers={"Content-Type": "application/json"})
+
+            ready_property_mock.assert_called_once()
+            schema_registry.get_master.assert_called_once()
+            mock_forward_func.assert_called_once_with(
+                request=ANY, body=None, url="http://primary-url/schemas/ids/1", content_type="application/json", method="GET"
+            )


### PR DESCRIPTION
# About this change - What it does

When Karapace is not ready and still replaying the state from `_schemas` the instance should forward every request to primary node.
