### PR TITLE
Karapace integration tests 15 minute timeout for GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       run: python3 -m pytest -s -vvv tests/unit/
 
     - name: Execute integration-tests
-      timeout-minutes: 10
+      timeout-minutes: 15
       run: python3 -m pytest -s -vvv tests/integration/ --log-dir=/tmp/ci-logs --log-file=/tmp/ci-logs/pytest.log
 
     - name: Archive logs


### PR DESCRIPTION
# About this change - What it does
Current integration tests timeouts frequently as tests take ~10 minutes.
