### PR TITLE
chore: Update to get flake8 from Github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         args:
           - --line-length=125
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Changes flake8 pre-commit hook to use Github repository instead of Gitlab, [which has been deleted](https://github.com/PyCQA/flake8/issues/1737).

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Installing from Gitlab was failing, [PyPI package](https://pypi.org/project/flake8/) points to Github repository and not Gitlab, according to [this pinned issue](https://github.com/PyCQA/flake8/issues/1737), the Gitlab repository has recently been deleted after being obsolete for many years.
