### PR TITLE
website: remove community link from header

### DIFF
--- a/website/source/_templates/header-links.html
+++ b/website/source/_templates/header-links.html
@@ -4,8 +4,6 @@
 <a href="{{ pathto('quickstart') }}" class="text-grey-80 hover:text-grey-80"
   >Documentation</a
 >
-<!-- TODO: Add href here. -->
-<a href="#" class="text-grey-80 hover:text-grey-80">Community</a>
 <a
   class="button btn-primary sm-hidden gap-2 text-sm"
   href="{{ pathto('install') }}"


### PR DESCRIPTION
This link is not needed at the moment so we can get rid of it.