### PR TITLE
Add missing required module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ networkx==2.5
 protobuf==3.19.5
 python-dateutil==2.8.2
 tenacity==8.0.1
+typing_extensions==4.5.0
 ujson==5.7.0
 watchfiles==0.19.0
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

The `ghcr.io/aiven/karapace:develop` image is currently failing to start with the following error (for the REST api, but the same thing occurs for registry):

```
karapace-rest_1      | Traceback (most recent call last):
karapace-rest_1      |   File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
karapace-rest_1      |     return _run_code(code, main_globals, None,
karapace-rest_1      |   File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
karapace-rest_1      |     exec(code, run_globals)
karapace-rest_1      |   File "/usr/local/lib/python3.9/dist-packages/karapace/karapace_all.py", line 8, in <module>
karapace-rest_1      |     from karapace.config import read_config
karapace-rest_1      |   File "/usr/local/lib/python3.9/dist-packages/karapace/config.py", line 11, in <module>
karapace-rest_1      |     from karapace.utils import json_decode, json_encode, JSONDecodeError
karapace-rest_1      |   File "/usr/local/lib/python3.9/dist-packages/karapace/utils.py", line 17, in <module>
karapace-rest_1      |     from karapace.typing import ArgJsonData, JsonData
karapace-rest_1      |   File "/usr/local/lib/python3.9/dist-packages/karapace/typing.py", line 6, in <module>
karapace-rest_1      |     from typing_extensions import TypeAlias
karapace-rest_1      | ModuleNotFoundError: No module named 'typing_extensions'
```

Added the `typing_extensions` module pinned to `4.5.0`

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
