### PR TITLE
Add Backup Partition Count Check

### DIFF
--- a/tests/unit/test_schema_backup.py
+++ b/tests/unit/test_schema_backup.py
@@ -2,11 +2,67 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
-from karapace.schema_backup import _writer
+from kafka import KafkaConsumer, KafkaProducer
+from kafka.structs import PartitionMetadata
+from karapace import config
+from karapace.config import Config
+from karapace.schema_backup import _consumer, _producer, _writer, PartitionCountError
 from pathlib import Path
+from types import FunctionType
+from typing import AbstractSet, Callable, Type, Union
+from unittest import mock
 
 import pytest
 import sys
+
+
+class TestClients:
+    @staticmethod
+    def _partition_metadata(c: int = 1) -> AbstractSet[PartitionMetadata]:
+        return {PartitionMetadata("topic", i, 0, tuple(), tuple(), None) for i in range(0, c)}
+
+    @pytest.mark.parametrize(
+        "ctx_mng,client_class,partitions_method",
+        (
+            (_consumer, KafkaConsumer, KafkaConsumer.partitions_for_topic),
+            (_producer, KafkaProducer, KafkaProducer.partitions_for),
+        ),
+    )
+    def test_auto_closing(
+        self,
+        ctx_mng: Callable[[Config, str], Union[KafkaConsumer, KafkaProducer]],
+        client_class: Type[Union[KafkaConsumer, KafkaProducer]],
+        partitions_method: FunctionType,
+    ) -> None:
+        with mock.patch(f"{client_class.__module__}.{client_class.__qualname__}.__new__", autospec=True) as client_ctor:
+            client_mock = client_ctor.return_value
+            getattr(client_mock, partitions_method.__name__).return_value = self._partition_metadata()
+            with ctx_mng(config.DEFAULTS, "topic") as client:
+                assert client is client_mock
+            assert client_mock.close.call_count == 1
+
+    @pytest.mark.parametrize("partition_count", (0, 2))
+    @pytest.mark.parametrize(
+        "ctx_mng,client_class,partitions_method",
+        (
+            (_consumer, KafkaConsumer, KafkaConsumer.partitions_for_topic),
+            (_producer, KafkaProducer, KafkaProducer.partitions_for),
+        ),
+    )
+    def test_partition_count_check(
+        self,
+        ctx_mng: Callable[[Config, str], Union[KafkaConsumer, KafkaProducer]],
+        client_class: Type[Union[KafkaConsumer, KafkaProducer]],
+        partitions_method: FunctionType,
+        partition_count: int,
+    ) -> None:
+        with mock.patch(f"{client_class.__module__}.{client_class.__qualname__}.__new__", autospec=True) as client_ctor:
+            client_mock = client_ctor.return_value
+            getattr(client_mock, partitions_method.__name__).return_value = self._partition_metadata(partition_count)
+            with pytest.raises(PartitionCountError):
+                with ctx_mng(config.DEFAULTS, "topic") as client:
+                    assert client == client_mock
+            assert client_mock.close.call_count == 1
 
 
 class TestWrite:


### PR DESCRIPTION
This adds a check that verifies that the source and target topic for a backup indeed have a single partition, instead of simply assuming that it does. This is not a breaking change, since it makes the implicit explicit, and users who are going to receive the error are going to be protected from a lot of hardship.

This also removes the consumer and producer clients from the class by moving them into dedicated top-level functions. Those top-level functions are context managers that close the clients automatically in a reliable way. This removal could be considered a breaking change, since we are removing public functions from a class. However, these functions were never meant to be public, especially not because they were directly meddling with internal state.

The new top-level functions **always** check the partition count, and client creation without a partition count check is not possible. This is on purpose, to ensure safety. Last, but not least, there are tests that verify all of the claims.