### PR TITLE
Fix `allocate_port()` on Mac

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,6 @@ pytest==6.2.5
 pytest-xdist[psutil]==2.2.1
 pytest-timeout==1.4.2
 pdbpp==0.10.2
-psutil==5.9.0
 requests==2.27.1
 
 # workflow

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,7 +24,7 @@ from tests.integration.utils.kafka_server import (
     maybe_download_kafka,
     wait_for_kafka,
 )
-from tests.integration.utils.network import PortRangeInclusive
+from tests.integration.utils.network import inet_port
 from tests.integration.utils.process import stop_process, wait_for_port_subprocess
 from tests.integration.utils.synchronization import lock_path_for
 from tests.integration.utils.zookeeper import configure_and_start_zk
@@ -38,7 +38,6 @@ import os
 import pathlib
 import pytest
 import re
-import string
 import time
 
 REPOSITORY_DIR = pathlib.Path(__file__).parent.parent.parent.absolute()
@@ -56,29 +55,6 @@ def _clear_test_name(name: str) -> str:
     # https://github.com/pytest-dev/pytest/blob/238b25ffa9d4acbc7072ac3dd6d8240765643aed/src/_pytest/tmpdir.py#L189-L194
     # The purpose is to return a similar name to make finding matching logs easier
     return re.sub(r"[\W]", "_", name)[:30]
-
-
-@pytest.fixture(scope="session", name="port_range")
-def fixture_port_range() -> PortRangeInclusive:
-    """Container used by other fixtures to register used ports"""
-    # To find a good port range use the following:
-    #
-    #   curl --silent 'https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt' | \
-    #       egrep -i -e '^\s*[0-9]+-[0-9]+\s*unassigned' | \
-    #       awk '{print $1}'
-    #
-    start = 48700
-    end = 49000
-
-    # Split the ports among the workers to prevent port reuse
-    worker_name = os.environ.get("PYTEST_XDIST_WORKER", "0")
-    worker_id = int(worker_name.lstrip(string.ascii_letters))
-    worker_count = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "1"))
-    total_ports = end - start
-    ports_per_worker = total_ports // worker_count
-    start_worker = (ports_per_worker * worker_id) + start
-    end_worker = start_worker + ports_per_worker - 1
-    return PortRangeInclusive(start_worker, end_worker)
 
 
 @pytest.fixture(scope="session", name="kafka_description")
@@ -104,7 +80,6 @@ def fixture_kafka_server(
     session_datadir: Path,
     session_logdir: Path,
     kafka_description: KafkaDescription,
-    port_range: PortRangeInclusive,
 ) -> Iterator[KafkaServers]:
     bootstrap_servers = request.config.getoption("kafka_bootstrap_servers")
 
@@ -123,9 +98,9 @@ def fixture_kafka_server(
     lock_file = lock_path_for(transfer_file)
 
     with ExitStack() as stack:
-        zk_client_port = stack.enter_context(port_range.allocate_port())
-        zk_admin_port = stack.enter_context(port_range.allocate_port())
-        kafka_plaintext_port = stack.enter_context(port_range.allocate_port())
+        zk_client_port = inet_port()
+        zk_admin_port = inet_port()
+        kafka_plaintext_port = inet_port()
 
         with FileLock(str(lock_file)):
             if transfer_file.exists():
@@ -356,7 +331,6 @@ async def fixture_registry_async_pair(
     loop: asyncio.AbstractEventLoop,  # pylint: disable=unused-argument
     session_logdir: Path,
     kafka_servers: KafkaServers,
-    port_range: PortRangeInclusive,
 ) -> AsyncIterator[List[str]]:
     """Starts a cluster of two Schema Registry servers and returns their URL endpoints."""
 
@@ -366,7 +340,6 @@ async def fixture_registry_async_pair(
     async with start_schema_registry_cluster(
         config_templates=[config1, config2],
         data_dir=session_logdir / _clear_test_name(request.node.name),
-        port_range=port_range,
     ) as endpoints:
         yield [server.endpoint.to_url() for server in endpoints]
 
@@ -377,7 +350,6 @@ async def fixture_registry_cluster(
     loop: asyncio.AbstractEventLoop,  # pylint: disable=unused-argument
     session_logdir: Path,
     kafka_servers: KafkaServers,
-    port_range: PortRangeInclusive,
 ) -> AsyncIterator[RegistryDescription]:
     # Do not start a registry when the user provided an external service. Doing
     # so would cause this node to join the existing group and participate in
@@ -394,7 +366,6 @@ async def fixture_registry_cluster(
     async with start_schema_registry_cluster(
         config_templates=[config],
         data_dir=session_logdir / _clear_test_name(request.node.name),
-        port_range=port_range,
     ) as servers:
         yield servers[0]
 
@@ -457,7 +428,6 @@ async def fixture_registry_https_endpoint(
     kafka_servers: KafkaServers,
     server_cert: str,
     server_key: str,
-    port_range: PortRangeInclusive,
 ) -> AsyncIterator[str]:
     # Do not start a registry when the user provided an external service. Doing
     # so would cause this node to join the existing group and participate in
@@ -476,7 +446,6 @@ async def fixture_registry_https_endpoint(
     async with start_schema_registry_cluster(
         config_templates=[config],
         data_dir=session_logdir / _clear_test_name(request.node.name),
-        port_range=port_range,
     ) as servers:
         yield servers[0].endpoint.to_url()
 
@@ -516,7 +485,6 @@ async def fixture_registry_http_auth_endpoint(
     loop: asyncio.AbstractEventLoop,  # pylint: disable=unused-argument
     session_logdir: Path,
     kafka_servers: KafkaServers,
-    port_range: PortRangeInclusive,
 ) -> AsyncIterator[str]:
     # Do not start a registry when the user provided an external service. Doing
     # so would cause this node to join the existing group and participate in
@@ -534,7 +502,6 @@ async def fixture_registry_http_auth_endpoint(
     async with start_schema_registry_cluster(
         config_templates=[config],
         data_dir=session_logdir / _clear_test_name(request.node.name),
-        port_range=port_range,
     ) as servers:
         yield servers[0].endpoint.to_url()
 
@@ -572,7 +539,6 @@ async def fixture_registry_async_auth_pair(
     loop: asyncio.AbstractEventLoop,  # pylint: disable=unused-argument
     session_logdir: Path,
     kafka_servers: KafkaServers,
-    port_range: PortRangeInclusive,
 ) -> AsyncIterator[List[str]]:
     """Starts a cluster of two Schema Registry servers with authentication enabled and returns their URL endpoints."""
 
@@ -588,6 +554,5 @@ async def fixture_registry_async_auth_pair(
     async with start_schema_registry_cluster(
         config_templates=[config1, config2],
         data_dir=session_logdir / _clear_test_name(request.node.name),
-        port_range=port_range,
     ) as endpoints:
         yield [server.endpoint.to_url() for server in endpoints]

--- a/tests/integration/test_karapace.py
+++ b/tests/integration/test_karapace.py
@@ -2,17 +2,14 @@ from contextlib import ExitStack
 from karapace.config import set_config_defaults
 from pathlib import Path
 from subprocess import Popen
-from tests.integration.utils.network import PortRangeInclusive
+from tests.integration.utils.network import inet_port
 from tests.integration.utils.process import stop_process
 
 import json
 import socket
 
 
-def test_regression_server_must_exit_on_exception(
-    port_range: PortRangeInclusive,
-    tmp_path: Path,
-) -> None:
+def test_regression_server_must_exit_on_exception(tmp_path: Path) -> None:
     """Regression test for Karapace properly exiting.
 
     Karapace was not closing all its background threads, so when an exception
@@ -20,7 +17,7 @@ def test_regression_server_must_exit_on_exception(
     be stopped but the threads would keep the server running.
     """
     with ExitStack() as stack:
-        port = stack.enter_context(port_range.allocate_port())
+        port = inet_port()
         sock = stack.enter_context(socket.socket())
 
         config = set_config_defaults(

--- a/tests/integration/utils/cluster.py
+++ b/tests/integration/utils/cluster.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from karapace.config import Config, set_config_defaults, write_config
 from pathlib import Path
 from subprocess import Popen
-from tests.integration.utils.network import PortRangeInclusive
+from tests.integration.utils.network import inet_port
 from tests.integration.utils.process import stop_process, wait_for_port_subprocess
 from tests.utils import new_random_name
 from typing import AsyncIterator, List
@@ -29,7 +29,6 @@ class RegistryDescription:
 async def start_schema_registry_cluster(
     config_templates: List[Config],
     data_dir: Path,
-    port_range: PortRangeInclusive,
 ) -> AsyncIterator[List[RegistryDescription]]:
     """Start a cluster of schema registries, one process per `config_templates`."""
     for template in config_templates:
@@ -64,7 +63,7 @@ async def start_schema_registry_cluster(
             )
             actual_group_id = config.setdefault("group_id", group_id)
 
-            port = config.setdefault("port", stack.enter_context(port_range.allocate_port()))
+            port = config.setdefault("port", inet_port())
             assert isinstance(port, int), "Port must be an integer"
 
             group_dir = data_dir / str(actual_group_id)

--- a/tests/integration/utils/network.py
+++ b/tests/integration/utils/network.py
@@ -2,82 +2,18 @@
 Copyright (c) 2022 Aiven Ltd
 See LICENSE for details
 """
-from contextlib import contextmanager
-
-import psutil
 import socket
 
 
-def is_time_wait(port: int) -> bool:
-    """True if the port is still on TIME_WAIT state."""
-    return any(conn.laddr.port == port for conn in psutil.net_connections(kind="inet"))
+def inet_port() -> int:
+    """Returns a free and usable IPv4 port.
 
-
-class PortRangeInclusive:
-    PRIVILEGE_END = 2**10
-    MAX_PORTS = 2**16 - 1
-
-    def __init__(
-        self,
-        start: int,
-        end: int,
-    ) -> None:
-        # Make sure the range is valid and that we don't need to be root
-        assert end > start, "there must be at least one port available"
-        assert end <= self.MAX_PORTS, f"end must be lower than {self.MAX_PORTS}"
-        assert start > self.PRIVILEGE_END, "start must not be a privileged port"
-
-        self.start = start
-        self.end = end
-        self._maybe_available = list(range(start, end + 1))
-
-    def next_range(self, number_of_ports: int) -> "PortRangeInclusive":
-        next_start = self.end
-        next_end = next_start + number_of_ports
-        return PortRangeInclusive(next_start, next_end)
-
-    @contextmanager
-    def allocate_port(self) -> int:
-        """Find a random port in the range `PortRangeInclusive`.
-
-        Note:
-            This function is *not* aware of the ports currently open in the system,
-            the blacklist only prevents two services of the same type to randomly
-            get the same ports for *a single test run*.
-
-            Because of that, the port range should be chosen such that there is no
-            system service in the range. Also note that running two sessions of the
-            tests with the same range is not supported and will lead to flakiness.
-        """
-        if len(self._maybe_available) == 0:
-            raise RuntimeError(f"No free ports available. start: {self.start} end: {self.end}")
-
-        filtered_ports = ((pos, port) for pos, port in enumerate(self._maybe_available) if not is_time_wait(port))
-
-        try:
-            pos, port = next(filtered_ports)
-        except StopIteration as e:
-            raise RuntimeError(
-                f"No free ports available. start: {self.start} end: {self.end} time_wait: {self._maybe_available}"
-            ) from e
-
-        self._maybe_available.pop(pos)
-        yield port
-
-        # Append the port at the end, this is a hack to give extra time for a TIME_WAIT socket to
-        # close, but it is not sufficient.
-        self._maybe_available.append(port)
-
-
-def port_is_listening(hostname: str, port: int, ipv6: bool) -> bool:
-    if ipv6:
-        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM, 0)
-    else:
-        s = socket.socket()
-    s.settimeout(0.5)
+    :raises OSError: if no free port can be found.
+    """
+    sock = socket.socket()
+    sock.settimeout(0.1)
     try:
-        s.connect((hostname, port))
-        s.close()
-        return True
-    except socket.error:
-        return False
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()


### PR DESCRIPTION
The `PortRangeInclusive.allocate_port()` function uses `psutil` under the hood to find out if a port is allocatable. This leads to an `AccessDenied` error on Mac. Effectively making it impossible to run any of the integration tests.

This patch changes the implementation to not rely on `psutil` at all, it also removes it from the dependencies since this is the only usage. Instead, we simply try to bind to a port and see if it is free, while keeping track of the ports we already predestined for binding by one of our own components.

This does not fix any possible race conditions that might arise from trying to find a free port on a system where other processes are running that might bind to ports. There is no way to achieve this since any free port can be bound by any process. The only way to achieve this would be if the software in question itself has direct support for finding a suitable port. It would be possible to add this functionality to Karapace (e.g., if port is set to `-1` automatically find a suitable one). However, I did not go in that direction, as it would require extensive changes to various parts. The patch is only meant to allow integration test execution on Mac, without any visible API changes.

A detail I think worth mentioning that might not be clear from the patch itself is that it removes the `maybe_available` collection in favor of a `bound` collection. The `maybe_available` collection is created from the given `start` and `end` parameters, that range might be big (up to 64,511 integers to be precise) and consume an unreasonable amount of memory. The `bound` approach does the opposite of the `maybe_available` and keeps track of those ports that were identified as being free, hence, the collection is small throughout the entire execution time.

Last, but not least, the `port_is_listening()` was inline as it had only a single usage and the `ipv6` flag was removed as it was unused. IPv6 support would require a more global approach for enabling if needed.