### PR TITLE
chore: bump mypy, move config from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,16 +25,11 @@ repos:
         files: \.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.991
     hooks:
       - id: mypy
         name: Mypy Karapace
         pass_filenames: false
-        args:
-          - "--show-error-codes"
-          - "--ignore-missing-imports"
-          - "--package"
-          - "karapace"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,8 @@
 [mypy]
 python_version = 3.7
+packages = karapace
+show_error_codes = True
+pretty = True
 warn_redundant_casts = True
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION


<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Bumps mypy to latest version, 0.991.

Config for mypy is moved from the pre-commit hook definition to mypy.ini, and in addition `pretty = True` is set to show more human friendly error messages.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Keep project up-to-date.
