### PR TITLE
Acquire the lock once per batch in schema reader

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -296,7 +296,7 @@ class KafkaSchemaReader(Thread):
                         LOG.exception("Invalid JSON in msg.value")
                         continue
 
-                self.handle_msg(key, value)
+                self._handle_msg(key, value)
                 self.offset = msg.offset
 
                 if msg_keymode == KeyMode.CANONICAL:
@@ -488,7 +488,7 @@ class KafkaSchemaReader(Thread):
             else:
                 self._delete_from_schema_id_on_subject(subject=schema_subject, schema=typed_schema)
 
-    def handle_msg(self, key: dict, value: Optional[dict]) -> None:
+    def _handle_msg(self, key: dict, value: Optional[dict]) -> None:
         if key["keytype"] == "CONFIG":
             self._handle_msg_config(key, value)
         elif key["keytype"] == "SCHEMA":


### PR DESCRIPTION
# About this change - What it does

Take the lock once per batch when processing the messages incoming from the schemas topic.

# Why this way

Taking and releasing a lock in a rather expensive operation. When Karapace is booting up (catching up with the schemas topic) and when it's already up and running (has processed all the messages in the schemas topic), a new batch of messages should be processed as fast as possible in order to have fresh data. This change makes this faster.

The kind of downside is that the REST API methods acquiring the same lock will respond slower if this background thread happens to have the lock at the same time. There's a benefit also here - since there's a batch of messages coming, Karapace doesn't have the latest data. Thus, it's actually a good thing that the batch is processed before the REST API request gets the data.