### PR TITLE
Bump dependencies to latest version of watchfiles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,7 @@ protobuf==3.19.5
 python-dateutil==2.8.2
 tenacity==8.0.1
 ujson==5.7.0
-
-# Using 0.15.0 until following issue gets fixed.
-# https://github.com/samuelcolvin/watchfiles/issues/200
-watchfiles==0.15.0
+watchfiles==0.19.0
 
 # Patched dependencies
 #


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
### About this change - What it does

The quoted issue has been fixed in [latest version of watchfiles](https://github.com/samuelcolvin/watchfiles/releases/tag/v0.19.0).
<!-- Provide a small sentence that summarizes the change. -->




<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
