### PR TITLE
Increase Integration Test Timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       run: python3 -m pytest -s -vvv tests/unit/
 
     - name: Execute integration-tests
-      timeout-minutes: 15
+      timeout-minutes: 30
       run: python3 -m pytest -s -vvv tests/integration/ --log-dir=/tmp/ci-logs --log-file=/tmp/ci-logs/pytest.log
 
     - name: Archive logs


### PR DESCRIPTION
The integration tests are constantly running into timeouts, requiring manual reruns.