### PR TITLE
fix: Make smoke-tests retry on failure

### DIFF
--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -18,20 +18,7 @@ jobs:
         run: docker compose --file=container/compose.yml up --build --wait --detach
 
       - name: Smoke test registry
-        run: |
-          response=$(
-            curl --silent --verbose --fail --request POST \
-              --header 'Content-Type: application/vnd.schemaregistry.v1+json' \
-              --data '{"schema": "{\"type\": \"record\", \"name\": \"Obj\", \"fields\":[{\"name\": \"age\", \"type\": \"int\"}]}"}' \
-              http://localhost:8081/subjects/test-key/versions
-          )
-          echo "$response"
-          [[ $response == '{"id":1}' ]] || exit 1
-          echo "Ok!"
+        run: bin/smoke-test-registry.sh
 
       - name: Smoke test REST proxy
-        run: |
-          response=$(curl --silent --verbose --fail http://localhost:8082/topics)
-          echo "$response"
-          [[ $response == '["_schemas","__consumer_offsets"]' ]] || exit 1
-          echo "Ok!"
+        run: bin/smoke-test-rest.sh

--- a/bin/smoke-test-registry.sh
+++ b/bin/smoke-test-registry.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+retries=5
+
+for ((i = 0; i <= retries; i++)); do
+    response=$(
+        curl --silent --verbose --fail --request POST \
+            --header 'Content-Type: application/vnd.schemaregistry.v1+json' \
+            --data '{"schema": "{\"type\": \"record\", \"name\": \"Obj\", \"fields\":[{\"name\": \"age\", \"type\": \"int\"}]}"}' \
+            http://localhost:8081/subjects/test-key/versions
+    )
+
+    if [[ $response == '{"id":1}' ]]; then
+        echo "Ok!"
+        break
+    fi
+
+    if ((i == retries)); then
+        echo "Still failing after $i retries, giving up."
+        exit 1
+    fi
+
+    echo "Smoke test failed, retrying in 5 seconds ..."
+    sleep 5
+done

--- a/bin/smoke-test-rest.sh
+++ b/bin/smoke-test-rest.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+retries=5
+
+for ((i = 0; i <= retries; i++)); do
+    response=$(curl --silent --verbose --fail http://localhost:8082/topics)
+
+    if [[ $response == '["_schemas","__consumer_offsets"]' ]]; then
+        echo "Ok!"
+        break
+    fi
+
+    if ((i == retries)); then
+        echo "Still failing after $i retries, giving up."
+        exit 1
+    fi
+
+    echo "Smoke test failed, retrying in 5 seconds ..."
+    sleep 5
+done


### PR DESCRIPTION
### Why this way

The newly introduced smoke-test is seemingly flaky, with `HTTP 503` responses from Karapace. This PR introduces retries on failures.

I first attempted to introduce waiting for Kafka to listen, using netcat, as well as waiting for schema registry to respond with `"schema_registry_ready": true` in `/_health`, but saw `503` after both of these. So retrying seems like a more viable solution.

Here's an example of a failing build: https://github.com/aiven/karapace/actions/runs/4872294084/jobs/8690298720?pr=578