### PR TITLE
Include latest fix of aiven patched kafka-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ watchfiles==0.15.0
 # - The contents of the file change, which invalidates the existing docker
 #   images and forces a new image generation.
 #
-git+https://github.com/aiven/kafka-python.git@b9f2f78377d56392f61cba8856dc6c02ae841b79
+git+https://github.com/aiven/kafka-python.git@1b95333c9628152066fb8b1092de9da0433401fd
 
 # Indirect dependencies
 aiosignal==1.2.0 # aiohttp


### PR DESCRIPTION
# About this change - What it does

Include latest aiven patched kafka-python fixes in karapace depedency.

# Why this way

Karapace uses patched kafka-python due upstream no maintained. A long term plan is to get rid of kafka-python, but for now use most recent patched version of Aiven fork of kafka-python.
