### PR TITLE
Fix Python Executable Search in Tests

### DIFF
--- a/tests/integration/test_karapace.py
+++ b/tests/integration/test_karapace.py
@@ -5,9 +5,9 @@ See LICENSE for details
 from contextlib import ExitStack
 from karapace.config import set_config_defaults
 from pathlib import Path
-from subprocess import Popen
 from tests.integration.utils.network import PortRangeInclusive
 from tests.integration.utils.process import stop_process
+from tests.utils import popen_karapace_all
 
 import json
 import socket
@@ -39,10 +39,6 @@ def test_regression_server_must_exit_on_exception(
         errfile = stack.enter_context((tmp_path / "karapace.err").open("w"))
         config_path.write_text(json.dumps(config))
         sock.bind(("127.0.0.1", port))
-        process = Popen(  # pylint: disable=consider-using-with
-            args=["python", "-m", "karapace.karapace_all", str(config_path)],
-            stdout=logfile,
-            stderr=errfile,
-        )
+        process = popen_karapace_all(config_path, logfile, errfile)
         stack.callback(stop_process, process)  # make sure to stop the process if the test fails
         assert process.wait(timeout=10) != 0, "Process should have exited with an error, port is already is use"

--- a/tests/integration/utils/cluster.py
+++ b/tests/integration/utils/cluster.py
@@ -6,10 +6,9 @@ from contextlib import asynccontextmanager, ExitStack
 from dataclasses import dataclass
 from karapace.config import Config, set_config_defaults, write_config
 from pathlib import Path
-from subprocess import Popen
 from tests.integration.utils.network import PortRangeInclusive
 from tests.integration.utils.process import stop_process, wait_for_port_subprocess
-from tests.utils import new_random_name
+from tests.utils import new_random_name, popen_karapace_all
 from typing import AsyncIterator, List
 
 
@@ -82,11 +81,7 @@ async def start_schema_registry_cluster(
 
             logfile = stack.enter_context(open(log_path, "w"))
             errfile = stack.enter_context(open(error_path, "w"))
-            process = Popen(
-                args=["python", "-m", "karapace.karapace_all", str(config_path)],
-                stdout=logfile,
-                stderr=errfile,
-            )
+            process = popen_karapace_all(config_path, logfile, errfile)
             stack.callback(stop_process, process)
             all_processes.append(process)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,13 +8,16 @@ from karapace.client import Client
 from karapace.protobuf.kotlin_wrapper import trim_margin
 from karapace.utils import Expiration
 from pathlib import Path
-from typing import Callable, List
+from subprocess import Popen
+from typing import Callable, IO, List, Union
 from urllib.parse import quote
 
 import asyncio
 import copy
 import json
+import os
 import ssl
+import sys
 import uuid
 
 consumer_valid_payload = {
@@ -268,3 +271,16 @@ def write_ini(file_path: Path, ini_data: dict) -> None:
 
     with file_path.open("w") as fp:
         fp.write(file_contents)
+
+
+def python_exe() -> str:
+    python = sys.executable
+    if python is None:
+        python = os.environ.get("PYTHON", "python3")
+    return python
+
+
+def popen_karapace_all(config_path: Union[Path, str], stdout: IO, stderr: IO, **kwargs) -> Popen:
+    kwargs["stdout"] = stdout
+    kwargs["stderr"] = stderr
+    return Popen([python_exe(), "-m", "karapace.karapace_all", str(config_path)], **kwargs)


### PR DESCRIPTION
This removes the hardcoded `python` executable name in tests with a more dynamic approach that resolves to the Python executable used by the tests. Not all systems have Python 3 available at `python` by default, and there is no guarantee that the `PATH` in a `venv` is modified to include the `venv/bin` directory in the `PATH`. Python offers `sys.executable` to find the current executable, if that fails we fall back to the same environment variable we use in our make file, and if that fails we use `python3` (seems to be available on most systems).