### PR TITLE
test: test incompatible data publish on REST proxy

### DIFF
--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -412,6 +412,49 @@ async def test_publish_incompatible_schema(rest_async_client, admin_client):
     assert "Error when registering schema" in res_json["message"]
 
 
+async def test_publish_with_incompatible_data(rest_async_client, registry_async_client, admin_client):
+    topic_name = new_topic(admin_client)
+    subject_1 = f"{topic_name}-value"
+
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+    url = f"/topics/{topic_name}"
+
+    schema_1 = {
+        "type": "record",
+        "name": "Schema1",
+        "fields": [
+            {
+                "name": "name",
+                "type": "string",
+            },
+        ],
+    }
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_1}/versions",
+        json={"schema": json.dumps(schema_1)},
+    )
+    schema_1_id = res.json()["id"]
+
+    res = await rest_async_client.post(
+        url,
+        json={"value_schema_id": json.dumps(schema_1_id), "records": [{"value": {"name": "Foobar"}}]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200
+
+    res = await rest_async_client.post(
+        url,
+        json={"value_schema_id": json.dumps(schema_1_id), "records": [{"value": {"temperature": 25}}]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 422
+    res_json = res.json()
+    assert res_json["error_code"] == 42205
+    assert "message" in res_json
+    assert "Object does not fit to stored schema" in res_json["message"]
+
+
 async def test_brokers(rest_async_client):
     res = await rest_async_client.get("/brokers")
     assert res.ok


### PR DESCRIPTION
# About this change - What it does

Add a pin-point test for REST proxy when data given in publish request is incompatible with the given schema.

