### PR TITLE
fix: Replace references to old default branch name

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '42 20 * * 6'
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,7 +5,6 @@ on:
     # Publish main branch as `develop` image
     branches:
       - main
-      - master
 
     # Publish tags as versioned release and `latest` image
     tags:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/website/source/install.rst
+++ b/website/source/install.rst
@@ -30,7 +30,7 @@ override the ``bootstrap_uri`` config value, one would use the environment varia
 ``KARAPACE_BOOTSTRAP_URI``. Here_ you can find an example configuration file to give you an idea
 what you need to change.
 
-.. _`Here`: https://github.com/aiven/karapace/blob/master/karapace.config.json
+.. _`Here`: https://github.com/aiven/karapace/blob/main/karapace.config.json
 
 Source install
 --------------


### PR DESCRIPTION
### About this change - What it does

Fix broken references to previous name of default branch.

### Why this way

Linting isn't currently running on main. CodeQL analysis looks like it hasn't been running for 9 months.
