### PR TITLE
Ignore library logged errors in Sentry

### DIFF
--- a/karapace/sentry/sentry_client.py
+++ b/karapace/sentry/sentry_client.py
@@ -32,6 +32,14 @@ class SentryClient(SentryClientAPI):
         # the Sentry client does not send any events.
         sentry_sdk.init(**sentry_config)
 
+        # Don't send library logged errors to Sentry as there is also proper return value or raised exception to calling code
+        from sentry_sdk.integrations.logging import ignore_logger
+
+        ignore_logger("aiokafka")
+        ignore_logger("aiokafka.*")
+        ignore_logger("kafka")
+        ignore_logger("kafka.*")
+
     def unexpected_exception(self, error: Exception, where: str, tags: Optional[Dict] = None) -> None:
         scope_args = {"tags": {"where": where, **(tags or {})}}
         sentry_sdk.Hub.current.capture_exception(error=error, scope=None, **scope_args)


### PR DESCRIPTION
# About this change - What it does

Ignore library logged errors in Sentry

# Why this way

Ignore sending library logged errors to Sentry.  Errors sent currently are such as authentication failures or connection errors, which return or raise also to the calling code, which should handle those per case.
