### PR TITLE
feat(rest:consumer): add timestamp to consumer fetch response

### DIFF
--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -526,6 +526,7 @@ class ConsumerManager:
                         "topic": tp.topic,
                         "partition": tp.partition,
                         "offset": msg.offset,
+                        "timestamp": msg.timestamp,
                         "key": key,
                         "value": value,
                     }

--- a/tests/integration/test_rest_consumer.py
+++ b/tests/integration/test_rest_consumer.py
@@ -276,6 +276,10 @@ async def test_consume(rest_async_client, admin_client, producer, trail):
         data = resp.json()
         assert len(data) == len(values[fmt]), f"Expected {len(values[fmt])} element in response: {resp}"
         for i in range(len(values[fmt])):
+            assert data[i]["topic"] == topic_name
+            assert data[i]["partition"] == 0
+            assert data[i]["offset"] >= 0
+            assert data[i]["timestamp"] > 0
             assert deserializers[fmt](data[i]["value"]) == values[fmt][i], (
                 f"Extracted data {deserializers[fmt](data[i]['value'])}" f" does not match {values[fmt][i]} for format {fmt}"
             )


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
Adds `timestamp` to the consumer records response.

<!-- Provide the issue number below if it exists. -->

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
Timestamp is already available on the internal response. This implementation is following the same approach as e.g offset.