### PR TITLE
Primary node selection prefers ready node

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -309,8 +309,8 @@ class KafkaSchemaReader(Thread):
         raw_msgs = self.consumer.poll(timeout_ms=self.timeout_ms)
         if self.ready is False:
             self.ready = self._is_ready()
-            if self.master_coordinator:
-                self.master_coordinator.ready(self.ready)
+            if self.ready and self.master_coordinator is not None:
+                self.master_coordinator.ready(True)
 
         watch_offsets = False
         if self.master_coordinator is not None:

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -309,6 +309,8 @@ class KafkaSchemaReader(Thread):
         raw_msgs = self.consumer.poll(timeout_ms=self.timeout_ms)
         if self.ready is False:
             self.ready = self._is_ready()
+            if self.master_coordinator:
+                self.master_coordinator.ready(self.ready)
 
         watch_offsets = False
         if self.master_coordinator is not None:

--- a/tests/integration/test_schema_backup_avro_export.py
+++ b/tests/integration/test_schema_backup_avro_export.py
@@ -101,7 +101,15 @@ async def test_export_anonymized_avro_schemas(
     tmp_path: Path,
     registry_cluster: RegistryDescription,
 ) -> None:
-    await insert_data(registry_async_client, "AVRO", AVRO_SUBJECT, AVRO_SCHEMA)
+    tries = 0
+    while tries < 3:
+        try:
+            await insert_data(registry_async_client, "AVRO", AVRO_SUBJECT, AVRO_SCHEMA)
+            break
+        except Exception:  # pylint: disable=broad-except
+            tries += 1
+            continue
+
     await insert_compatibility_level_change(registry_async_client, COMPATIBILITY_SUBJECT, COMPATIBILITY_CHANGE)
     await insert_delete_subject(registry_async_client, AVRO_SUBJECT)
 


### PR DESCRIPTION
# About this change - What it does

The primary node selection prefers node that is ready, has replayed the schemas topic. The selection uses the strategy, i.e. lowest ready or highest ready. Selected node will stay as primary until a new group selection is run and new (or the same) node is selected as primary based on the strategy.

Fallback will be to select primary based on the strategy from the full set of nodes.

# Why this way

In case when there is restarts in the Karapace cluster the writing is enabled faster when first ready node is selected as primary.
When a Karapace node is not ready it has been possible to select unready node as a primary. If the schemas topic to replay is large it may take significant amount of time for Karapace to become ready.
