### PR TITLE
Add Backup File Overwrite Protection

### DIFF
--- a/tests/unit/test_schema_backup.py
+++ b/tests/unit/test_schema_backup.py
@@ -1,0 +1,61 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from karapace.schema_backup import _writer
+from pathlib import Path
+
+import pytest
+import sys
+
+
+class TestWrite:
+    @pytest.mark.parametrize("it", ("", "-"))
+    def test_stdout(self, it: str) -> None:
+        with _writer(it) as fp:
+            assert fp is sys.stdout
+
+    def test_file_creation(self, tmp_path: Path) -> None:
+        file = tmp_path / "file"
+        with _writer(file) as fp:
+            fp.write("test")
+        assert list(tmp_path.iterdir()) == [file], "tmp file should be gone"
+        assert file.read_text() == "test"
+
+    def test_file_overwrite(self, tmp_path: Path) -> None:
+        file = tmp_path / "file"
+        file.touch()
+        with _writer(file, overwrite=True) as fp:
+            fp.write("test")
+        assert list(tmp_path.iterdir()) == [file], "tmp file should be gone"
+        assert file.read_text() == "test"
+
+    def test_fails_if_file_exists_at_start(self, tmp_path: Path) -> None:
+        file = tmp_path / "file"
+        file.touch()
+        with pytest.raises(FileExistsError):
+            with _writer(file):
+                pass
+        assert list(tmp_path.iterdir()) == [file], "no tmp file is created"
+
+    def test_fails_if_file_exists_at_end(self, tmp_path: Path) -> None:
+        file = tmp_path / "file"
+        with pytest.raises(FileExistsError):
+            with _writer(file):
+                file.touch()
+        assert list(tmp_path.iterdir()) == [file], "tmp file should be gone"
+
+    def test_fails_if_path_exists_and_is_not_a_file_despite_overwrite_flag_at_start(self, tmp_path: Path) -> None:
+        file = tmp_path / "dir"
+        file.mkdir()
+        with pytest.raises(FileExistsError):
+            with _writer(file, overwrite=True):
+                pass
+        assert list(tmp_path.iterdir()) == [file], "no tmp file is created"
+
+    def test_fails_if_path_exists_and_is_not_a_file_despite_overwrite_flag_at_end(self, tmp_path: Path) -> None:
+        file = tmp_path / "dir"
+        with pytest.raises(FileExistsError):
+            with _writer(file, overwrite=True):
+                file.mkdir()
+        assert list(tmp_path.iterdir()) == [file], "no tmp file is created"


### PR DESCRIPTION
The schema backup tool is currently overwriting the output file without asking to do so. It is also writing directly to the output file, and leaves the file intact even if the backup actually failed. This patch adds guards that fail if the output file already exists, but also an `--overwrite` flag. It also introduces a temporary file that is persisted only if the backup actually succeeded, not leaving behind any trace of the work if not.

The output needs to be a file to be overwritten, even with the `--overwrite` flag present. Any other path type is not going to be touched. Our code verifies this, and Python's `replace` function does as well.

Other smaller things worth mentioning:

- The `--location` accepts `-` as synonym for `stdout` as is conventional, the current empty string continues to work as well and stays the default. But, `-` is not going to create a file called `-` anymore.
- Renamed `Writer` to `_writer` and by doing so made it private. This could be considered a breaking change since the name of the symbol changed, and anyone relying on it fails now. However, the `Writer` was never meant to be a public symbol, and we do not have any policy regarding such changes.
- Fixed the return type hint from `Iterable[TextIO]` to `TextIO` since it is a context manager, and not something that can be iterated.