### PR TITLE
Add more graceful handling when deserialization fails for a record during consuming

### DIFF
--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -25,6 +25,10 @@ HEADER_FORMAT = ">bI"
 HEADER_SIZE = 5
 
 
+class DeserializationError(Exception):
+    pass
+
+
 class InvalidMessageHeader(Exception):
     pass
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -132,7 +132,7 @@ second_obj = [{"name": "doe"}, {"name": "john"}]
 REST_HEADERS = {
     "json": {
         "Content-Type": "application/vnd.kafka.json.v2+json",
-        "Accept": "*/*",
+        "Accept": "application/vnd.kafka.json.v2+json, application/vnd.kafka.v2+json, application/json, */*",
     },
     "jsonschema": {
         "Content-Type": "application/vnd.kafka.jsonschema.v2+json",


### PR DESCRIPTION
Currently, failing to deserialize a record to the requested format during consuming results in internal error. Also, json decode error was not caught.

For example: If user has produced binary records to a topic and then tried to consume them using format json. The response would be a 500 internal server error without proper message.

Should now properly catch json decode exception and change exception type from 500 to 422 including the intended message. Also adds test that should help ensure this will happen with all known formats.
