### PR TITLE
chore: Incorporate copyright check in pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,11 +27,3 @@ jobs:
 
       - name: Run all pre-commit hooks
         run: pre-commit run --all-files
-
-  copyright:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
-
-        - name: Enforce copyright headers
-          run: make copyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,18 @@ repos:
         exclude: ^vendor/|^tests/.*/fixtures/.*|^tests/integration/test_data/.*
       - id: debug-statements
 
+  - repo: local
+    hooks:
+      - id: copyright
+        name: copyright
+        language: system
+        types: [python]
+        exclude: ^vendor/
+        pass_filenames: false
+        # Lists the Python files that do not have an Aiven copyright. Exits with a
+        # non-zero exit code if any are found.
+        entry: bash -c "! git grep --untracked -ELm1 'Copyright \(c\) 20[0-9]{2} Aiven' -- '*.py' ':!*__init__.py'"
+
   - repo: https://github.com/asottile/pyupgrade
     rev: "v3.3.1"
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,3 @@ clean:
 
 karapace/version.py: version.py
 	$(PYTHON) $^ $@
-
-# Lists the Python files that do not have an Aiven copyright. Exits with a
-# non-zero exit code if any are found.
-.PHONY: copyright
-copyright:
-	! git grep --untracked -ELm1 'Copyright \(c\) 20[0-9]{2} Aiven' -- '*.py' ':!*__init__.py'


### PR DESCRIPTION
# About this change - What it does

Delete the copyright make target and replace it with a pre-commit hook. Remove the Github Action job, as this will now run as part of `lint.yml::lint`.

# Why this way

Fewer moving parts and shorter feedback cycle. _All_ linting can now be run uniformly with `pre-commit run --all-files`.
