### PR TITLE
fix: Incorrect package-ecosystem value for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: pip-compile
+  - package-ecosystem: pip
     directory: requirements
     schedule:
       interval: daily


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
### About this change - What it does

Interestingly, this did not fail on the PR that introduced it, but started failing here: https://github.com/aiven/karapace/pull/583/checks?check_run_id=13200070246

Here's the relevant documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem