### PR TITLE
fix: Broken backup handling of empty topics

### DIFF
--- a/karapace/backup/api.py
+++ b/karapace/backup/api.py
@@ -459,7 +459,9 @@ def create_backup(
         )
         with _admin(config) as admin:
             topic_configurations = get_topic_configurations(
-                admin=admin, topic_name=topic_name, config_source_filter={ConfigSource.TOPIC_CONFIG}
+                admin=admin,
+                topic_name=topic_name,
+                config_source_filter={ConfigSource.TOPIC_CONFIG},
             )
 
         # Note: It's expected that we at some point want to introduce handling of

--- a/karapace/backup/backends/v3/schema.py
+++ b/karapace/backup/backends/v3/schema.py
@@ -60,7 +60,7 @@ class Metadata(AvroModel):
     checksum_algorithm: ChecksumAlgorithm = ChecksumAlgorithm.unknown
 
     def __post_init__(self) -> None:
-        assert len(self.data_files) == self.partition_count
+        assert len(self.data_files) <= self.partition_count
         assert self.topic_name
         assert self.finished_at >= self.started_at
         assert self.partition_count == 1

--- a/tests/integration/utils/kafka_server.py
+++ b/tests/integration/utils/kafka_server.py
@@ -3,7 +3,7 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from dataclasses import dataclass
-from kafka.errors import LeaderNotAvailableError, NoBrokersAvailable
+from kafka.errors import LeaderNotAvailableError, NoBrokersAvailable, UnrecognizedBrokerVersion
 from karapace.kafka_rest_apis import KafkaRestAdminClient
 from karapace.utils import Expiration
 from pathlib import Path
@@ -58,9 +58,12 @@ def wait_for_kafka(
             # - if the address/port does not point to a running server
             # LeaderNotAvailableError:
             # - if there is no leader yet
+            # UnrecognizedBrokerVersion:
+            # - happens during start-up of dockerized Kafka
             except (
                 NoBrokersAvailable,
                 LeaderNotAvailableError,
+                UnrecognizedBrokerVersion,
                 ValueError,
             ) as e:
                 print(f"Error checking kafka cluster: {e}")


### PR DESCRIPTION
### About this change - What it does

- Remove an incorrect assertion on number of data files in `Metadata.__post_init__`. Empty partitions will not have data files.
- Add integration test verifying a full backup-restoration cycle for an empty partition.