### PR TITLE
Fix Backup Topic Creation Retries and Interrupts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ jsonschema==3.2.0
 networkx==2.5
 protobuf==3.19.5
 python-dateutil==2.8.2
+tenacity==8.0.1
 ujson==5.7.0
 
 # Using 0.15.0 until following issue gets fixed.

--- a/tests/unit/test_schema_backup.py
+++ b/tests/unit/test_schema_backup.py
@@ -2,18 +2,82 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
-from kafka import KafkaConsumer, KafkaProducer
+from kafka import KafkaAdminClient, KafkaConsumer, KafkaProducer
+from kafka.admin import NewTopic
+from kafka.errors import TopicAlreadyExistsError
 from kafka.structs import PartitionMetadata
 from karapace import config
 from karapace.config import Config
-from karapace.schema_backup import _consumer, _producer, _writer, PartitionCountError
+from karapace.constants import DEFAULT_SCHEMA_TOPIC
+from karapace.schema_backup import _admin, _consumer, _maybe_create_topic, _producer, _writer, PartitionCountError
 from pathlib import Path
 from types import FunctionType
-from typing import AbstractSet, Callable, Type, Union
+from typing import AbstractSet, Callable, List, Type, Union
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 import sys
+
+ADMIN_NEW_FQN = f"{KafkaAdminClient.__module__}.{KafkaAdminClient.__qualname__}.__new__"
+
+
+class TestAdmin:
+    @mock.patch(ADMIN_NEW_FQN, autospec=True)
+    def test_auto_closing(self, admin_new: MagicMock):
+        admin_mock = admin_new.return_value
+        with _admin(config.DEFAULTS) as admin:
+            assert admin is admin_mock
+        assert admin_mock.close.call_count == 1
+
+    @mock.patch("time.sleep", autospec=True)
+    @mock.patch(ADMIN_NEW_FQN, autospec=True)
+    def test_retry(self, admin_new: MagicMock, sleep_mock: MagicMock) -> None:
+        admin_mock = admin_new.return_value
+        admin_new.side_effect = [Exception("1"), Exception("2"), admin_mock]
+        with _admin(config.DEFAULTS) as admin:
+            assert admin is admin_mock
+        assert sleep_mock.call_count == 2  # proof that we waited between retries
+        assert admin_mock.close.call_count == 1
+
+    @pytest.mark.parametrize("e", (KeyboardInterrupt, SystemExit))
+    @mock.patch("time.sleep", autospec=True)
+    @mock.patch(ADMIN_NEW_FQN, autospec=True)
+    def test_interrupts(self, admin_new: MagicMock, sleep_mock: MagicMock, e: Type[BaseException]) -> None:
+        admin_new.side_effect = [e()]
+        with pytest.raises(e):
+            with _admin(config.DEFAULTS):
+                pass
+        assert sleep_mock.call_count == 0  # proof that we did not retry
+
+
+class TestMaybeCreateTopic:
+    @mock.patch(ADMIN_NEW_FQN, autospec=True)
+    def test_ok(self, admin_new: MagicMock) -> None:
+        assert _maybe_create_topic(config.DEFAULTS) is True
+        create_topics: MagicMock = admin_new.return_value.create_topics
+        assert create_topics.call_count == 1
+        topic_list: List[NewTopic] = create_topics.call_args[0][0]
+        assert len(topic_list) == 1
+        assert topic_list[0].name == DEFAULT_SCHEMA_TOPIC
+
+    @mock.patch(ADMIN_NEW_FQN, autospec=True)
+    def test_exists(self, admin_new: MagicMock) -> None:
+        create_topics: MagicMock = admin_new.return_value.create_topics
+        create_topics.side_effect = TopicAlreadyExistsError()
+        assert _maybe_create_topic(config.DEFAULTS) is False
+
+    @mock.patch("time.sleep", autospec=True)
+    @mock.patch(ADMIN_NEW_FQN, autospec=True)
+    def test_retry(self, admin_new: MagicMock, sleep_mock: MagicMock) -> None:
+        create_topics: MagicMock = admin_new.return_value.create_topics
+        create_topics.side_effect = [Exception("1"), Exception("2"), None]
+        assert _maybe_create_topic(config.DEFAULTS) is True
+        assert sleep_mock.call_count == 2  # proof that we waited between retries
+
+    def test_name_override(self) -> None:
+        assert "custom-name" != DEFAULT_SCHEMA_TOPIC
+        assert _maybe_create_topic(config.DEFAULTS, "custom-name") is None
 
 
 class TestClients:


### PR DESCRIPTION
The retry logic in the backup code for admin client and topic creation is flawed as it compares seconds to milliseconds. Instead of aborting after the desired 60 seconds it aborts after 60,000 seconds. The retry implementation itself has several other issues, most notable the fact that it swallows `BaseException`, and thus cannot be interrupted by the user when it enters the retry loop.

Instead of trying to come up with an optimized retry logic or a generic solution that can be used across the board, I decided to add a well tested library that already provides this logic. ~I also use `timedelta` in favor of primitives for all durations, to avoid unit confusion.~ This was reverted, because we have to use an older tenacity version that does not support `timedelta`.

This updates only the backup code. Other code might or might not have similar flaws. For instance, after this change there are still 11 `pylint: disable=bare-except` left in the `karapace` source directory.

----

~Requires https://github.com/aiven/karapace/pull/537 to be merged first, as it includes it and builds on top of it.~