### PR TITLE
chore: Add autoflake pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,15 @@ repos:
   - id: pyupgrade
     args: [ --py38-plus ]
 
+- repo: https://github.com/pycqa/autoflake
+  rev: v2.0.2
+  hooks:
+    - id: autoflake
+      args:
+        - --in-place
+        - --remove-all-unused-imports
+        - --ignore-init-module-imports
+
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0
   hooks:


### PR DESCRIPTION
### About this change - What it does

This automatically removes unused imports, providing auto-fix for some of the linters that come after (pylint, flake8).
<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

### Why this way

QoL, providing auto-fix for rule enforced by other linters.

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
