### PR TITLE
chore: Set --showlocals in CI env instead of global

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,11 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+    env:
+      PYTEST_ADDOPTS: >-
+        --log-dir=/tmp/ci-logs
+        --log-file=/tmp/ci-logs/pytest.log
+        --showlocals
     steps:
     - uses: actions/checkout@v3
 
@@ -33,8 +38,6 @@ jobs:
     - run: make install version
     - run: make unit-tests
     - run: make integration-tests
-      env:
-        PYTEST_ARGS: --log-dir=/tmp/ci-logs --log-file=/tmp/ci-logs/pytest.log
 
     - name: Archive logs
       uses: actions/upload-artifact@v3

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -ra -q --tb=short --showlocals --numprocesses auto --import-mode=importlib
+addopts = -ra -q --tb=short --numprocesses auto --import-mode=importlib
 timeout = 60
 timeout_func_only = true


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
### About this change - What it does

Set `--showlocals` via `PYTEST_ADDOPTS` in CI, instead of setting globally in `pytest.ini`.
<!-- Provide a small sentence that summarizes the change. -->

### Why this way

`--showlocals` is very verbose, and cannot be disabled without editing `pytest.ini` currently. To allow disabling it locally, while keeping it enabled in CI, it's moved from `pytest.ini` to an env var in CI. It can still easily be enabled on dev machines, either by passing `--showlocals`, or by setting `export PYTEST_ADDOPTS=--showlocals` (and this can be made ergonomic by using a tool like direnv).
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
