### PR TITLE
Add tarfile member sanitization to extractall()

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -91,6 +91,7 @@ def fixture_kafka_description(request: SubRequest) -> KafkaDescription:
 
     return KafkaDescription(
         version=kafka_version,
+        kafka_tgz=RUNTIME_DIR / kafka_tgz,
         install_dir=kafka_dir,
         download_url=kafka_url,
         protocol_version="2.7",

--- a/tests/integration/utils/config.py
+++ b/tests/integration/utils/config.py
@@ -24,6 +24,7 @@ class ZKConfig:
 @dataclass(frozen=True)
 class KafkaDescription:
     version: str
+    kafka_tgz: str
     install_dir: Path
     download_url: str
     protocol_version: str


### PR DESCRIPTION
# About this change - What it does

Add tarfile member sanitization to extractall()

This replaces #510 with the formatting following setup & rules.

Closes #510

# Why this way

Fix test code to use CVE-2007-4559 safe tarfile.extractall.
