### PR TITLE
chore: Simplify pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,6 @@
 ---
 minimum_pre_commit_version: 2.9.2
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
-        files: \.py$
-        args:
-          - --line-length=125
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        files: \.py$
-        args:
-          - --config=.flake8
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
-        files: \.py$
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
-    hooks:
-      - id: mypy
-        name: Mypy Karapace
-        pass_filenames: false
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
@@ -39,6 +9,30 @@ repos:
       - id: end-of-file-fixer
         exclude: ^vendor/|^tests/.*/fixtures/.*|^tests/integration/test_data/.*
       - id: debug-statements
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+      - id: mypy
+        name: Mypy Karapace
+        pass_filenames: false
+
 
   # https://pre-commit.com/#repository-local-hooks
   - repo: local

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ language of the WEB.
 Features
 ========
 
-* Drop in replacement both on pre-existing Schema Registry / Kafka Rest Proxy client and
+* Drop-in replacement both on pre-existing Schema Registry / Kafka Rest Proxy client and
   server-sides
 * Moderate memory consumption
 * Asynchronous architecture based on aiohttp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+target-version = ["py37"]
+line-length = 125

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Database :: Database Engines/Servers",
         "Topic :: Software Development :: Libraries",
     ],


### PR DESCRIPTION
# About this change - What it does

Change execution order of pre-commit hooks. It's a good idea to allow isort to run before black, to let black be authoritative on formatting. The very fast builtin pre-commit checks are moved to top to always execute first.

Some superfluous configuration options are removed, specifically there's no need to point out that Python tools should run on Python files, this is already configured in the hooks themselves.

By default, flake8 uses the .flake8 config file.

Black line-length config is moved from a hard-coded CLI argument to pyproject.toml which is picked up by default, and target-version=37 is added there explicitly.

#### Misc.:

- 🎉 Advertise support for Python 3.11 with a setup.py classifier.
- 🕵️ Fix a typo in README.

# Why this way

Simplify and improve project config.