### PR TITLE
feat: Add REST producer max request size config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -366,6 +366,10 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
      - ``0``
      - Time to wait for grouping together requests.
        More on `Kafka Producer <https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html>`_
+   * - ``producer_max_request_size``
+     - ``1048576``
+     - The maximum size of a request in bytes.
+       More on `Kafka Producer configs <https://kafka.apache.org/documentation/#producerconfigs_max.request.size>`_
    * - ``security_protocol``
      - ``PLAINTEXT``
      - Default Kafka security protocol needed to communicate with the Kafka

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -69,6 +69,7 @@ class Config(TypedDict):
     producer_compression_type: str | None
     producer_count: int
     producer_linger_ms: int
+    producer_max_request_size: int
     session_timeout_ms: int
     karapace_rest: bool
     karapace_registry: bool
@@ -132,6 +133,7 @@ DEFAULTS: ConfigDefaults = {
     "producer_compression_type": None,
     "producer_count": 5,
     "producer_linger_ms": 100,
+    "producer_max_request_size": 1048576,
     "session_timeout_ms": 10000,
     "karapace_rest": False,
     "karapace_registry": False,

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -459,17 +459,18 @@ class UserRestProxy:
 
                 # Don't retry if instantiating the producer fails, likely a configuration error.
                 producer = AIOKafkaProducer(
+                    acks=acks,
                     bootstrap_servers=self.config["bootstrap_uri"],
+                    compression_type=self.config["producer_compression_type"],
+                    connections_max_idle_ms=self.config["connections_max_idle_ms"],
+                    linger_ms=self.config["producer_linger_ms"],
+                    max_request_size=self.config["producer_max_request_size"],
+                    metadata_max_age_ms=self.config["metadata_max_age_ms"],
                     security_protocol=self.config["security_protocol"],
                     ssl_context=ssl_context,
                     sasl_mechanism=self.config["sasl_mechanism"],
                     sasl_plain_username=self.config["sasl_plain_username"],
                     sasl_plain_password=self.config["sasl_plain_password"],
-                    metadata_max_age_ms=self.config["metadata_max_age_ms"],
-                    acks=acks,
-                    compression_type=self.config["producer_compression_type"],
-                    linger_ms=self.config["producer_linger_ms"],
-                    connections_max_idle_ms=self.config["connections_max_idle_ms"],
                 )
 
                 try:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,6 +50,8 @@ KAFKA_SCALA_VERSION = "2.13"
 KAFKA_LOG4J = TEST_INTEGRATION_DIR / "config" / "log4j.properties"
 WORKER_COUNTER_KEY = "worker_counter"
 
+REST_PRODUCER_MAX_REQUEST_BYTES = 10240
+
 
 def _clear_test_name(name: str) -> str:
     # Based on:
@@ -231,7 +233,14 @@ async def fixture_rest_async(
 
     config_path = tmp_path / "karapace_config.json"
 
-    config = set_config_defaults({"bootstrap_uri": kafka_servers.bootstrap_servers, "admin_metadata_max_age": 2})
+    config = set_config_defaults(
+        {
+            "admin_metadata_max_age": 2,
+            "bootstrap_uri": kafka_servers.bootstrap_servers,
+            # Use non-default max request size for REST producer.
+            "producer_max_request_size": REST_PRODUCER_MAX_REQUEST_BYTES,
+        }
+    )
     write_config(config_path, config)
     rest = KafkaRest(config=config)
 


### PR DESCRIPTION
# About this change - What it does

The REST producer uses default maximum request size of 1048576 bytes. This is now defined explicitly and configuration file allows overriding the value.

