### PR TITLE
fix: Repair broken schema check

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        # Need fetch-depth 0 to fetch tags, see https://github.com/actions/checkout/issues/701
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -88,6 +88,6 @@ requirements:
 	cd requirements && pip-compile --upgrade --resolver=backtracking requirements-dev.in
 
 .PHONY: schema
-schema: against := main
+schema: against := origin/main
 schema:
 	python3 -m karapace.backup.backends.v3.schema_tool --against=$(against)

--- a/karapace/backup/backends/v3/schema_tool.py
+++ b/karapace/backup/backends/v3/schema_tool.py
@@ -61,7 +61,14 @@ def relative_path(path: pathlib.Path) -> pathlib.Path:
 def check_compatibility(git_target: str) -> None:
     errored = False
     found_any = False
-    subprocess.run(["git", "fetch"], check=True)
+
+    try:
+        remote, branch = git_target.split("/", 1)
+    except ValueError:
+        remote = "origin"
+        branch = git_target
+
+    subprocess.run(["git", "fetch", remote, branch], check=True, capture_output=True)
 
     for file in schema_directory.glob(f"*{extension}"):
         relative = relative_path(file)
@@ -92,7 +99,7 @@ def check_compatibility(git_target: str) -> None:
         if forwards_compat.compatibility is not SchemaCompatibilityType.compatible:
             errored = True
             print(
-                f"💥 Changes in {relative} breaks forwards compatibility with " f"{git_target}.",
+                f"💥 Changes in {relative} breaks forwards compatibility with {git_target}.",
                 file=sys.stderr,
             )
 
@@ -103,7 +110,7 @@ def check_compatibility(git_target: str) -> None:
         if backwards_compat.compatibility is not SchemaCompatibilityType.compatible:
             errored = True
             print(
-                f"💥 Changes in {relative} breaks backwards compatibility with " f"{git_target}.",
+                f"💥 Changes in {relative} breaks backwards compatibility with {git_target}.",
                 file=sys.stderr,
             )
 


### PR DESCRIPTION
### About this change - What it does

- Add fetch-depth 0 to CI job.
- Change logic to accept remote name and pull from it.
<!-- Provide a small sentence that summarizes the change. -->

### Why

Check is currently broken.

Note that this introduces an expectation on how remotes are named, i.e. it expects to be able pull `origin/main`. This seems like an acceptable trade-off to me, and the make target accepts this as a parameter, so one can override it by running `make schema against=upstream/main` locally, if one has named the remote “upstream”.