### PR TITLE
fix: return 404 for config actions on unknown subjects

### DIFF
--- a/karapace/in_memory_database.py
+++ b/karapace/in_memory_database.py
@@ -137,13 +137,17 @@ class InMemoryDatabase:
         self.subjects.setdefault(subject, SubjectData())
 
     def get_subject_compatibility(self, *, subject: Subject) -> Optional[str]:
-        return self.subjects[subject].compatibility
+        if subject in self.subjects:
+            return self.subjects[subject].compatibility
+        return None
 
     def delete_subject_compatibility(self, *, subject: Subject) -> None:
-        self.subjects[subject].compatibility = None
+        if subject in self.subjects:
+            self.subjects[subject].compatibility = None
 
     def set_subject_compatibility(self, *, subject: Subject, compatibility: str) -> None:
-        self.subjects[subject].compatibility = compatibility
+        if subject in self.subjects:
+            self.subjects[subject].compatibility = compatibility
 
     def find_schema(self, *, schema_id: SchemaId) -> Optional[TypedSchema]:
         return self.schemas[schema_id]

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1998,6 +1998,19 @@ async def test_schema_version_number_existing_schema(registry_async_client: Clie
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
+async def test_get_config_unknown_subject(registry_async_client: Client, trail: str) -> None:
+    res = await registry_async_client.get(f"config/unknown-subject{trail}")
+    assert res.status_code == 404, f"{res} - Should return 404 for unknown subject"
+
+    # Set global config, see that unknown subject is still returns correct 404 and does not fallback to global config
+    res = await registry_async_client.put(f"config{trail}", json={"compatibility": "FULL"})
+    assert res.status_code == 200
+
+    res = await registry_async_client.get(f"config/unknown-subject{trail}")
+    assert res.status_code == 404, f"{res} - Should return 404 for unknown subject also when global config set"
+
+
+@pytest.mark.parametrize("trail", ["", "/"])
 async def test_config(registry_async_client: Client, trail: str) -> None:
     subject_name_factory = create_subject_name_factory(f"test_config-{trail}")
 


### PR DESCRIPTION
# About this change - What it does

The subject config endpoints did not return 404 for unknown subjects. A 500 internal error was returned.
