### PR TITLE
fixed "dictionary changed size during iteration"

### DIFF
--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -84,7 +84,7 @@ class KarapaceSchemaRegistry:
     def subjects_list(self, include_deleted: bool = False) -> List[Subject]:
         return [
             key
-            for key, val in self.schema_reader.subjects.items()
+            for key in list(self.schema_reader.subjects.keys())
             if self.schema_reader.get_schemas(key, include_deleted=include_deleted)
         ]
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
This change is needed to avoid the race condition on [this line](https://github.com/aiven/karapace/blob/main/karapace/schema_registry.py#L87) under heavy load.
<!-- Provide a small sentence that summarizes the change. -->

# Why this way
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
The dict keys() method return a views on the data that could change during the execution, it is needed a copy of them to avoid "RuntimeError: dictionary changed size during iteration". We can get read of the values as they are not needed in this method.