### PR TITLE
Improve references support

### DIFF
--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -93,7 +93,7 @@ class TypedSchema:
             schema_type (SchemaType): The type of the schema
             schema_str (str): The original schema string
             schema (Optional[Union[Draft7Validator, AvroSchema, ProtobufSchema]]): The parsed and validated schema
-             references (Optional[List[Dependency]]): The references of schema
+            references (Optional[List[Dependency]]): The references of schema
         """
         self.schema_type = schema_type
         self.references = references
@@ -118,8 +118,6 @@ class TypedSchema:
         schema_str: str,
         schema_type: SchemaType,
         schema: Optional[Union[Draft7Validator, AvroSchema, ProtobufSchema]] = None,
-        # references: Optional[List[Reference]] = None,
-        # dependencies: Optional[Dict[str, Dependency]] = None,
     ) -> str:
         if schema_type is SchemaType.AVRO or schema_type is SchemaType.JSONSCHEMA:
             try:

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -101,7 +101,6 @@ class TypedSchema:
         self.schema_str = TypedSchema.normalize_schema_str(schema_str, schema_type, schema)
         self.max_id: Optional[SchemaId] = None
         self._fingerprint_cached: Optional[str] = None
-        self._str_cached: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         if self.schema_type is SchemaType.PROTOBUF:
@@ -140,12 +139,7 @@ class TypedSchema:
         return schema_str
 
     def __str__(self) -> str:
-        if self.schema_type == SchemaType.PROTOBUF:
-            return self.schema_str
-
-        if self._str_cached is None:
-            self._str_cached = json_encode(self.to_dict())
-        return self._str_cached
+        return self.schema_str
 
     def __repr__(self) -> str:
         return f"TypedSchema(type={self.schema_type}, schema={str(self)})"

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,16 +17,10 @@ strict_equality = True
 [mypy-karapace.schema_registry_apis]
 ignore_errors = True
 
-[mypy-karapace.version]
-ignore_errors = True
-
 [mypy-karapace.compatibility.jsonschema.checks]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 warn_unused_ignores = False
-
-[mypy-karapace.constants]
-ignore_errors = True
 
 [mypy-karapace.karapace_all]
 ignore_errors = True
@@ -131,7 +125,4 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-karapace.kafka_rest_apis.admin]
-ignore_errors = True
-
-[mypy-karapace.kafka_rest_apis.error_codes]
 ignore_errors = True

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -975,6 +975,10 @@ async def test_references(testcase: ReferenceTestCase, registry_async_client: Cl
                 schema_id = res.json().get("id")
                 fetch_schema_res = await registry_async_client.get(f"/schemas/ids/{schema_id}")
                 assert fetch_schema_res.status_code == 200
+                if testdata.references:
+                    assert "references" in fetch_schema_res.json()
+                else:
+                    assert "references" not in fetch_schema_res.json()
         if isinstance(testdata, TestCaseDeleteSchema):
             if testdata.expected == 200:
                 fetch_res = await registry_async_client.get(f"/subjects/{testdata.subject}/versions/{testdata.version}")


### PR DESCRIPTION
# About this change - What it does

* Include references in responses
* Add support to latest version with references

Both are to better support `references` feature implemented in #560 but missing parts of full references support.

# Why this way

Schema fetch and list operations should contain references if any in the response.

Registering a schema with a reference to version -1 is a reference to latest version of referenced schema.

Also minor cleanups, including eliminating of cached string representation of non-protobuf schemas, which should not have been changed with #560.