### PR TITLE
Set token for arduino/setup-protoc for rate limits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
          version: '3.13.0'
+         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     # needed by both unit and integation tests
     - name: Generate version.py


### PR DESCRIPTION
# About this change - What it does

Set token for arduino/setup-protoc for rate limits

# Why this way

This is a way instructed at https://github.com/arduino/setup-protoc to overcome GitHub rate limits.