### PR TITLE
chore: Remove max-parallel from test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     steps:


### PR DESCRIPTION
# About this change - What it does

Remove `max-parallel` limitation from test workflow.

# Why this way

The test matrix contains 5 versions, there's really no need to cap parallelism to 4 here. This should make the test suite pass in about half the time as all the jobs can run in parallel.
