### PR TITLE
chore: remove untracked files from copyright header check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     pass_filenames: false
     # Lists the Python files that do not have an Aiven copyright. Exits with a
     # non-zero exit code if any are found.
-    entry: bash -c "! git grep --untracked -ELm1 'Copyright \(c\) 20[0-9]{2} Aiven' -- '*.py' ':!*__init__.py'"
+    entry: bash -c "! git grep -ELm1 'Copyright \(c\) 20[0-9]{2} Aiven' -- '*.py' ':!*__init__.py'"
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.9.0.2


### PR DESCRIPTION
# About this change - What it does

Remove untracked files from pre-commit copyright header check.

# Why this way

Some times, at least I, have some special purpose scripts that are not tracked and won't be commited. The pre-commit hook then fails for missing copyright headers. This corrects the behavior to select only the files tracked by Git.