### PR TITLE
Handle message field compare with known types

### DIFF
--- a/karapace/protobuf/proto_type.py
+++ b/karapace/protobuf/proto_type.py
@@ -121,7 +121,7 @@ class ProtoType:
             else:
                 raise IllegalArgumentException(f"map key must be non-byte, non-floating point scalar: {key_type}")
 
-    def to_kind(self) -> Optional[OptionElement.Kind]:
+    def to_kind(self) -> OptionElement.Kind:
         return {
             "bool": OptionElement.Kind.BOOLEAN,
             "string": OptionElement.Kind.STRING,

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,9 +31,6 @@ ignore_errors = True
 [mypy-karapace.protobuf.io]
 ignore_errors = True
 
-[mypy-karapace.protobuf.field_element]
-ignore_errors = True
-
 [mypy-karapace.protobuf.proto_file_element]
 ignore_errors = True
 

--- a/tests/integration/test_dependencies_compatibility_protobuf.py
+++ b/tests/integration/test_dependencies_compatibility_protobuf.py
@@ -274,6 +274,142 @@ async def test_protobuf_schema_compatibility_dependencies1(registry_async_client
     assert res.json() == {"is_compatible": False}
 
 
+# Do compatibility check when message field is altered from referenced type to google type
+async def test_protobuf_schema_compatibility_dependencies1g(registry_async_client: Client) -> None:
+    subject = create_subject_name_factory("test_protobuf_schema_compatibility_dep1g")()
+    subject_container = create_subject_name_factory("test_protobuf_schema_compatibility_dep1g_container")()
+
+    res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "BACKWARD"})
+    assert res.status_code == 200
+
+    container = """
+syntax = "proto3";
+package a1;
+message container {
+    message H {
+        string s = 1;
+    }
+}
+"""
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_container}/versions", json={"schemaType": "PROTOBUF", "schema": container}
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+
+    original_schema = """
+syntax = "proto3";
+package a1;
+import "container.proto";
+message TestMessage {
+    message V {
+        .a1.container.H h = 1;
+        int32 x = 2;
+    }
+    string t = 1;
+    .a1.TestMessage.V v = 2;
+}
+"""
+
+    original_references = [{"name": "container.proto", "subject": subject_container, "version": 1}]
+    res = await registry_async_client.post(
+        f"subjects/{subject}/versions",
+        json={"schemaType": "PROTOBUF", "schema": original_schema, "references": original_references},
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+
+    evolved_schema = """
+syntax = "proto3";
+package a1;
+import "google/type/postal_address.proto";
+message TestMessage {
+    message V {
+        google.type.PostalAddress h = 1;
+        int32 x = 2;
+    }
+    string t = 1;
+    .a1.TestMessage.V v = 2;
+}
+"""
+
+    res = await registry_async_client.post(
+        f"compatibility/subjects/{subject}/versions/latest",
+        json={"schemaType": "PROTOBUF", "schema": evolved_schema},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"is_compatible": False}
+
+
+# Do compatibility check when message field is altered from google type to referenced type
+async def test_protobuf_schema_compatibility_dependencies1g_otherway(registry_async_client: Client) -> None:
+    subject = create_subject_name_factory("test_protobuf_schema_compatibility_dep1g_back")()
+    subject_container = create_subject_name_factory("test_protobuf_schema_compatibility_dep1g_back_container")()
+
+    res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "BACKWARD"})
+    assert res.status_code == 200
+
+    container = """
+syntax = "proto3";
+package a1;
+message container {
+    message H {
+        string s = 1;
+    }
+}
+"""
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_container}/versions", json={"schemaType": "PROTOBUF", "schema": container}
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+
+    original_schema = """
+syntax = "proto3";
+package a1;
+import "google/type/postal_address.proto";
+message TestMessage {
+    message V {
+        google.type.PostalAddress h = 1;
+        int32 x = 2;
+    }
+    string t = 1;
+    .a1.TestMessage.V v = 2;
+}
+"""
+
+    res = await registry_async_client.post(
+        f"subjects/{subject}/versions",
+        json={"schemaType": "PROTOBUF", "schema": original_schema},
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+
+    evolved_schema = """
+syntax = "proto3";
+package a1;
+import "container.proto";
+message TestMessage {
+    message V {
+        .a1.container.H h = 1;
+        int32 x = 2;
+    }
+    string t = 1;
+    .a1.TestMessage.V v = 2;
+}
+"""
+
+    container_references = [{"name": "container.proto", "subject": subject_container, "version": 1}]
+    res = await registry_async_client.post(
+        f"compatibility/subjects/{subject}/versions/latest",
+        json={"schemaType": "PROTOBUF", "schema": evolved_schema, "references": container_references},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"is_compatible": False}
+
+
 @pytest.mark.parametrize("trail", ["", "/"])
 async def test_protobuf_schema_compatibility_dependencies2(registry_async_client: Client, trail: str) -> None:
     subject = create_subject_name_factory(f"test_protobuf_schema_compatibility-{trail}")()
@@ -457,3 +593,79 @@ async def test_protobuf_references_latest(registry_async_client: Client) -> None
     )
     assert res.status_code == 200
     assert "id" in res.json()
+
+
+async def test_protobuf_customer_update_when_having_references(registry_async_client: Client) -> None:
+    subject_place = create_subject_name_factory("test_protobuf_place")()
+    subject_customer = create_subject_name_factory("test_protobuf_customer")()
+
+    place_proto = """\
+syntax = "proto3";
+package a1;
+message Place {
+        string city = 1;
+        int32 zone = 2;
+}
+"""
+
+    body = {"schemaType": "PROTOBUF", "schema": place_proto}
+    res = await registry_async_client.post(f"subjects/{subject_place}/versions", json=body)
+
+    assert res.status_code == 200
+
+    customer_proto = """\
+syntax = "proto3";
+package a1;
+import "place.proto";
+import "google/type/postal_address.proto";
+// @producer: another comment
+message Customer {
+        string name = 1;
+        int32 code = 2;
+        Place place = 3;
+        google.type.PostalAddress address = 4;
+}
+"""
+    body = {
+        "schemaType": "PROTOBUF",
+        "schema": customer_proto,
+        "references": [
+            {
+                "name": "place.proto",
+                "subject": subject_place,
+                "version": -1,
+            }
+        ],
+    }
+    res = await registry_async_client.post(f"subjects/{subject_customer}/versions", json=body)
+
+    assert res.status_code == 200
+
+    customer_proto_updated = """\
+syntax = "proto3";
+package a1;
+import "place.proto";
+import "google/type/postal_address.proto";
+// @consumer: the comment was incorrect, updating it now
+message Customer {
+        string name = 1;
+        int32 code = 2;
+        Place place = 3;
+        google.type.PostalAddress address = 4;
+}
+"""
+
+    body = {
+        "schemaType": "PROTOBUF",
+        "schema": customer_proto_updated,
+        "references": [
+            {
+                "name": "place.proto",
+                "subject": subject_place,
+                "version": -1,
+            }
+        ],
+    }
+    res = await registry_async_client.post(f"subjects/{subject_customer}/versions", json=body)
+
+    assert res.status_code == 200

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -1055,3 +1055,39 @@ message UsingGoogleTypesWithoutImport {
 
     myjson = res.json()
     assert myjson["error_code"] == 42201 and '"google.type.PostalAddress" is not defined' in myjson["message"]
+
+
+async def test_protobuf_customer_update(registry_async_client: Client) -> None:
+    subject = create_subject_name_factory("test_protobuf_customer_update")()
+
+    customer_proto = """\
+syntax = "proto3";
+package a1;
+import "google/type/postal_address.proto";
+// @consumer: the first comment
+message Customer {
+        string name = 1;
+        google.type.PostalAddress address = 2;
+}
+"""
+
+    body = {"schemaType": "PROTOBUF", "schema": customer_proto}
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json=body)
+
+    assert res.status_code == 200
+
+    customer_proto = """\
+syntax = "proto3";
+package a1;
+import "google/type/postal_address.proto";
+// @consumer: the comment was incorrect, updating it now
+message Customer {
+        string name = 1;
+        google.type.PostalAddress address = 2;
+}
+"""
+
+    body = {"schemaType": "PROTOBUF", "schema": customer_proto}
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json=body)
+
+    assert res.status_code == 200


### PR DESCRIPTION
# About this change - What it does

Hard-coded known types do not have message element linked similar to user defined messages.  Handle comparing of those fields without internal errors from exceptions.

Fixes #626

