### PR TITLE
Simplify Dockerfile and narrow context 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,18 @@
-# Ignoring files that are specific to a given checkout, these change based on
-# the user commands and not on the repository history. They are not important
-# to determine the state of the repository and would invalidate the cache
-# layer.
-#
-# - .git/logs/HEAD - command history
-# - .git/index - binary file for the current index, very important for a
-#    working repository, not interesting for our image
-#
-.git/logs/HEAD
-.git/index
+# Ignore everything by default. Making as few files as possible part of default context
+# ensures only relevant changes will evict layer cache.
+*
+
+# Include source directories and files required for building.
+!karapace
+!requirements.txt
+!setup.py
+!version.py
+!README.rst
+!container/start.sh
+
+# Ignore some files in source directories.
+**/.DS_Store
+**/Thumbs.db
+**/*.pyc
+**/*.pyo
+**/__pycache__

--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Build karapace/version.py
+        run: python version.py
+
       - name: Build and start services
         run: docker compose --file=container/compose.yml up --build --wait --detach
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,16 @@ repos:
   - id: mypy
     pass_filenames: false
 
+- repo: https://github.com/hadolint/hadolint
+  rev: v2.12.0
+  hooks:
+  - id: hadolint-docker
+    alias: hadolint
+    args:
+    # This rule has false positives when using a mounted cache volume.
+    # https://github.com/hadolint/hadolint/issues/497
+    - --ignore=DL3042
+
 - repo: https://github.com/PyCQA/pylint
   # Note: pre-commit autoupdate changes to an alpha version. Instead, manually find the
   # latest stable version here: https://github.com/pylint-dev/pylint/releases

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,76 +1,38 @@
-# Builder image contains header files and additional dependencies necessary to
-# generate wheel files.
-FROM debian:stable-slim AS builder
+# Current versions of avro and zstandard don't yet have wheels for 3.11.
+FROM python:3.10.11-bullseye AS builder
 
 ARG KARAPACE_VERSION
 
-ARG KARAPACE_VERSION
-ARG PYTHON_VERSION="3.9.2-3"
-ARG PIP_VERSION="20.3.4-4+deb11u1"
-ARG SETUPTOOLS_VERSION="52.0.0-4"
-ARG WHEEL_VERSION="0.34.2-1"
-ARG GCC_VERSION="4:10.2.1-1"
+# Create, activate, and enforce usage of virtualenv.
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+ENV PIP_REQUIRE_VIRTUALENV=true
 
-# Build dependencies that need to be installed:
-# - python3-devel: Python .h files, used to compile C extensions (e.g. multidict)
-#
-# Build dependencies that need to be installed because of `--no-install-recommends`:
-# - gcc: g++ and gcc to compile C extensions
-# - python3-wheel: Library to generate .whl files
-# - python3-setuptools: Packaging library
-#
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update \
- && apt-get -y install --no-install-recommends \
-      python3-dev=$PYTHON_VERSION \
-      python3-pip=$PIP_VERSION \
-      python3-setuptools=$SETUPTOOLS_VERSION \
-      python3-wheel=$WHEEL_VERSION \
-      gcc=$GCC_VERSION
-
-# Copy the requirements.txt and generate wheels for each dependency. Using a
-# separate command to use layer caching.
+# Copy the requirements.txt and install dependencies in venv. Using a separate
+# command to use layer caching.
 #
 # Note: the requirements.txt is pinned, if any of the dependencies is updated
 # the cache will be invalidated and the image regenerated, which is the
 # intended behavior.
-#
 COPY ./requirements/requirements.txt /build/
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 wheel --requirement /build/requirements.txt --wheel-dir /build/dependencies-wheels
+    python3 -m pip install -r /build/requirements.txt
 
 COPY . /build/karapace-repo
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 wheel --no-deps /build/karapace-repo --wheel-dir /build/karapace-wheel
+    python3 -m pip install /build/karapace-repo
 
 # Karapace image.
-FROM debian:stable-slim AS karapace
+FROM python:3.10.11-slim-bullseye AS karapace
 
 RUN groupadd --system karapace \
  && useradd --system --gid karapace karapace \
  && mkdir /opt/karapace /opt/karapace/runtime /var/log/karapace \
  && chown --recursive karapace:karapace /opt/karapace /var/log/karapace
 
-ARG PROTOBUF_COMPILER_VERSION="3.12.4-1"
-ARG PIP_VERSION="20.3.4-4+deb11u1"
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update \
- && apt-get -y install --no-install-recommends \
-       python3-pip=$PIP_VERSION \
-       protobuf-compiler=$PROTOBUF_COMPILER_VERSION
-
-COPY --from=builder /build/dependencies-wheels/*.whl /build/dependencies-wheels/
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install --no-deps /build/dependencies-wheels/*.whl \
- && rm -rf /build/dependencies-wheels/
-
-COPY --from=builder /build/karapace-wheel/*.whl /build/karapace-wheel/
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install --no-deps /build/karapace-wheel/*.whl \
- && rm -rf /build/karapace-wheel/
+# Copy virtualenv from builder and activate it.
+COPY --from=builder /venv /venv
+ENV PATH="/venv/bin:$PATH"
 
 COPY ./container/start.sh /opt/karapace
 RUN chmod 500 /opt/karapace/start.sh \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -4,9 +4,14 @@ FROM debian:stable-slim AS builder
 
 ARG KARAPACE_VERSION
 
+ARG KARAPACE_VERSION
+ARG PYTHON_VERSION="3.9.2-3"
+ARG PIP_VERSION="20.3.4-4+deb11u1"
+ARG SETUPTOOLS_VERSION="52.0.0-4"
+ARG WHEEL_VERSION="0.34.2-1"
+ARG GCC_VERSION="4:10.2.1-1"
+
 # Build dependencies that need to be installed:
-# - git: Used to install dependencies directly from their public repos (release
-#   not on PyPI).
 # - python3-devel: Python .h files, used to compile C extensions (e.g. multidict)
 #
 # Build dependencies that need to be installed because of `--no-install-recommends`:
@@ -14,9 +19,15 @@ ARG KARAPACE_VERSION
 # - python3-wheel: Library to generate .whl files
 # - python3-setuptools: Packaging library
 #
-RUN apt-get update && \
-    apt-get -y install --no-install-recommends git python3-dev python3-pip python3-setuptools python3-wheel gcc && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+ && apt-get -y install --no-install-recommends \
+      python3-dev=$PYTHON_VERSION \
+      python3-pip=$PIP_VERSION \
+      python3-setuptools=$SETUPTOOLS_VERSION \
+      python3-wheel=$WHEEL_VERSION \
+      gcc=$GCC_VERSION
 
 # Copy the requirements.txt and generate wheels for each dependency. Using a
 # separate command to use layer caching.
@@ -26,31 +37,44 @@ RUN apt-get update && \
 # intended behavior.
 #
 COPY ./requirements/requirements.txt /build/
-RUN pip3 wheel --requirement /build/requirements.txt --wheel-dir /build/dependencies-wheels
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 wheel --requirement /build/requirements.txt --wheel-dir /build/dependencies-wheels
 
 COPY . /build/karapace-repo
-RUN pip3 wheel --no-deps /build/karapace-repo --wheel-dir /build/karapace-wheel
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 wheel --no-deps /build/karapace-repo --wheel-dir /build/karapace-wheel
 
 # Karapace image.
 FROM debian:stable-slim AS karapace
 
-RUN groupadd --system karapace && \
-    useradd --system --gid karapace karapace && \
-    mkdir /opt/karapace /opt/karapace/runtime /var/log/karapace && \
-    chown --recursive karapace:karapace /opt/karapace /var/log/karapace
+RUN groupadd --system karapace \
+ && useradd --system --gid karapace karapace \
+ && mkdir /opt/karapace /opt/karapace/runtime /var/log/karapace \
+ && chown --recursive karapace:karapace /opt/karapace /var/log/karapace
 
-RUN apt-get update && \
-    apt-get -y install --no-install-recommends python3-pip protobuf-compiler && \
-    rm -rf /var/lib/apt/lists/*
+ARG PROTOBUF_COMPILER_VERSION="3.12.4-1"
+ARG PIP_VERSION="20.3.4-4+deb11u1"
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+ && apt-get -y install --no-install-recommends \
+       python3-pip=$PIP_VERSION \
+       protobuf-compiler=$PROTOBUF_COMPILER_VERSION
 
 COPY --from=builder /build/dependencies-wheels/*.whl /build/dependencies-wheels/
-RUN pip3 install --no-deps /build/dependencies-wheels/*.whl && rm -rf /build/dependencies-wheels/
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --no-deps /build/dependencies-wheels/*.whl \
+ && rm -rf /build/dependencies-wheels/
 
 COPY --from=builder /build/karapace-wheel/*.whl /build/karapace-wheel/
-RUN pip3 install --no-deps /build/karapace-wheel/*.whl && rm -rf /build/karapace-wheel/
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --no-deps /build/karapace-wheel/*.whl \
+ && rm -rf /build/karapace-wheel/
 
 COPY ./container/start.sh /opt/karapace
-RUN chmod 500 /opt/karapace/start.sh && chown karapace:karapace /opt/karapace/start.sh
+RUN chmod 500 /opt/karapace/start.sh \
+ && chown karapace:karapace /opt/karapace/start.sh
 
 COPY ./container/healthcheck.py /opt/karapace
 

--- a/container/start.sh
+++ b/container/start.sh
@@ -35,7 +35,7 @@ registry)
     [[ -n ${KARAPACE_REGISTRY_PORT+isset} ]] && export KARAPACE_PORT="${KARAPACE_REGISTRY_PORT}"
     [[ -n ${KARAPACE_REGISTRY_CLIENT_ID+isset} ]] && export KARAPACE_CLIENT_ID="${KARAPACE_REGISTRY_CLIENT_ID}"
     [[ -n ${KARAPACE_REGISTRY_GROUP_ID+isset} ]] && export KARAPACE_GROUP_ID="${KARAPACE_REGISTRY_GROUP_ID}"
-    # Map misspelt environment variable to correct spelling for backwards compatibility.
+    # Map misspelled environment variables to correct spelling for backwards compatibility.
     [[ -n ${KARAPACE_REGISTRY_MASTER_ELIGIBITY+isset} ]] && export KARAPACE_MASTER_ELIGIBILITY="${KARAPACE_REGISTRY_MASTER_ELIGIBITY}"
     [[ -n ${KARAPACE_REGISTRY_MASTER_ELIGIBILITY+isset} ]] && export KARAPACE_MASTER_ELIGIBILITY="${KARAPACE_REGISTRY_MASTER_ELIGIBILITY}"
     [[ -n ${KARAPACE_REGISTRY_TOPIC_NAME+isset} ]] && export KARAPACE_TOPIC_NAME="${KARAPACE_REGISTRY_TOPIC_NAME}"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ readme_path = os.path.join(os.path.dirname(__file__), "README.rst")
 with open(readme_path, encoding="utf8") as fp:
     readme_text = fp.read()
 
-version_for_setup_py = version.get_project_version("karapace/version.py")
+version_for_setup_py = version.get_project_version()
 version_for_setup_py = ".dev".join(version_for_setup_py.split("-", 2)[:2])
 
 setup(


### PR DESCRIPTION
### About this change - What it does

- Move to using Python base images for builder and final stage. This allows omitting installation of some build tools. It also allows moving to a more recent Python version, no longer being bound by what's in distro repositories. Wheel availability of some of our Python dependencies prevents us from moving to 3.11 for now.
- Change installation approach to construct a virtualenv in the builder step, and copying it unaltered to the final stage, with dependencies and Karapace itself installed in it. This allows having even fewer layers in the final stage, and is simpler.
- Introduces a _much_ stricter .dockerignore, ignoring files by default and explicitly including what's required. This makes sure changes in unrelated files does not evict layer cache. For example, a few files that previously erroneously evicted caches, because everything was included:
  - `.git/*`
  - `.mypy_cache/*`
  - `container/Dockerfile` itself
  - `__pycache__/*`
  - `.idea/*`

Image size remains the about the same as previously, but slightly reduced (the `karapace-dev` tag is the new version):

```sh
$ docker image ls
REPOSITORY                           TAG               IMAGE ID       CREATED          SIZE
karapace-dev                         latest            b31c7d811294   10 seconds ago   194MB
ghcr.io/aiven/karapace               develop           b8366c494bec   5 days ago       204MB
ghcr.io/aiven/karapace               latest            ef8485cb1181   3 weeks ago      203MB
```