### PR TITLE
fix: Reduce mutability in schema references

### DIFF
--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -18,7 +18,7 @@ from karapace.protobuf.proto_parser import ProtoParser
 from karapace.protobuf.type_element import TypeElement
 from karapace.protobuf.utils import append_documentation, append_indented
 from karapace.schema_references import Reference
-from typing import Dict, List, Optional
+from typing import Mapping, Optional, Sequence
 
 
 def add_slashes(text: str) -> str:
@@ -110,7 +110,10 @@ class ProtobufSchema:
     DEFAULT_LOCATION = Location("", "")
 
     def __init__(
-        self, schema: str, references: Optional[List[Reference]] = None, dependencies: Optional[Dict[str, Dependency]] = None
+        self,
+        schema: str,
+        references: Optional[Sequence[Reference]] = None,
+        dependencies: Optional[Mapping[str, Dependency]] = None,
     ) -> None:
         if type(schema).__name__ != "str":
             raise IllegalArgumentException("Non str type of schema string")

--- a/karapace/schema_references.py
+++ b/karapace/schema_references.py
@@ -7,9 +7,9 @@ See LICENSE for details
 
 from __future__ import annotations
 
+from karapace.dataclasses import default_dataclass
 from karapace.typing import JsonData, ResolvedVersion, SchemaId, Subject
 from typing import List, Mapping, NewType, TypeVar
-from typing_extensions import Self
 
 Referents = NewType("Referents", List[SchemaId])
 
@@ -28,16 +28,34 @@ def _read_typed(
     return value
 
 
+# Represents a reference with an alias to latest version, where the version has
+# not yet been determined. Representing this as a separate entity gives us nice
+# static type checking semantics, and means we cannot pass an unresolved object
+# where a resolved one is expected.
+@default_dataclass
+class LatestVersionReference:
+    name: str
+    subject: Subject
+
+    def resolve(self, version: ResolvedVersion) -> Reference:
+        return Reference(
+            name=self.name,
+            subject=self.subject,
+            version=version,
+        )
+
+
+@default_dataclass
 class Reference:
-    def __init__(
-        self,
-        name: str,
-        subject: Subject,
-        version: ResolvedVersion,
-    ) -> None:
-        self.name = name
-        self.subject = subject
-        self.version = version
+    name: str
+    subject: Subject
+    version: ResolvedVersion
+
+    def __post_init__(self) -> None:
+        assert self.version != -1
+
+    def __repr__(self) -> str:
+        return f"{{name='{self.name}', subject='{self.subject}', version={self.version}}}"
 
     def to_dict(self) -> JsonData:
         return {
@@ -46,21 +64,23 @@ class Reference:
             "version": self.version,
         }
 
-    @classmethod
-    def from_mapping(cls, data: Mapping[str, object]) -> Self:
-        return cls(
-            name=_read_typed(data, "name", str),
-            subject=Subject(_read_typed(data, "subject", str)),
-            version=ResolvedVersion(_read_typed(data, "version", int)),
+
+def reference_from_mapping(
+    data: Mapping[str, object],
+) -> Reference | LatestVersionReference:
+    name = _read_typed(data, "name", str)
+    subject = Subject(_read_typed(data, "subject", str))
+    version = _read_typed(data, "version", int)
+    return (
+        LatestVersionReference(
+            name=name,
+            subject=subject,
         )
-
-    def __repr__(self) -> str:
-        return f"{{name='{self.name}', subject='{self.subject}', version={self.version}}}"
-
-    def __hash__(self) -> int:
-        return hash((self.name, self.subject, self.version))
-
-    def __eq__(self, other: object) -> bool:
-        if other is None or not isinstance(other, Reference):
-            return False
-        return self.name == other.name and self.subject == other.subject and self.version == other.version
+        # -1 is alias to latest version
+        if version == -1
+        else Reference(
+            name=name,
+            subject=subject,
+            version=ResolvedVersion(version),
+        )
+    )

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -32,7 +32,7 @@ from karapace.karapace import KarapaceBase
 from karapace.protobuf.exception import ProtobufUnresolvedDependencyException
 from karapace.rapu import HTTPRequest, JSON_CONTENT_TYPE, SERVER_NAME
 from karapace.schema_models import ParsedTypedSchema, SchemaType, SchemaVersion, TypedSchema, ValidatedTypedSchema
-from karapace.schema_references import Reference
+from karapace.schema_references import LatestVersionReference, Reference, reference_from_mapping
 from karapace.schema_registry import KarapaceSchemaRegistry, validate_version
 from karapace.typing import JsonData, JsonObject, ResolvedVersion, SchemaId
 from karapace.utils import JSONDecodeError
@@ -77,13 +77,6 @@ class SchemaErrorMessages(Enum):
     )
     SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_FMT = "Subject '%s' does not have subject-level compatibility configured"
     REFERENCES_SUPPORT_NOT_IMPLEMENTED = "Schema references are not supported for '{schema_type}' schema type"
-
-
-def references_list(references: dict | None) -> list[Reference] | None:
-    _references: list[Reference] | None = None
-    if references:
-        _references = [Reference(reference["name"], reference["subject"], reference["version"]) for reference in references]
-    return _references
 
 
 class KarapaceSchemaRegistryController(KarapaceBase):
@@ -368,7 +361,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         schema_type = self._validate_schema_type(content_type=content_type, data=body)
         references = self._validate_references(content_type, schema_type, body)
         try:
-            new_schema_dependencies = self.schema_registry.resolve_references(references)
+            references, new_schema_dependencies = self.schema_registry.resolve_references(references)
             new_schema = ValidatedTypedSchema.parse(
                 schema_type=schema_type,
                 schema_str=body["schema"],
@@ -402,7 +395,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
             old_references = old.get("references", None)
             old_dependencies = None
             if old_references:
-                old_dependencies = self.schema_registry.resolve_references(old_references)
+                old_references, old_dependencies = self.schema_registry.resolve_references(old_references)
             old_schema = ParsedTypedSchema.parse(old_schema_type, old["schema"], old_references, old_dependencies)
         except InvalidSchema:
             self.r(
@@ -996,7 +989,12 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-    def _validate_references(self, content_type: str, schema_type: SchemaType, body: JsonData) -> list[Reference] | None:
+    def _validate_references(
+        self,
+        content_type: str,
+        schema_type: SchemaType,
+        body: JsonData,
+    ) -> list[Reference | LatestVersionReference] | None:
         references = body.get("references", [])
         # Allow passing `null` as value for compatibility
         if references is None:
@@ -1023,12 +1021,12 @@ class KarapaceSchemaRegistryController(KarapaceBase):
             )
 
         validated_references = []
-        for reference in references:
-            if ["name", "subject", "version"] != sorted(reference.keys()):
-                raise InvalidReferences()
-            validated_references.append(
-                Reference(name=reference["name"], subject=reference["subject"], version=reference["version"])
-            )
+        for reference_data in references:
+            try:
+                reference = reference_from_mapping(reference_data)
+            except (TypeError, KeyError) as exc:
+                raise InvalidReferences from exc
+            validated_references.append(reference)
         if validated_references:
             return validated_references
         return None
@@ -1065,7 +1063,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         schema_str = body["schema"]
         schema_type = self._validate_schema_type(content_type=content_type, data=body)
         references = self._validate_references(content_type, schema_type, body)
-        new_schema_dependencies = self.schema_registry.resolve_references(references)
+        references, new_schema_dependencies = self.schema_registry.resolve_references(references)
         try:
             # When checking if schema is already registered, allow unvalidated schema in as
             # there might be stored schemas that are non-compliant from the past.
@@ -1159,7 +1157,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         references = self._validate_references(content_type, schema_type, body)
 
         try:
-            resolved_dependencies = self.schema_registry.resolve_references(references)
+            references, resolved_dependencies = self.schema_registry.resolve_references(references)
             new_schema = ValidatedTypedSchema.parse(
                 schema_type=schema_type,
                 schema_str=body["schema"],

--- a/tests/unit/test_protobuf_serialization.py
+++ b/tests/unit/test_protobuf_serialization.py
@@ -97,7 +97,7 @@ async def test_happy_flow_references(default_config_path):
         {"query": 10, "speed": {"speed": "MIDDLE"}},
     ]
 
-    references = [Reference("Speed.proto", "speed", 1)]
+    references = [Reference(name="Speed.proto", subject="speed", version=1)]
 
     no_ref_schema = ParsedTypedSchema.parse(SchemaType.PROTOBUF, no_ref_schema_str)
     dep = Dependency("Speed.proto", "speed", 1, no_ref_schema)
@@ -179,8 +179,8 @@ async def test_happy_flow_references_two(default_config_path):
         {"index": 2, "qry": {"query": 10, "speed": {"speed": "HIGH"}}},
     ]
 
-    references = [Reference("Speed.proto", "speed", 1)]
-    references_two = [Reference("Query.proto", "msg", 1)]
+    references = [Reference(name="Speed.proto", subject="speed", version=1)]
+    references_two = [Reference(name="Query.proto", subject="msg", version=1)]
 
     no_ref_schema = ParsedTypedSchema.parse(SchemaType.PROTOBUF, no_ref_schema_str)
     dep = Dependency("Speed.proto", "speed", 1, no_ref_schema)


### PR DESCRIPTION
### About this change - What it does

First off, this fixes the issue that `Reference` objects were mutated while acting as immutable by implementing `__hash__()`. To do that, it breaks up the `Reference` class into two, so that instead of it having two overloaded meanings, the unresolved state is instead represented as its own entity, `LatestVersionReference`. A `LatestVersionReference` can be converted to a `Reference` by providing a version to its `.resolve()` method. This is a typical "make illegal states unrepresentable" kind of refactoring.
    
Related to this, a few `list` and `dict`s are replaced with their immutable abstract counterparts, `Sequence` and `Mapping`. This greatly helps in reasoning about where mutation can happen, and stops me from constantly wondering "will this list be altered when I pass this down this chain of methods".

<!-- Provide the issue number below if it exists. -->
Fixes #640.