### PR TITLE
feat: Add `shellcheck` and `shfmt` Pre-Commit Hooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+tab_width = 4
+trim_trailing_whitespace = true
+
+ij_yaml_indent_sequence_value = false
+
+[*.{json,md,proto,rst,yaml,yml}]
+indent_size = 2
+tab_width = 2
+
+# This MUST be a dedicated section, or shfmt is not going to pick it up.
+# noinspection EditorConfigOptionRedundancy
+[*.sh]
+indent_size = 4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,28 +2,27 @@ name: Lint
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
   push:
-    branches:
-      - main
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-
-      - name: Install dependencies
-        run: pip install 'pre-commit>=2.2.0'
-
-      # required for pylint
-      - name: Generate version.py
-        run: make karapace/version.py
-
-      - name: Run all pre-commit hooks
-        run: pre-commit run --all-files
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    # required for pylint
+    - run: make karapace/version.py
+    - run: pip install pre-commit
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,61 +1,66 @@
----
 minimum_pre_commit_version: 2.9.2
+
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-      - id: trailing-whitespace
-        exclude: ^vendor/|^tests/.*/fixtures/.*|^tests/integration/test_data/.*
-      - id: end-of-file-fixer
-        exclude: ^vendor/|^tests/.*/fixtures/.*|^tests/integration/test_data/.*
-      - id: debug-statements
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: trailing-whitespace
+    exclude: ^tests/integration/test_data/.*
+  - id: end-of-file-fixer
+    exclude: ^tests/integration/test_data/.*
+  - id: debug-statements
 
-  - repo: local
-    hooks:
-      - id: copyright
-        name: copyright
-        language: system
-        types: [python]
-        exclude: ^vendor/
-        pass_filenames: false
-        # Lists the Python files that do not have an Aiven copyright. Exits with a
-        # non-zero exit code if any are found.
-        entry: bash -c "! git grep --untracked -ELm1 'Copyright \(c\) 20[0-9]{2} Aiven' -- '*.py' ':!*__init__.py'"
+# https://pre-commit.com/#repository-local-hooks
+- repo: local
+  hooks:
+  - id: copyright
+    name: copyright
+    language: system
+    types: [ python ]
+    pass_filenames: false
+    # Lists the Python files that do not have an Aiven copyright. Exits with a
+    # non-zero exit code if any are found.
+    entry: bash -c "! git grep --untracked -ELm1 'Copyright \(c\) 20[0-9]{2} Aiven' -- '*.py' ':!*__init__.py'"
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: "v3.3.1"
-    hooks:
-      - id: pyupgrade
-        args: ["--py37-plus"]
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.9.0.2
+  hooks:
+  - id: shellcheck
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
+- repo: https://github.com/scop/pre-commit-shfmt
+  rev: v3.6.0-1
+  hooks:
+  - id: shfmt
 
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-      - id: black
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.3.1
+  hooks:
+  - id: pyupgrade
+    args: [ --py37-plus ]
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
+- repo: https://github.com/PyCQA/isort
+  rev: 5.12.0
+  hooks:
+  - id: isort
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
-    hooks:
-      - id: mypy
-        name: Mypy Karapace
-        pass_filenames: false
+- repo: https://github.com/psf/black
+  rev: 22.12.0
+  hooks:
+  - id: black
 
-  # https://pre-commit.com/#repository-local-hooks
-  - repo: https://github.com/PyCQA/pylint
-    rev: v2.15.10
-    hooks:
-      - id: pylint
-        exclude: ^vendor/
-        args:
-          - --rcfile=.pylintrc
+- repo: https://github.com/PyCQA/flake8
+  rev: 6.0.0
+  hooks:
+  - id: flake8
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.991
+  hooks:
+  - id: mypy
+    pass_filenames: false
+
+- repo: https://github.com/PyCQA/pylint
+  rev: v2.15.10
+  hooks:
+  - id: pylint
+    args: [ --rcfile=.pylintrc ]

--- a/container/start.sh
+++ b/container/start.sh
@@ -1,10 +1,9 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
 # Configuration is done using environment variables. The environment variable
 # names are the same as the configuration keys, all letters in caps, and always
 # start with `KARAPACE_`.
-
 
 # In the code below the expression ${var+isset} is used to check if the
 # variable was defined, and ${var-isunset} if not.
@@ -12,46 +11,46 @@ set -e
 # Ref: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02
 
 case $1 in
-  rest)
+rest)
     # Reexport variables for compatibility
-    [[ -n "${KARAPACE_REST_ADVERTISED_HOSTNAME+isset}" ]] && export KARAPACE_ADVERTISED_HOSTNAME="${KARAPACE_REST_ADVERTISED_HOSTNAME}"
-    [[ -n "${KARAPACE_REST_BOOTSTRAP_URI+isset}" ]] && export KARAPACE_BOOTSTRAP_URI="${KARAPACE_REST_BOOTSTRAP_URI}"
-    [[ -n "${KARAPACE_REST_REGISTRY_HOST+isset}" ]] && export KARAPACE_REGISTRY_HOST="${KARAPACE_REST_REGISTRY_HOST}"
-    [[ -n "${KARAPACE_REST_REGISTRY_PORT+isset}" ]] && export KARAPACE_REGISTRY_PORT="${KARAPACE_REST_REGISTRY_PORT}"
-    [[ -n "${KARAPACE_REST_HOST+isset}" ]] && export KARAPACE_HOST="${KARAPACE_REST_HOST}"
-    [[ -n "${KARAPACE_REST_PORT+isset}" ]] && export KARAPACE_PORT="${KARAPACE_REST_PORT}"
-    [[ -n "${KARAPACE_REST_ADMIN_METADATA_MAX_AGE+isset}" ]] && export KARAPACE_ADMIN_METADATA_MAX_AGE="${KARAPACE_REST_ADMIN_METADATA_MAX_AGE}"
-    [[ -n "${KARAPACE_REST_LOG_LEVEL+isset}" ]] && export KARAPACE_LOG_LEVEL="${KARAPACE_REST_LOG_LEVEL}"
+    [[ -n ${KARAPACE_REST_ADVERTISED_HOSTNAME+isset} ]] && export KARAPACE_ADVERTISED_HOSTNAME="${KARAPACE_REST_ADVERTISED_HOSTNAME}"
+    [[ -n ${KARAPACE_REST_BOOTSTRAP_URI+isset} ]] && export KARAPACE_BOOTSTRAP_URI="${KARAPACE_REST_BOOTSTRAP_URI}"
+    [[ -n ${KARAPACE_REST_REGISTRY_HOST+isset} ]] && export KARAPACE_REGISTRY_HOST="${KARAPACE_REST_REGISTRY_HOST}"
+    [[ -n ${KARAPACE_REST_REGISTRY_PORT+isset} ]] && export KARAPACE_REGISTRY_PORT="${KARAPACE_REST_REGISTRY_PORT}"
+    [[ -n ${KARAPACE_REST_HOST+isset} ]] && export KARAPACE_HOST="${KARAPACE_REST_HOST}"
+    [[ -n ${KARAPACE_REST_PORT+isset} ]] && export KARAPACE_PORT="${KARAPACE_REST_PORT}"
+    [[ -n ${KARAPACE_REST_ADMIN_METADATA_MAX_AGE+isset} ]] && export KARAPACE_ADMIN_METADATA_MAX_AGE="${KARAPACE_REST_ADMIN_METADATA_MAX_AGE}"
+    [[ -n ${KARAPACE_REST_LOG_LEVEL+isset} ]] && export KARAPACE_LOG_LEVEL="${KARAPACE_REST_LOG_LEVEL}"
     export KARAPACE_REST=1
-    echo "{}" > /opt/karapace/rest.config.json
+    echo "{}" >/opt/karapace/rest.config.json
 
     echo "Starting Karapace REST API"
     exec python3 -m karapace.karapace_all /opt/karapace/rest.config.json
-  ;;
-  registry)
+    ;;
+registry)
     # Reexport variables for compatibility
-    [[ -n "${KARAPACE_REGISTRY_ADVERTISED_HOSTNAME+isset}" ]] && export KARAPACE_ADVERTISED_HOSTNAME="${KARAPACE_REGISTRY_ADVERTISED_HOSTNAME}"
-    [[ -n "${KARAPACE_REGISTRY_BOOTSTRAP_URI+isset}" ]] && export KARAPACE_BOOTSTRAP_URI="${KARAPACE_REGISTRY_BOOTSTRAP_URI}"
-    [[ -n "${KARAPACE_REGISTRY_HOST+isset}" ]] && export KARAPACE_HOST="${KARAPACE_REGISTRY_HOST}"
-    [[ -n "${KARAPACE_REGISTRY_PORT+isset}" ]] && export KARAPACE_PORT="${KARAPACE_REGISTRY_PORT}"
-    [[ -n "${KARAPACE_REGISTRY_CLIENT_ID+isset}" ]] && export KARAPACE_CLIENT_ID="${KARAPACE_REGISTRY_CLIENT_ID}"
-    [[ -n "${KARAPACE_REGISTRY_GROUP_ID+isset}" ]] && export KARAPACE_GROUP_ID="${KARAPACE_REGISTRY_GROUP_ID}"
+    [[ -n ${KARAPACE_REGISTRY_ADVERTISED_HOSTNAME+isset} ]] && export KARAPACE_ADVERTISED_HOSTNAME="${KARAPACE_REGISTRY_ADVERTISED_HOSTNAME}"
+    [[ -n ${KARAPACE_REGISTRY_BOOTSTRAP_URI+isset} ]] && export KARAPACE_BOOTSTRAP_URI="${KARAPACE_REGISTRY_BOOTSTRAP_URI}"
+    [[ -n ${KARAPACE_REGISTRY_HOST+isset} ]] && export KARAPACE_HOST="${KARAPACE_REGISTRY_HOST}"
+    [[ -n ${KARAPACE_REGISTRY_PORT+isset} ]] && export KARAPACE_PORT="${KARAPACE_REGISTRY_PORT}"
+    [[ -n ${KARAPACE_REGISTRY_CLIENT_ID+isset} ]] && export KARAPACE_CLIENT_ID="${KARAPACE_REGISTRY_CLIENT_ID}"
+    [[ -n ${KARAPACE_REGISTRY_GROUP_ID+isset} ]] && export KARAPACE_GROUP_ID="${KARAPACE_REGISTRY_GROUP_ID}"
     # Map misspelt environment variable to correct spelling for backwards compatibility.
-    [[ -n "${KARAPACE_REGISTRY_MASTER_ELIGIBITY+isset}" ]] && export KARAPACE_MASTER_ELIGIBILITY="${KARAPACE_REGISTRY_MASTER_ELIGIBITY}"
-    [[ -n "${KARAPACE_REGISTRY_MASTER_ELIGIBILITY+isset}" ]] && export KARAPACE_MASTER_ELIGIBILITY="${KARAPACE_REGISTRY_MASTER_ELIGIBILITY}"
-    [[ -n "${KARAPACE_REGISTRY_TOPIC_NAME+isset}" ]] && export KARAPACE_TOPIC_NAME="${KARAPACE_REGISTRY_TOPIC_NAME}"
-    [[ -n "${KARAPACE_REGISTRY_COMPATIBILITY+isset}" ]] && export KARAPACE_COMPATIBILITY="${KARAPACE_REGISTRY_COMPATIBILITY}"
-    [[ -n "${KARAPACE_REGISTRY_LOG_LEVEL+isset}" ]] && export KARAPACE_LOG_LEVEL="${KARAPACE_REGISTRY_LOG_LEVEL}"
+    [[ -n ${KARAPACE_REGISTRY_MASTER_ELIGIBITY+isset} ]] && export KARAPACE_MASTER_ELIGIBILITY="${KARAPACE_REGISTRY_MASTER_ELIGIBITY}"
+    [[ -n ${KARAPACE_REGISTRY_MASTER_ELIGIBILITY+isset} ]] && export KARAPACE_MASTER_ELIGIBILITY="${KARAPACE_REGISTRY_MASTER_ELIGIBILITY}"
+    [[ -n ${KARAPACE_REGISTRY_TOPIC_NAME+isset} ]] && export KARAPACE_TOPIC_NAME="${KARAPACE_REGISTRY_TOPIC_NAME}"
+    [[ -n ${KARAPACE_REGISTRY_COMPATIBILITY+isset} ]] && export KARAPACE_COMPATIBILITY="${KARAPACE_REGISTRY_COMPATIBILITY}"
+    [[ -n ${KARAPACE_REGISTRY_LOG_LEVEL+isset} ]] && export KARAPACE_LOG_LEVEL="${KARAPACE_REGISTRY_LOG_LEVEL}"
     export KARAPACE_REGISTRY=1
-    echo "{}" > /opt/karapace/registry.config.json
+    echo "{}" >/opt/karapace/registry.config.json
 
     echo "Starting Karapace Schema Registry"
     exec python3 -m karapace.karapace_all /opt/karapace/registry.config.json
-  ;;
-  *)
+    ;;
+*)
     echo "usage: start-karapace.sh <registry|rest>"
     exit 0
-  ;;
+    ;;
 esac
 
 wait

--- a/performance-test/run-locust-test.sh
+++ b/performance-test/run-locust-test.sh
@@ -1,5 +1,5 @@
-#!/bin/env bash
-set -eo pipefail
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
 # The REST proxy address params
 BASE_URL=${BASE_URL:-http://localhost:8082}
@@ -10,14 +10,14 @@ CONCURRENCY=${CONCURRENCY:-50}
 LOCUST_FILE=${LOCUST_FILE:-"rest-proxy-post-topic-test.py"}
 
 GUI_PARAMS="--headless"
-if [ ! -z $LOCUST_GUI ]; then
+if [[ -n $LOCUST_GUI ]]; then
     GUI_PARAMS="--autostart"
 fi
 
 TOPIC="${TOPIC}" locust "${GUI_PARAMS}" \
-     --run-time "${DURATION}" \
-     --users "${CONCURRENCY}" \
-     -H "${BASE_URL}" \
-     --spawn-rate 0.50 \
-     --stop-timeout 5 \
-     --locustfile "${LOCUST_FILE}"
+    --run-time "${DURATION}" \
+    --users "${CONCURRENCY}" \
+    -H "${BASE_URL}" \
+    --spawn-rate 0.50 \
+    --stop-timeout 5 \
+    --locustfile "${LOCUST_FILE}"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,11 @@
 # testing
+filelock==3.9.0
 pytest==6.2.5
 pytest-xdist[psutil]==2.2.1
 pytest-timeout==1.4.2
 pdbpp==0.10.2
 psutil==5.9.0
 requests==2.27.1
-
-# linting
-pre-commit>=2.2.0
 
 # performance test
 locust==2.13.0


### PR DESCRIPTION
This adds `shellcheck` and `shfmt` pre-commit hooks. I fixed the most pressing issues that were found, but did not go through the existing scripts otherwise. We are going to need more shell scripts to automate other things, this is why it is a good idea to add these tools to our verification chain.

~This also changes the GHA lint workflow to use the official pre-commit action, which also makes use of caching, and thus should be faster.~ The pre-commit action uses the `--color=always` option, and that option results in the action hanging forever if paired with local hooks, which we have.