### PR TITLE
chore: Add partial stubs for the isodate library

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+mypy_path = $MYPY_CONFIG_FILE_DIR/stubs
 python_version = 3.8
 packages = karapace
 show_error_codes = True
@@ -116,9 +117,6 @@ ignore_errors = True
 # - Write your own stubs. You don't need to write stubs for the whole library,
 #   only the parts that Karapace is interacting with.
 [mypy-kafka.*]
-ignore_missing_imports = True
-
-[mypy-isodate.*]
 ignore_missing_imports = True
 
 [mypy-networkx.*]

--- a/stubs/isodate/__init__.pyi
+++ b/stubs/isodate/__init__.pyi
@@ -1,0 +1,3 @@
+from isodate.isoduration import duration_isoformat, parse_duration
+
+__all__ = ("duration_isoformat", "parse_duration")

--- a/stubs/isodate/duration.pyi
+++ b/stubs/isodate/duration.pyi
@@ -1,0 +1,21 @@
+from decimal import Decimal
+
+import datetime
+
+class Duration:
+    months: Decimal
+    years: Decimal
+    tdelta: datetime.timedelta
+
+    def __init__(
+        self,
+        days: int = ...,
+        seconds: int = ...,
+        microseconds: int = ...,
+        milliseconds: int = ...,
+        minutes: int = ...,
+        hours: int = ...,
+        weeks: int = ...,
+        months: int = ...,
+        years: int = ...,
+    ) -> None: ...

--- a/stubs/isodate/isoduration.pyi
+++ b/stubs/isodate/isoduration.pyi
@@ -1,0 +1,18 @@
+from .duration import Duration
+from typing import Literal, overload
+
+import datetime
+
+@overload
+def parse_duration(
+    datestring: str,
+) -> datetime.timedelta | Duration: ...
+@overload
+def parse_duration(
+    datestring: str,
+    as_timedelta_if_possible: Literal[False],
+) -> Duration: ...
+def duration_isoformat(
+    tduration: Duration | datetime.timedelta,
+    format: str = ...,
+) -> str: ...

--- a/tests/unit/backup/test_poll_timeout.py
+++ b/tests/unit/backup/test_poll_timeout.py
@@ -12,9 +12,18 @@ import pytest
 class TestPollTimeout:
     @pytest.mark.parametrize("it", ("PT0.999S", timedelta(milliseconds=999)))
     def test_min_validation(self, it: Union[str, timedelta]) -> None:
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(
+            ValueError,
+            match=r"^Poll timeout must be at least one second, got: 0:00:00.999000$",
+        ):
             PollTimeout(it)
-        assert str(e.value) == "Poll timeout MUST be at least one second, got: PT0.999S"
+
+    def test_max_validation(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"^Poll timeout must be less than one year, got: 1 years, 0:00:00$",
+        ):
+            PollTimeout("P1Y")
 
     # Changing the default is not a breaking change, but the documentation needs to be adjusted!
     def test_default(self) -> None:


### PR DESCRIPTION
### About this change - What it does

Add partial stubs for the isodate library.

This revealed a surprising bug in `PollTimeout`, where we don't handle `parse_duration()` returning `isodate.duration.Duration`.

### Why this way

Increase type coverage.

This is potentially controversial as it only adds partial stubs for the isodate library. This means that the interactions we have currently will now be typed, which is an improvement. But it also means that if someone tries to introduce other valid interactions with the library, that aren't covered by the stubs, it will yield static type checker errors.

The "right" fix when that happens is to expand the partial stubs so that they also cover the new usage, but it's quite hard to make this discoverable, and teach that this is how to fix the issue.