### PR TITLE
Implement health status endpoint

### DIFF
--- a/karapace/karapace.py
+++ b/karapace/karapace.py
@@ -9,12 +9,21 @@ from functools import partial
 from http import HTTPStatus
 from karapace.config import Config
 from karapace.rapu import HTTPRequest, HTTPResponse, RestApp
+from karapace.utils import json_encode
 from typing import Callable, NoReturn, Optional, Union
+
+import aiohttp.web
+import time
 
 
 class KarapaceBase(RestApp):
     def __init__(self, config: Config, not_ready_handler: Optional[Callable[[HTTPRequest], None]] = None) -> None:
         super().__init__(app_name="karapace", config=config, not_ready_handler=not_ready_handler)
+
+        self._process_start_time = time.monotonic()
+        self.health_hooks = []
+        # Do not use rapu's etag, readiness and other wrapping
+        self.app.router.add_route("GET", "/_health", self.health)
 
         self.kafka_timeout = 10
         self.route("/", callback=self.root_get, method="GET")
@@ -61,6 +70,16 @@ class KarapaceBase(RestApp):
 
     async def root_get(self) -> NoReturn:
         self.r({}, "application/json")
+
+    async def health(self, _request) -> aiohttp.web.Response:
+        resp = {"process_uptime_sec": int(time.monotonic() - self._process_start_time)}
+        for hook in self.health_hooks:
+            resp.update(await hook())
+        return aiohttp.web.Response(
+            body=json_encode(resp, binary=True, compact=True),
+            status=HTTPStatus.OK.value,
+            headers={"Content-Type": "application/json"},
+        )
 
 
 empty_response = partial(KarapaceBase.r, body={}, status=HTTPStatus.NO_CONTENT, content_type="application/json")

--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -474,6 +474,3 @@ class RestApp:
             access_log_class=self.config["access_log_class"],
             access_log_format='%Tfs %{x-client-ip}i "%r" %s "%{user-agent}i" response=%bb request_body=%{content-length}ib',
         )
-
-    def add_routes(self):
-        pass  # Override in sub-classes

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -84,6 +84,26 @@ class KarapaceSchemaRegistryController(KarapaceBase):
 
         self._forward_client = None
         self.app.on_startup.append(self._create_forward_client)
+        self.health_hooks.append(self.schema_registry_health)
+
+    async def schema_registry_health(self) -> dict:
+        resp = {}
+        if self._auth is not None:
+            resp["schema_registry_authfile_timestamp"] = self._auth.authfile_last_modified
+        resp["schema_registry_ready"] = self.schema_registry.schema_reader.ready
+        if self.schema_registry.schema_reader.ready:
+            resp["schema_registry_startup_time_sec"] = (
+                self.schema_registry.schema_reader.last_check - self._process_start_time
+            )
+        resp["schema_registry_reader_current_offset"] = self.schema_registry.schema_reader.offset
+        resp["schema_registry_reader_highest_offset"] = self.schema_registry.schema_reader.highest_offset()
+        cs = self.schema_registry.mc.get_coordinator_status()
+        resp["schema_registry_is_primary"] = cs.is_primary
+        resp["schema_registry_is_primary_eligible"] = cs.is_primary_eligible
+        resp["schema_registry_primary_url"] = cs.primary_url
+        resp["schema_registry_coordinator_running"] = cs.is_running
+        resp["schema_registry_coordinator_generation_id"] = cs.group_generation_id
+        return resp
 
     async def _create_forward_client(self, app: aiohttp.web.Application) -> None:  # pylint: disable=unused-argument
         """Callback for aiohttp.Application.on_startup"""


### PR DESCRIPTION
# About this change - What it does

Add health status endpoint
    
Fixes #143

# Why this way

Implement health status endpoint which returns status of schema registry.  This by design avoids long running operations, and queries status from internal state variables acquiring only minimal locks.  This is designed to robustly and quickly return internal status of Karapace.
