### PR TITLE
Add type hints to schema_backup

### DIFF
--- a/karapace/anonymize_schemas/anonymize_avro.py
+++ b/karapace/anonymize_schemas/anonymize_avro.py
@@ -5,6 +5,7 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from typing import Any, Dict, List, Union
+from typing_extensions import TypeAlias
 
 import hashlib
 import re
@@ -94,7 +95,7 @@ def anonymize_name(name: str) -> str:
     return NAME_ANONYMIZABLE_PATTERN.sub(anonymize_element, name)
 
 
-Schema = Union[str, Dict[str, Any], List[Any]]
+Schema: TypeAlias = Union[str, Dict[str, Any], List[Any]]
 
 
 def anonymize(input_schema: Schema) -> Schema:

--- a/karapace/key_format.py
+++ b/karapace/key_format.py
@@ -62,7 +62,7 @@ class KeyFormatter:
         keymode = keymode or self._keymode
         if keymode == KeyMode.DEPRECATED_KARAPACE:
             # No alterations
-            return json_encode(key, binary=True, sort_keys=False, compact=True)  # type: ignore[return-value]
+            return json_encode(key, binary=True, sort_keys=False, compact=True)
         corrected_key = {
             "keytype": key["keytype"],
         }
@@ -72,7 +72,7 @@ class KeyFormatter:
             corrected_key["version"] = key["version"]
         # Magic is the last element
         corrected_key["magic"] = key["magic"]
-        return json_encode(corrected_key, binary=True, sort_keys=False, compact=True)  # type: ignore[return-value]
+        return json_encode(corrected_key, binary=True, sort_keys=False, compact=True)
 
 
 def is_key_in_canonical_format(key: ArgJsonObject) -> bool:

--- a/karapace/master_coordinator.py
+++ b/karapace/master_coordinator.py
@@ -15,7 +15,7 @@ from karapace.typing import JsonData, JsonObject
 from karapace.utils import json_decode, json_encode, KarapaceKafkaClient
 from karapace.version import __version__
 from threading import Event, Thread
-from typing import Any, cast, Final, List, Optional, Sequence, Tuple
+from typing import Any, Final, List, Optional, Sequence, Tuple
 from typing_extensions import TypedDict
 
 import logging
@@ -231,12 +231,12 @@ class MasterCoordinator(Thread):
         self.sc = SchemaCoordinator(
             client=self.kafka_client,
             metrics=self._metrics,
-            hostname=cast(str, self.config["advertised_hostname"]),
-            port=cast(int, self.config["advertised_port"]),
-            scheme=cast(str, self.config["advertised_protocol"]),
-            master_eligibility=cast(bool, self.config["master_eligibility"]),
-            election_strategy=cast(str, self.config.get("master_election_strategy", "lowest")),
-            group_id=cast(str, self.config["group_id"]),
+            hostname=self.config["advertised_hostname"],
+            port=self.config["advertised_port"],
+            scheme=self.config["advertised_protocol"],
+            master_eligibility=self.config["master_eligibility"],
+            election_strategy=self.config.get("master_election_strategy", "lowest"),
+            group_id=self.config["group_id"],
             session_timeout_ms=session_timeout_ms,
             request_timeout_ms=max(session_timeout_ms, KafkaConsumer.DEFAULT_CONFIG["request_timeout_ms"]),
         )
@@ -246,7 +246,7 @@ class MasterCoordinator(Thread):
         generation = self.sc.generation() if self.sc is not None else None
         return SchemaCoordinatorStatus(
             is_primary=self.sc.are_we_master if self.sc is not None else None,
-            is_primary_eligible=cast(bool, self.config["master_eligibility"]),
+            is_primary_eligible=self.config["master_eligibility"],
             primary_url=self.sc.master_url if self.sc is not None else None,
             is_running=self.is_alive(),
             group_generation_id=generation.generation_id if generation is not None else -1,

--- a/karapace/messaging.py
+++ b/karapace/messaging.py
@@ -12,7 +12,7 @@ from karapace.key_format import KeyFormatter
 from karapace.offset_watcher import OffsetWatcher
 from karapace.utils import json_encode, KarapaceKafkaClient
 from karapace.version import __version__
-from typing import Any, cast, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Final, Optional, Union
 
 import logging
 import time
@@ -29,9 +29,7 @@ class KarapaceProducer:
         self._key_formatter = key_formatter
         self._kafka_timeout = 10
         self._schemas_topic = self._config["topic_name"]
-
-        host: str = cast(str, self._config["host"])
-        self.x_origin_host_header: Tuple[str, bytes] = ("X-Origin-Host", host.encode("utf8"))
+        self._x_origin_host_header: Final = ("X-Origin-Host", self._config["host"].encode())
 
     def initialize_karapace_producer(
         self,
@@ -74,7 +72,7 @@ class KarapaceProducer:
             self._schemas_topic,
             key=key,
             value=value,
-            headers=[X_REGISTRY_VERSION_HEADER, self.x_origin_host_header],
+            headers=[X_REGISTRY_VERSION_HEADER, self._x_origin_host_header],
         )
         self._producer.flush(timeout=self._kafka_timeout)
         try:

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -25,7 +25,7 @@ from karapace.offset_watcher import OffsetWatcher
 from karapace.schema_models import ParsedTypedSchema, SchemaType, SchemaVersion, TypedSchema, ValidatedTypedSchema
 from karapace.schema_reader import KafkaSchemaReader
 from karapace.typing import JsonObject, ResolvedVersion, Subject, Version
-from typing import cast, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import asyncio
 import logging
@@ -126,7 +126,7 @@ class KarapaceSchemaRegistry:
         compatibility = self.database.get_subject_compatibility(subject=subject)
         if compatibility is None:
             # If no subject compatiblity found, use global compatibility
-            compatibility = cast(str, self.config["compatibility"])
+            compatibility = self.config["compatibility"]
         try:
             compatibility_mode = CompatibilityModes(compatibility)
         except ValueError as e:

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -16,7 +16,7 @@ from http import HTTPStatus
 from kafka.client_async import BrokerConnection, KafkaClient
 from karapace.typing import ArgJsonData, JsonData
 from types import MappingProxyType
-from typing import AnyStr, cast, IO, NoReturn, overload, TypeVar
+from typing import AnyStr, cast, IO, Literal, NoReturn, overload, TypeVar
 
 import importlib
 import kafka.client_async
@@ -86,10 +86,9 @@ def default_json_serialization(
 def json_encode(
     obj: ArgJsonData,
     *,
-    binary: bool = False,
-    sort_keys: bool | None = None,
-    compact: bool | None = None,
-    indent: int | None = None,
+    sort_keys: bool | None = ...,
+    compact: bool | None = ...,
+    indent: int | None = ...,
 ) -> str:
     ...
 
@@ -98,10 +97,10 @@ def json_encode(
 def json_encode(
     obj: ArgJsonData,
     *,
-    binary: bool = True,
-    sort_keys: bool | None = None,
-    compact: bool | None = None,
-    indent: int | None = None,
+    binary: Literal[True] = ...,
+    sort_keys: bool | None = ...,
+    compact: bool | None = ...,
+    indent: int | None = ...,
 ) -> bytes:
     ...
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -162,6 +162,3 @@ ignore_errors = True
 
 [mypy-karapace.kafka_rest_apis.error_codes]
 ignore_errors = True
-
-[mypy-karapace.schema_backup]
-ignore_errors = True

--- a/tests/unit/test_schema_registry_api.py
+++ b/tests/unit/test_schema_registry_api.py
@@ -3,7 +3,7 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from aiohttp.test_utils import TestClient, TestServer
-from karapace.config import DEFAULTS
+from karapace.config import DEFAULTS, set_config_defaults
 from karapace.rapu import HTTPResponse
 from karapace.schema_registry_apis import KarapaceSchemaRegistryController
 from unittest.mock import ANY, Mock, patch, PropertyMock
@@ -36,7 +36,7 @@ async def test_forward_when_not_ready():
         schema_registry.close = close_func
         client_session.close = close_func
 
-        controller = KarapaceSchemaRegistryController(config=DEFAULTS)
+        controller = KarapaceSchemaRegistryController(config=set_config_defaults(DEFAULTS))
         mock_forward_func_future = asyncio.Future()
         mock_forward_func_future.set_exception(HTTPResponse({"mock": "response"}))
         mock_forward_func = Mock()


### PR DESCRIPTION
### About this change - What it does

- Add type hints to schema_backup.
- Add TypedDict to describe configuration.
- Fix non-functioning overload of json_encode.
- anonymize_avro_schema_message() is updated to adhere to the interface stipulated by SchemaBackup.create(), i.e. must accept None.