### PR TITLE
Fix partitioning if no key given

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -810,7 +810,8 @@ class UserRestProxy:
         for record in data["records"]:
             key = record.get("key")
             value = record.get("value")
-            key = await self.serialize(content_type, key, ser_format, key_schema_id)
+            if key is not None:
+                key = await self.serialize(content_type, key, ser_format, key_schema_id)
             value = await self.serialize(content_type, value, ser_format, value_schema_id)
             prepared_records.append((key, value, record.get("partition", default_partition)))
         return prepared_records

--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -37,8 +37,8 @@ class KafkaRestAdminClient(KafkaAdminClient):
             topic_config[name] = val
         return topic_config
 
-    def new_topic(self, name: str) -> None:
-        self.create_topics([NewTopic(name, 1, 1)])
+    def new_topic(self, name: str, *, num_partitions: int = 1, replication_factor: int = 1) -> None:
+        self.create_topics([NewTopic(name, num_partitions, replication_factor)])
 
     def cluster_metadata(self, topics: list[str] | None = None, retries: int = 0) -> dict:
         """Fetch cluster metadata and topic information for given topics or all topics if not given."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -202,10 +202,10 @@ def create_id_factory(prefix: str) -> Callable[[], str]:
     return create_name
 
 
-def new_topic(admin_client: KafkaRestAdminClient, prefix: str = "topic") -> str:
+def new_topic(admin_client: KafkaRestAdminClient, prefix: str = "topic", *, num_partitions: int = 1) -> str:
     topic_name = f"{new_random_name(prefix)}"
     try:
-        admin_client.new_topic(topic_name)
+        admin_client.new_topic(topic_name, num_partitions=num_partitions)
     except TopicAlreadyExistsError:
         pass
     return topic_name


### PR DESCRIPTION
# About this change - What it does

Default partitioner uses random partition if no key is given.  Add test that verifies random partition assignment with time-out.


# Why this way

Internally no key was converted to zero length byte array, which caused kafka library partitioner to handle it differently than no key.