### PR TITLE
Fix Avro enum compatibility handling

### DIFF
--- a/karapace/compatibility/__init__.py
+++ b/karapace/compatibility/__init__.py
@@ -57,14 +57,7 @@ class CompatibilityModes(Enum):
 
 
 def check_avro_compatibility(reader_schema: AvroSchema, writer_schema: AvroSchema) -> SchemaCompatibilityResult:
-    result = AvroChecker().get_compatibility(reader=reader_schema, writer=writer_schema)
-    if (
-        result.compatibility is SchemaCompatibilityType.incompatible
-        and [SchemaIncompatibilityType.missing_enum_symbols] != result.incompatibilities
-    ):
-        return result
-
-    return SchemaCompatibilityResult(SchemaCompatibilityType.compatible)
+    return AvroChecker().get_compatibility(reader=reader_schema, writer=writer_schema)
 
 
 def check_jsonschema_compatibility(reader: Draft7Validator, writer: Draft7Validator) -> SchemaCompatibilityResult:

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -368,7 +368,9 @@ class KarapaceSchemaRegistry:
                     )
                     if is_incompatible(result):
                         message = set(result.messages).pop() if result.messages else ""
-                        LOG.warning("Incompatible schema: %s", result)
+                        LOG.warning(
+                            "Incompatible schema: %s, incompatibilities: %s", result.compatibility, result.incompatibilities
+                        )
                         raise IncompatibleSchema(
                             f"Incompatible schema, compatibility_mode={compatibility_mode.value} {message}"
                         )


### PR DESCRIPTION
# About this change - What it does

Fix Avro enum symbol addition and removal compatibility handling. Karapace has been ignoring those incompatibilities for unknown historical reason.  Improve compatibility result logging to be more informative.

Fixes #524
