### PR TITLE
feature: Allow passing backup directory to backup commands

### DIFF
--- a/karapace/backup/api.py
+++ b/karapace/backup/api.py
@@ -48,6 +48,7 @@ __all__ = (
     "restore_backup",
     "normalize_location",
     "normalize_topic_name",
+    "locate_backup_file",
     "BackupVersion",
     "VerifyLevel",
 )
@@ -62,6 +63,35 @@ def normalize_location(input_location: str) -> Path | StdOut:
     if input_location in ("", "-"):
         return "-"
     return Path(input_location).absolute()
+
+
+# Type for a file that has been validated to exist, and to be a file (not a
+# directory). Note that this is no guarantee that the file remains in this
+# state throughout execution of the program.
+ExistingFile = NewType("ExistingFile", Path)
+
+
+def locate_backup_file(path: Path | StdOut) -> ExistingFile:
+    if isinstance(path, str):
+        raise BackupError("Cannot restore backups from stdin")
+
+    if path.is_dir():
+        metadata_files = tuple(path.glob("*.metadata"))
+        try:
+            (path,) = metadata_files
+        except ValueError as exc:
+            raise BackupError(
+                f"When a given location is a directory, it must contain exactly one "
+                f"metadata file, found {len(metadata_files)}."
+            ) from exc
+
+    if not path.exists():
+        raise BackupError("Backup location doesn't exist")
+
+    if not path.is_file():
+        raise BackupError("The normalized path is not a file")
+
+    return ExistingFile(path)
 
 
 TopicName = NewType("TopicName", str)
@@ -360,7 +390,7 @@ def _handle_producer_send(
 
 def restore_backup(
     config: Config,
-    backup_location: Path | StdOut,
+    backup_location: ExistingFile,
     topic_name: TopicName,
 ) -> None:
     """Restores a backup from the specified location into the configured topic.
@@ -369,12 +399,6 @@ def restore_backup(
         see Kafka implementation.
     :raises BackupTopicAlreadyExists: if backup version is V3 and topic already exists
     """
-    if isinstance(backup_location, str):
-        raise NotImplementedError("Cannot restore backups from stdin")
-
-    if not backup_location.exists():
-        raise BackupError("Backup location doesn't exist")
-
     key_formatter = (
         KeyFormatter() if topic_name == constants.DEFAULT_SCHEMA_TOPIC or config.get("force_key_correction", False) else None
     )
@@ -513,11 +537,7 @@ def create_backup(
     )
 
 
-def inspect(backup_location: Path | StdOut) -> None:
-    if isinstance(backup_location, str):
-        raise NotImplementedError("Cannot inspect backup via stdin")
-    if not backup_location.exists():
-        raise BackupError("Backup location doesn't exist")
+def inspect(backup_location: ExistingFile) -> None:
     backup_version = BackupVersion.identify(backup_location)
 
     if backup_version is not BackupVersion.V3:
@@ -568,11 +588,7 @@ class VerifyLevel(enum.Enum):
     record = "record"
 
 
-def verify(backup_location: Path | StdOut, level: VerifyLevel) -> None:
-    if isinstance(backup_location, str):
-        raise NotImplementedError("Cannot verify backup via stdin")
-    if not backup_location.exists():
-        raise BackupError("Backup location doesn't exist")
+def verify(backup_location: ExistingFile, level: VerifyLevel) -> None:
     backup_version = BackupVersion.identify(backup_location)
 
     if backup_version is not BackupVersion.V3:

--- a/karapace/backup/cli.py
+++ b/karapace/backup/cli.py
@@ -84,14 +84,14 @@ def dispatch(args: argparse.Namespace) -> None:
             replication_factor=args.replication_factor,
         )
     elif args.command == "inspect":
-        api.inspect(location)
+        api.inspect(api.locate_backup_file(location))
     elif args.command == "verify":
-        api.verify(location, level=VerifyLevel(args.level))
+        api.verify(api.locate_backup_file(location), level=VerifyLevel(args.level))
     elif args.command == "restore":
         config = get_config(args)
         api.restore_backup(
             config=config,
-            backup_location=location,
+            backup_location=api.locate_backup_file(location),
             topic_name=api.normalize_topic_name(args.topic, config),
         )
     elif args.command == "export-anonymized-avro-schemas":

--- a/tests/integration/backup/test_v3_backup.py
+++ b/tests/integration/backup/test_v3_backup.py
@@ -161,6 +161,7 @@ def test_roundtrip_from_kafka_state(
         f"{new_topic.name}:0.data",
     ]
     (metadata_path,) = backup_directory.glob("*.metadata")
+    assert metadata_path.exists()
 
     # Delete the source topic.
     admin_client.delete_topics([new_topic.name], timeout_ms=10_000)
@@ -176,7 +177,7 @@ def test_roundtrip_from_kafka_state(
             "--topic",
             new_topic.name,
             "--location",
-            str(metadata_path),
+            str(backup_directory),
         ],
         capture_output=True,
         check=True,


### PR DESCRIPTION


<!-- All contributors please complete these sections, including maintainers -->
### About this change - What it does

With this change, we allow passing the same path of the directory created when producing a backup, into restoration and inspection commands. Together with the fix in 5becdb4b, this makes V3 more similar to V2, in the respect of handling given paths.

Also improves test coverage of some of the helper functions in the internal API.