### PR TITLE
chore: Disable test suite re-runs on ready for review

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Test Suite
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - master


### PR DESCRIPTION
# About this change - What it does

Disable triggering of test suite re-run when marked ready for review.

# Why this way

Making the test suite re-run when marked ready for review incentivizes against using draft pull request and only marking them ready once the test suite is passing.
