### PR TITLE
fix: Use regular grep for copyright check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,8 @@ repos:
     name: copyright
     language: system
     types: [ python ]
-    pass_filenames: false
-    # Lists the Python files that do not have an Aiven copyright. Exits with a
-    # non-zero exit code if any are found.
-    entry: bash -c "! git grep -ELm1 'Copyright \(c\) 20[0-9]{2} Aiven' -- '*.py' ':!*__init__.py'"
+    exclude: __init__\.py
+    entry: ./copyright.sh
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
   rev: v0.9.0.2

--- a/copyright.sh
+++ b/copyright.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+missing_copyright=$(
+    grep \
+        --extended-regexp \
+        --files-without-match \
+        --max-count=1 \
+        'Copyright \(c\) 20[0-9]{2} Aiven' \
+        -- "$@"
+)
+
+if [[ -n $missing_copyright ]]; then
+    echo "💥 There are files missing required copyright statement."
+    echo "$missing_copyright"
+    exit 1
+else
+    echo "✅ All files have required copyright statement."
+fi


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
### About this change - What it does

- Change to using regular grep for copyright check.
- Move the check from inline in the pre-commit config to a separate shell file.
- Use pre-commit for file discovery and exclusion.

Fixes #563.
<!-- Provide a small sentence that summarizes the change. -->


### Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
