### PR TITLE
Introduce narrower JSON typing

### DIFF
--- a/karapace/key_format.py
+++ b/karapace/key_format.py
@@ -6,7 +6,7 @@ See LICENSE for details
 """
 
 from enum import Enum
-from karapace.typing import JsonData
+from karapace.typing import ArgJsonObject
 from karapace.utils import json_encode
 from typing import Optional
 
@@ -49,7 +49,11 @@ class KeyFormatter:
     def get_keymode(self) -> KeyMode:
         return self._keymode
 
-    def format_key(self, key: JsonData, keymode: Optional[KeyMode] = None) -> bytes:
+    def format_key(
+        self,
+        key: ArgJsonObject,
+        keymode: Optional[KeyMode] = None,
+    ) -> bytes:
         """Format key by the given keymode.
 
         :param key Key data as JsonData dict
@@ -71,5 +75,5 @@ class KeyFormatter:
         return json_encode(corrected_key, binary=True, sort_keys=False, compact=True)  # type: ignore[return-value]
 
 
-def is_key_in_canonical_format(key: JsonData) -> bool:
+def is_key_in_canonical_format(key: ArgJsonObject) -> bool:
     return list(key.keys()) in CANONICAL_KEY_ORDERS

--- a/karapace/master_coordinator.py
+++ b/karapace/master_coordinator.py
@@ -11,22 +11,37 @@ from kafka.errors import NoBrokersAvailable, NodeNotReadyError
 from kafka.metrics import MetricConfig, Metrics
 from karapace import constants
 from karapace.config import Config
-from karapace.typing import JsonData
+from karapace.typing import JsonData, JsonObject
 from karapace.utils import json_decode, json_encode, KarapaceKafkaClient
 from karapace.version import __version__
 from threading import Event, Thread
-from typing import Any, cast, List, Optional, Tuple
+from typing import Any, cast, List, Optional, Sequence, Tuple
+from typing_extensions import Final, TypedDict
 
 import logging
 import time
 
+__all__ = ("MasterCoordinator",)
+
 # SR group errors
-NO_ERROR = 0
-DUPLICATE_URLS = 1
+NO_ERROR: Final = 0
+DUPLICATE_URLS: Final = 1
 LOG = logging.getLogger(__name__)
 
 
-def get_member_url(scheme: str, host: str, port: str) -> str:
+class MemberIdentity(TypedDict):
+    host: str
+    port: int
+    scheme: str
+    master_eligibility: bool
+
+
+class MemberAssignment(TypedDict):
+    master: str
+    master_identity: MemberIdentity
+
+
+def get_member_url(scheme: str, host: str, port: int) -> str:
     return f"{scheme}://{host}:{port}"
 
 
@@ -92,14 +107,19 @@ class SchemaCoordinator(BaseCoordinator):
             )
         ]
 
-    def _perform_assignment(self, leader_id: str, protocol: str, members: JsonData) -> JsonData:
+    def _perform_assignment(
+        self,
+        leader_id: str,
+        protocol: str,
+        members: Sequence[Tuple[str, str]],
+    ) -> JsonObject:
         LOG.info("Creating assignment: %r, protocol: %r, members: %r", leader_id, protocol, members)
         self.are_we_master = None
         error = NO_ERROR
         urls = {}
         fallback_urls = {}
         for member_id, member_data in members:
-            member_identity = json_decode(member_data)
+            member_identity = json_decode(member_data, MemberIdentity)
             if member_identity["master_eligibility"] is True:
                 urls[get_member_url(member_identity["scheme"], member_identity["host"], member_identity["port"])] = (
                     member_id,
@@ -116,7 +136,7 @@ class SchemaCoordinator(BaseCoordinator):
             # Protocol guarantees there is at least one member thus if urls is empty, fallback_urls cannot be
             chosen_url = sorted(fallback_urls, reverse=self.election_strategy.lower() == "highest")[0]
             schema_master_id, member_data = fallback_urls[chosen_url]
-        member_identity = json_decode(member_data)
+        member_identity = json_decode(member_data, MemberIdentity)
         identity = get_member_configuration(
             host=member_identity["host"],
             port=member_identity["port"],
@@ -125,7 +145,7 @@ class SchemaCoordinator(BaseCoordinator):
         )
         LOG.info("Chose: %r with url: %r as the master", schema_master_id, chosen_url)
 
-        assignments = {}
+        assignments: JsonObject = {}
         for member_id, member_data in members:
             assignments[member_id] = json_encode(
                 {"master": schema_master_id, "master_identity": identity, "error": error}, compact=True
@@ -144,7 +164,7 @@ class SchemaCoordinator(BaseCoordinator):
             protocol,
             member_assignment_bytes,
         )
-        member_assignment = json_decode(member_assignment_bytes)
+        member_assignment = json_decode(member_assignment_bytes, MemberAssignment)
         member_identity = member_assignment["master_identity"]
 
         master_url = get_member_url(

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -90,7 +90,7 @@ class TypedSchema:
     def to_dict(self) -> Dict[str, Any]:
         if self.schema_type is SchemaType.PROTOBUF:
             raise InvalidSchema("Protobuf do not support to_dict serialization")
-        return json_decode(self.schema_str)
+        return json_decode(self.schema_str, Dict[str, Any])
 
     def fingerprint(self) -> str:
         if self._fingerprint_cached is None:

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -24,7 +24,7 @@ from karapace.messaging import KarapaceProducer
 from karapace.offset_watcher import OffsetWatcher
 from karapace.schema_models import ParsedTypedSchema, SchemaType, SchemaVersion, TypedSchema, ValidatedTypedSchema
 from karapace.schema_reader import KafkaSchemaReader
-from karapace.typing import JsonData, ResolvedVersion, Subject, Version
+from karapace.typing import JsonObject, ResolvedVersion, Subject, Version
 from typing import cast, Dict, List, Optional, Tuple, Union
 
 import asyncio
@@ -234,7 +234,7 @@ class KarapaceSchemaRegistry:
             raise SchemasNotFoundException
         return schemas
 
-    def subject_version_get(self, subject: Subject, version: Version, *, include_deleted: bool = False) -> JsonData:
+    def subject_version_get(self, subject: Subject, version: Version, *, include_deleted: bool = False) -> JsonObject:
         validate_version(version)
         schema_versions = self.subject_get(subject, include_deleted=include_deleted)
         if not schema_versions:
@@ -247,7 +247,7 @@ class KarapaceSchemaRegistry:
         schema_id = schema_data.schema_id
         schema = schema_data.schema
 
-        ret = {
+        ret: JsonObject = {
             "subject": subject,
             "version": resolved_version,
             "id": schema_id,

--- a/karapace/typing.py
+++ b/karapace/typing.py
@@ -2,13 +2,22 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
-from typing import Any, Union
+from typing import Dict, List, Mapping, Sequence, Union
+from typing_extensions import TypeAlias
 
-JsonData = Any  # Data that will be encoded to or has been parsed from JSON
+JsonArray: TypeAlias = List["JsonData"]
+JsonObject: TypeAlias = Dict[str, "JsonData"]
+JsonScalar: TypeAlias = Union[str, int, float, None]
+JsonData: TypeAlias = Union[JsonScalar, JsonObject, JsonArray]
 
-Subject = str
+# JSON types suitable as arguments, i.e. using abstract types that don't allow mutation.
+ArgJsonArray: TypeAlias = Sequence["ArgJsonData"]
+ArgJsonObject: TypeAlias = Mapping[str, "ArgJsonData"]
+ArgJsonData: TypeAlias = Union[JsonScalar, ArgJsonObject, ArgJsonArray]
 
-Version = Union[int, str]
-ResolvedVersion = int
+Subject: TypeAlias = str
 
-SchemaId = int
+Version: TypeAlias = Union[int, str]
+ResolvedVersion: TypeAlias = int
+
+SchemaId: TypeAlias = int


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

This introduces narrower type aliases to describe JSON-compatible dicts. Because we now have more accurate typing, in some places this reveals places where we are not properly dealing with all possible types that deserialized JSON can have. In order for this PR to not do too much in one go, I opted to introduce `TypedDict`s along with a mechanism to cast directly invocations of `json_decode()`. This reflects the same assumptions we make in runtime onto to our static typing.

We should consider introducing tooling to allow properly deserializing into rich Python types, such as Pydantic or Dacite.

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
