### PR TITLE
Fix `make copyright`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ clean:
 karapace/version.py: version.py
 	$(PYTHON) $^ $@
 
+# Lists the Python files that do not have an Aiven copyright. Exits with a
+# non-zero exit code if any are found.
 .PHONY: copyright
 copyright:
-	grep -EL "Copyright \(c\) 20.* Aiven" $(shell git ls-files "*.py" | grep -v __init__.py)
+	! git grep --untracked -ELm1 'Copyright \(c\) 20[0-9]{2} Aiven' -- '*.py' ':!*__init__.py'

--- a/karapace/anonymize_schemas/anonymize_avro.py
+++ b/karapace/anonymize_schemas/anonymize_avro.py
@@ -1,7 +1,7 @@
 """
 karapace - anonymize avro
 
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from typing import Any, Dict, List, Union

--- a/karapace/auth.py
+++ b/karapace/auth.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from base64 import b64encode
 from dataclasses import dataclass, field
 from enum import Enum, unique

--- a/karapace/client.py
+++ b/karapace/client.py
@@ -1,7 +1,7 @@
 """
 karapace - utils
 
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from aiohttp import BasicAuth, ClientSession

--- a/karapace/compatibility/jsonschema/checks.py
+++ b/karapace/compatibility/jsonschema/checks.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from avro.compatibility import merge, SchemaCompatibilityResult, SchemaCompatibilityType, SchemaIncompatibilityType
 from dataclasses import dataclass
 from itertools import product

--- a/karapace/compatibility/jsonschema/types.py
+++ b/karapace/compatibility/jsonschema/types.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from dataclasses import dataclass
 from enum import Enum, unique
 from typing import Callable, Generic, TypeVar

--- a/karapace/compatibility/jsonschema/utils.py
+++ b/karapace/compatibility/jsonschema/utils.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from copy import copy
 from jsonschema import Draft7Validator
 from karapace.compatibility.jsonschema.types import BooleanSchema, Instance, Keyword, Subschema

--- a/karapace/compatibility/protobuf/checks.py
+++ b/karapace/compatibility/protobuf/checks.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from avro.compatibility import SchemaCompatibilityResult, SchemaCompatibilityType
 from karapace.protobuf.compare_result import CompareResult
 from karapace.protobuf.schema import ProtobufSchema

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -1,7 +1,7 @@
 """
 karapace - configuration validation
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from aiohttp.web_log import AccessLogger

--- a/karapace/constants.py
+++ b/karapace/constants.py
@@ -1,7 +1,7 @@
 """
 karapace - constants
 
-Copyright (c) 2020 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 

--- a/karapace/errors.py
+++ b/karapace/errors.py
@@ -1,3 +1,9 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+
 class VersionNotFoundException(Exception):
     pass
 

--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from kafka import KafkaAdminClient
 from kafka.admin import ConfigResource, ConfigResourceType, NewTopic
 from kafka.errors import Cancelled, for_code, UnrecognizedBrokerVersion

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from aiokafka import AIOKafkaConsumer
 from asyncio import Lock
 from collections import defaultdict, namedtuple

--- a/karapace/kafka_rest_apis/error_codes.py
+++ b/karapace/kafka_rest_apis/error_codes.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from enum import Enum
 from http import HTTPStatus
 

--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -1,7 +1,7 @@
 """
 karapace - main
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 

--- a/karapace/karapace_all.py
+++ b/karapace/karapace_all.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from aiohttp.web_log import AccessLogger
 from contextlib import closing
 from karapace import version as karapace_version

--- a/karapace/key_format.py
+++ b/karapace/key_format.py
@@ -1,6 +1,7 @@
 """
 karapace - Key correction
-Copyright (c) 2022 Aiven Ltd
+
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 

--- a/karapace/master_coordinator.py
+++ b/karapace/master_coordinator.py
@@ -1,7 +1,7 @@
 """
 karapace - master coordinator
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from kafka import KafkaConsumer

--- a/karapace/protobuf/compare_result.py
+++ b/karapace/protobuf/compare_result.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from dataclasses import dataclass, field
 from enum import auto, Enum
 

--- a/karapace/protobuf/compare_type_storage.py
+++ b/karapace/protobuf/compare_type_storage.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from dataclasses import dataclass
 from karapace.protobuf.compare_result import CompareResult
 from karapace.protobuf.exception import IllegalArgumentException

--- a/karapace/protobuf/encoding_variants.py
+++ b/karapace/protobuf/encoding_variants.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Workaround to encode/decode indexes in protobuf messages
 # Based on https://developers.google.com/protocol-buffers/docs/encoding#varints
 

--- a/karapace/protobuf/enum_constant_element.py
+++ b/karapace/protobuf/enum_constant_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/EnumConstantElement.kt
 from dataclasses import dataclass, field

--- a/karapace/protobuf/enum_element.py
+++ b/karapace/protobuf/enum_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/EnumElement.kt
 from itertools import chain

--- a/karapace/protobuf/exception.py
+++ b/karapace/protobuf/exception.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 import json
 
 

--- a/karapace/protobuf/extend_element.py
+++ b/karapace/protobuf/extend_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ExtendElement.kt
 from dataclasses import dataclass

--- a/karapace/protobuf/extensions_element.py
+++ b/karapace/protobuf/extensions_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ExtensionsElement.kt
 from dataclasses import dataclass

--- a/karapace/protobuf/field.py
+++ b/karapace/protobuf/field.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
 

--- a/karapace/protobuf/field_element.py
+++ b/karapace/protobuf/field_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/FieldElement.kt
 from karapace.protobuf.compare_result import CompareResult, Modification

--- a/karapace/protobuf/group_element.py
+++ b/karapace/protobuf/group_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/GroupElement.kt
 from dataclasses import dataclass

--- a/karapace/protobuf/io.py
+++ b/karapace/protobuf/io.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from io import BytesIO
 from karapace.protobuf.encoding_variants import read_indexes, write_indexes
 from karapace.protobuf.exception import IllegalArgumentException, ProtobufSchemaResolutionException, ProtobufTypeException

--- a/karapace/protobuf/kotlin_wrapper.py
+++ b/karapace/protobuf/kotlin_wrapper.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from dataclasses import dataclass
 
 import textwrap

--- a/karapace/protobuf/location.py
+++ b/karapace/protobuf/location.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Location.kt
 from typing import Optional

--- a/karapace/protobuf/message_element.py
+++ b/karapace/protobuf/message_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/MessageElement.kt
 # compatibility routine added

--- a/karapace/protobuf/one_of_element.py
+++ b/karapace/protobuf/one_of_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OneOfElement.kt
 from itertools import chain

--- a/karapace/protobuf/option_element.py
+++ b/karapace/protobuf/option_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
 

--- a/karapace/protobuf/option_reader.py
+++ b/karapace/protobuf/option_reader.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
 from dataclasses import dataclass

--- a/karapace/protobuf/proto_file_element.py
+++ b/karapace/protobuf/proto_file_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
 from itertools import chain

--- a/karapace/protobuf/proto_parser.py
+++ b/karapace/protobuf/proto_parser.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
 

--- a/karapace/protobuf/proto_type.py
+++ b/karapace/protobuf/proto_type.py
@@ -1,9 +1,12 @@
-# Ported from square/wire:
-# wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
 """
 Names a protocol buffer message, enumerated type, service, map, or a scalar. This class models a
 fully-qualified name using the protocol buffer package.
+
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
 """
+# Ported from square/wire:
+# wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
 from enum import auto, Enum
 from karapace.protobuf.exception import IllegalArgumentException, IllegalStateException
 from karapace.protobuf.option_element import OptionElement

--- a/karapace/protobuf/protobuf_to_dict.py
+++ b/karapace/protobuf/protobuf_to_dict.py
@@ -3,6 +3,9 @@ This module provide a small Python library for creating dicts from protocol buff
 Module based on code :
 https://github.com/wearefair/protobuf-to-dict
 LICENSE: https://github.com/wearefair/protobuf-to-dict/blob/master/LICENSE
+
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
 """
 from dateutil.parser import parse as date_parser
 from google.protobuf.descriptor import FieldDescriptor

--- a/karapace/protobuf/reserved_element.py
+++ b/karapace/protobuf/reserved_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ReservedElement.kt
 from dataclasses import dataclass

--- a/karapace/protobuf/rpc_element.py
+++ b/karapace/protobuf/rpc_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/RpcElement.kt
 

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Schema.kt
 # Ported partially for required functionality.

--- a/karapace/protobuf/service_element.py
+++ b/karapace/protobuf/service_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ServiceElement.kt
 from dataclasses import dataclass

--- a/karapace/protobuf/syntax.py
+++ b/karapace/protobuf/syntax.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/Syntax.kt
 

--- a/karapace/protobuf/syntax_reader.py
+++ b/karapace/protobuf/syntax_reader.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/SyntaxReader.kt
 from karapace.protobuf.exception import IllegalStateException

--- a/karapace/protobuf/type_element.py
+++ b/karapace/protobuf/type_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/TypeElement.kt
 from dataclasses import dataclass

--- a/karapace/protobuf/utils.py
+++ b/karapace/protobuf/utils.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/Util.kt
 from typing import List, TYPE_CHECKING

--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -3,7 +3,7 @@ karapace -
 Custom middleware system on top of `aiohttp` implementing HTTP server and
 client components for use in Aiven's REST applications.
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from accept_types import get_best_match

--- a/karapace/schema_backup.py
+++ b/karapace/schema_backup.py
@@ -1,7 +1,7 @@
 """
 karapace - schema backup
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from enum import Enum

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from avro.errors import SchemaParseException
 from avro.schema import parse as avro_parse, Schema as AvroSchema
 from enum import Enum, unique

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -1,7 +1,7 @@
 """
 karapace - Kafka schema reader
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from contextlib import closing, ExitStack

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from contextlib import AsyncExitStack, closing
 from kafka import errors as kafka_errors, KafkaProducer
 from kafka.producer.future import FutureRecordMetadata

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from avro.errors import SchemaParseException
 from contextlib import AsyncExitStack
 from enum import Enum, unique

--- a/karapace/sentry/sentry_client.py
+++ b/karapace/sentry/sentry_client.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.sentry.sentry_client_api import SentryClientAPI
 from typing import Dict, Optional
 

--- a/karapace/sentry/sentry_client_api.py
+++ b/karapace/sentry/sentry_client_api.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from typing import Dict, Optional
 
 

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from aiohttp import BasicAuth
 from avro.io import BinaryDecoder, BinaryEncoder, DatumReader, DatumWriter
 from google.protobuf.message import DecodeError

--- a/karapace/statsd.py
+++ b/karapace/statsd.py
@@ -5,7 +5,7 @@ Supports telegraf's statsd protocol extension for 'key=value' tags:
 
   https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from contextlib import contextmanager

--- a/karapace/typing.py
+++ b/karapace/typing.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from typing import Any, Dict, Union
 
 JsonData = Any  # Data that will be encoded to or has been parsed from JSON

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -1,7 +1,7 @@
 """
 karapace - utils
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from aiohttp.web_log import AccessLogger

--- a/performance-test/rest-proxy-produce-consume-test.py
+++ b/performance-test/rest-proxy-produce-consume-test.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from kafka.admin import KafkaAdminClient, NewTopic
 from kafka.errors import TopicAlreadyExistsError
 from locust import FastHttpUser, task

--- a/performance-test/schema-registry-schema-post.py
+++ b/performance-test/schema-registry-schema-post.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from locust import FastHttpUser, task
 
 import json

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """
 karapace - setup
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from setuptools import find_packages, setup

--- a/tests/base_testcase.py
+++ b/tests/base_testcase.py
@@ -1,6 +1,7 @@
 """
 karapace - Test base class
-Copyright (c) 2022 Aiven Ltd
+
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from avro.compatibility import SchemaCompatibilityResult
 from pathlib import Path
 from typing import List, Optional

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 """
 karapace - conftest
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from _pytest.fixtures import SubRequest

--- a/tests/integration/schema_registry/test_jsonschema.py
+++ b/tests/integration/schema_registry/test_jsonschema.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from jsonschema import Draft7Validator
 from karapace.client import Client
 from karapace.compatibility import CompatibilityModes

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.client import Client
 from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.serialization import SchemaRegistryClient

--- a/tests/integration/test_client_protobuf.py
+++ b/tests/integration/test_client_protobuf.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.protobuf.kotlin_wrapper import trim_margin
 from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.serialization import SchemaRegistryClient

--- a/tests/integration/test_karapace.py
+++ b/tests/integration/test_karapace.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from contextlib import ExitStack
 from karapace.config import set_config_defaults
 from pathlib import Path

--- a/tests/integration/test_master_coordinator.py
+++ b/tests/integration/test_master_coordinator.py
@@ -1,7 +1,7 @@
 """
 karapace - master coordination test
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from contextlib import closing

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from kafka.errors import UnknownTopicOrPartitionError
 from pytest import raises
 from tests.utils import (

--- a/tests/integration/test_rest_consumer.py
+++ b/tests/integration/test_rest_consumer.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from tests.utils import (
     consumer_valid_payload,
     new_consumer,

--- a/tests/integration/test_rest_consumer_protobuf.py
+++ b/tests/integration/test_rest_consumer_protobuf.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from tests.utils import (
     new_consumer,
     new_topic,

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1,7 +1,7 @@
 """
 karapace - schema tests
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from http import HTTPStatus

--- a/tests/integration/test_schema_backup.py
+++ b/tests/integration/test_schema_backup.py
@@ -1,7 +1,7 @@
 """
 karapace - test schema backup
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from kafka import KafkaConsumer

--- a/tests/integration/test_schema_backup_avro_export.py
+++ b/tests/integration/test_schema_backup_avro_export.py
@@ -1,7 +1,7 @@
 """
 karapace - test schema backup
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from karapace.client import Client

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -1,7 +1,7 @@
 """
 karapace - schema tests
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from karapace.client import Client

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from contextlib import closing
 from dataclasses import dataclass
 from kafka import KafkaAdminClient, KafkaProducer

--- a/tests/integration/test_schema_registry_auth.py
+++ b/tests/integration/test_schema_registry_auth.py
@@ -1,7 +1,7 @@
 """
 karapace - schema registry authentication and authorization tests
 
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from karapace.client import Client

--- a/tests/integration/utils/cluster.py
+++ b/tests/integration/utils/cluster.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from contextlib import asynccontextmanager, ExitStack
 from dataclasses import dataclass
 from karapace.config import Config, set_config_defaults, write_config

--- a/tests/integration/utils/config.py
+++ b/tests/integration/utils/config.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from dataclasses import dataclass

--- a/tests/integration/utils/kafka_server.py
+++ b/tests/integration/utils/kafka_server.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from dataclasses import dataclass

--- a/tests/integration/utils/network.py
+++ b/tests/integration/utils/network.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from contextlib import contextmanager

--- a/tests/integration/utils/process.py
+++ b/tests/integration/utils/process.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from karapace.utils import Expiration

--- a/tests/integration/utils/synchronization.py
+++ b/tests/integration/utils/synchronization.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from pathlib import Path

--- a/tests/integration/utils/zookeeper.py
+++ b/tests/integration/utils/zookeeper.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from pathlib import Path

--- a/tests/schemas/json_schemas.py
+++ b/tests/schemas/json_schemas.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.schema_models import parse_jsonschema_definition
 
 # boolean schemas

--- a/tests/schemas/protobuf.py
+++ b/tests/schemas/protobuf.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 schema_protobuf_plain = """syntax = "proto3";
 package com.codingharbour.protobuf;
 

--- a/tests/unit/anonymize_schemas/test_anonymize_avro.py
+++ b/tests/unit/anonymize_schemas/test_anonymize_avro.py
@@ -1,7 +1,7 @@
 """
 karapace - test anonymize avro
 
-Copyright (c) 2022 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from karapace.anonymize_schemas.anonymize_avro import anonymize

--- a/tests/unit/compatibility/jsonschema/test_jsonschema_compatibility.py
+++ b/tests/unit/compatibility/jsonschema/test_jsonschema_compatibility.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from avro.compatibility import SchemaCompatibilityResult, SchemaCompatibilityType
 from jsonschema import Draft7Validator
 from karapace.compatibility.jsonschema.checks import compatibility

--- a/tests/unit/compatibility/test_compatibility.py
+++ b/tests/unit/compatibility/test_compatibility.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from avro.compatibility import SchemaCompatibilityType
 from karapace.compatibility import check_compatibility, CompatibilityModes
 from karapace.schema_models import SchemaType, ValidatedTypedSchema

--- a/tests/unit/protobuf/test_compare_elements.py
+++ b/tests/unit/protobuf/test_compare_elements.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.protobuf.compare_result import CompareResult, Modification
 from karapace.protobuf.compare_type_storage import CompareTypes
 from karapace.protobuf.field import Field

--- a/tests/unit/protobuf/test_enum_element.py
+++ b/tests/unit/protobuf/test_enum_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/EnumElementTest.kt
 

--- a/tests/unit/protobuf/test_extend_element.py
+++ b/tests/unit/protobuf/test_extend_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ExtendElementTest.kt
 

--- a/tests/unit/protobuf/test_extensions_element.py
+++ b/tests/unit/protobuf/test_extensions_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ExtensionsElementTest.kt
 

--- a/tests/unit/protobuf/test_field_element.py
+++ b/tests/unit/protobuf/test_field_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/FieldElementTest.kt
 

--- a/tests/unit/protobuf/test_message_element.py
+++ b/tests/unit/protobuf/test_message_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
 

--- a/tests/unit/protobuf/test_option_element.py
+++ b/tests/unit/protobuf/test_option_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/OptionElementTest.kt
 

--- a/tests/unit/protobuf/test_proto_file_element.py
+++ b/tests/unit/protobuf/test_proto_file_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
 from karapace.protobuf.extend_element import ExtendElement

--- a/tests/unit/protobuf/test_proto_parser.py
+++ b/tests/unit/protobuf/test_proto_parser.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
 

--- a/tests/unit/protobuf/test_protobuf_compatibility.py
+++ b/tests/unit/protobuf/test_protobuf_compatibility.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.protobuf.compare_result import CompareResult
 from karapace.protobuf.kotlin_wrapper import trim_margin
 from karapace.protobuf.location import Location

--- a/tests/unit/protobuf/test_protobuf_schema.py
+++ b/tests/unit/protobuf/test_protobuf_schema.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.protobuf.compare_result import CompareResult
 from karapace.protobuf.kotlin_wrapper import trim_margin
 from karapace.protobuf.location import Location

--- a/tests/unit/protobuf/test_protoc.py
+++ b/tests/unit/protobuf/test_protoc.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace import config
 from karapace.protobuf.io import calculate_class_name
 from karapace.protobuf.kotlin_wrapper import trim_margin

--- a/tests/unit/protobuf/test_service_element.py
+++ b/tests/unit/protobuf/test_service_element.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 # Ported from square/wire:
 # wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ServiceElementTest.kt
 

--- a/tests/unit/test_avro_compatibility.py
+++ b/tests/unit/test_avro_compatibility.py
@@ -1,6 +1,9 @@
 """
-    These are duplicates of other test_schema.py tests, but do not make use of the registry client fixture
-    and are here for debugging and speed, and as an initial sanity check
+These are duplicates of other test_schema.py tests, but do not make use of the registry client fixture and are here for
+debugging and speed, and as an initial sanity check
+
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
 """
 from avro.compatibility import ReaderWriterCompatibilityChecker, SchemaCompatibilityResult, SchemaCompatibilityType
 from avro.name import Names

--- a/tests/unit/test_key_format.py
+++ b/tests/unit/test_key_format.py
@@ -1,6 +1,7 @@
 """
 karapace - Test key format
-Copyright (c) 2022 Aiven Ltd
+
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 

--- a/tests/unit/test_protobuf_serialization.py
+++ b/tests/unit/test_protobuf_serialization.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.config import read_config
 from karapace.protobuf.kotlin_wrapper import trim_margin
 from karapace.schema_models import SchemaType, ValidatedTypedSchema

--- a/tests/unit/test_rapu.py
+++ b/tests/unit/test_rapu.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.rapu import HTTPRequest, REST_ACCEPT_RE, REST_CONTENT_TYPE_RE
 
 

--- a/tests/unit/test_rest_auth.py
+++ b/tests/unit/test_rest_auth.py
@@ -1,4 +1,8 @@
 # pylint: disable=protected-access
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.config import set_config_defaults
 from karapace.kafka_rest_apis import KafkaRest
 from unittest.mock import call, Mock

--- a/tests/unit/test_schema_reader.py
+++ b/tests/unit/test_schema_reader.py
@@ -1,6 +1,7 @@
 """
 karapace - Test schema reader
-Copyright (c) 2022 Aiven Ltd
+
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 

--- a/tests/unit/test_schema_registry_api.py
+++ b/tests/unit/test_schema_registry_api.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from aiohttp.test_utils import TestClient, TestServer
 from karapace.config import DEFAULTS
 from karapace.rapu import HTTPResponse

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from karapace.config import DEFAULTS, read_config
 from karapace.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.serialization import (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,7 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
 from aiohttp.client_exceptions import ClientOSError, ServerDisconnectedError
 from kafka.errors import TopicAlreadyExistsError
 from karapace.client import Client

--- a/version.py
+++ b/version.py
@@ -1,7 +1,7 @@
 """
 karapace - version
 
-Copyright (c) 2019 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 import importlib.util

--- a/website/source/conf.py
+++ b/website/source/conf.py
@@ -1,7 +1,7 @@
 """
 karapace - website configuration
 
-Copyright (c) 2020 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 


### PR DESCRIPTION
The `make copyright` goal always lists all Python files that have a copyright notice, and since we have more than one file with a copyright notice it always exits with success. This does not seem right, given that there is a GHA job that is supposed to check that all files (except `__init__.py`) have a copyright notice. This changes the code used in the goal to a single git invocation that does exactly that. The `!` in front inverts the exit code. Hence, if a Python file other than `__init__.py` is found without a copyright notice it exists with a non-zero exit code and lists the paths that miss the copyright notice relative to the repository root.