### PR TITLE
Change Dependabot schedule to monthly from daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: pip
     directory: requirements
     schedule:
-      interval: daily
+      interval: monthly


### PR DESCRIPTION
# About this change - What it does

Change Dependabot schedule to monthly from daily

# Why this way

It is too noisy with daily updates. No need for such frequent updates.