### PR TITLE
Fix GHA Protoc Installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
 
@@ -27,13 +27,17 @@ jobs:
     - name: Install dependencies
       run: python -m pip install -r requirements-dev.txt
 
-    - name: Install Protoc
+    - name: Extract Protobuf Version
+      id: protoc
+      run: pip freeze | grep -m1 '^protobuf==' | cut -d= -f3 | xargs printf 'version=%s' >>"$GITHUB_OUTPUT"
+
+    - name: Install Protobuf Compiler
       uses: arduino/setup-protoc@v1
       with:
-         version: '3.13.0'
+         version: ${{ steps.protoc.outputs.version }}
          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    # needed by both unit and integation tests
+    # needed by both unit and integration tests
     - name: Generate version.py
       run: make karapace/version.py
 


### PR DESCRIPTION
The protobuf compiler that is being installed in GitHub Actions has a different version than the library that is used by Karapace. To avoid further drift it is necessary to ensure that they stay aligned automatically. This patch adds some code to extract the actual Protobuf version from the `requirements.txt` file.

Note that this approach is going to break with newer Protobuf versions. This is because Google decided to stop versioning all Protobuf dependencies alike. However, newer versions of Python Protobuf do not require the Protobuf Compiler to be installed anymore. Hence, if we upgrade, we can get rid of the Protobuf Compiler installation entirely.