### PR TITLE
fix: Replace references to old default branch name

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -36,7 +36,7 @@ jobs:
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           # If not tag, then use `develop` as image tag
-          [ "$VERSION" == main -o "$VERSION" == master ] && VERSION=develop
+          [ "$VERSION" == main ] && VERSION=develop
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - master
+      - main
 
 jobs:
   tests:


### PR DESCRIPTION
# About this change - What it does

Fix references to previous name of default branch.

# Why this way

Runs full test suite on main branch after merging a pull request as intended.