### PR TITLE
fix: do not override SASL mechanism for user REST proxy

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -284,7 +284,8 @@ class KafkaRest(KarapaceBase):
                         config["security_protocol"] = (
                             "SASL_SSL" if config["security_protocol"] in ("SSL", "SASL_SSL") else "SASL_PLAINTEXT"
                         )
-                        config["sasl_mechanism"] = "PLAIN"
+                        if config["sasl_mechanism"] is None:
+                            config["sasl_mechanism"] = "PLAIN"
                         config["sasl_plain_username"] = auth.login
                         config["sasl_plain_password"] = auth.password
                         self.proxies[key] = UserRestProxy(config, self.kafka_timeout, self.serializer)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
If `sasl_mechanism` already defined in the config - do not override it with `PLAIN`.
Our Kafka installation allows SCRAM authentication only, so current code leads to failed authentication. Preferred mechanism already stated in the config, so let's use it for the user proxy.

# Why this way
`config["sasl_mechanism"]` default value is `None`, so let's check for it. I'm not sure if we can remove this line completely and rely on that undefined SASL mechanism often means `PLAIN`. This is the most safe patch - keeping existing behavior.