### PR TITLE
Remove Subjects info from the GET API response.

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -505,9 +505,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 status=HTTPStatus.NOT_FOUND,
             )
 
-        subjects = self.schema_registry.database.subjects_for_schema(parsed_schema_id)
-
-        response_body = {"schema": schema.schema_str, "subjects": subjects}
+        response_body = {"schema": schema.schema_str}
         if schema.schema_type is not SchemaType.AVRO:
             response_body["schemaType"] = schema.schema_type
         if schema.references:

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -956,14 +956,9 @@ async def test_union_comparing_to_other_types(registry_async_client: Client) -> 
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": json.dumps(schema)})
         assert res.status_code == 200
 
-        initial_schema_id = res.json()["id"]
-
         plain_schema = {"type": "string"}
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": json.dumps(plain_schema)})
         assert res.status_code == status_code
-
-        res = await registry_async_client.get(f"/schemas/ids/{initial_schema_id}")
-        assert subject in res.json()["subjects"]
 
     expected_results = [("BACKWARD", 200), ("FORWARD", 409), ("FULL", 409)]
     for compatibility, status_code in expected_results:
@@ -2352,7 +2347,7 @@ async def test_malformed_kafka_message(
         sleep=1,
     )
     res_data = res.json()
-    expected_payload = {"schema": json_encode({"foo": "bar"}, compact=True), "subjects": ["foo"]}
+    expected_payload = {"schema": json_encode({"foo": "bar"}, compact=True)}
     assert res_data == expected_payload, res_data
 
 


### PR DESCRIPTION
The subjects info in the API response is throwing an error in the customer client library. The fix is to remove it from the API response.

```
 curl https://avnadmin:AVNS_IwJRh4AyJf5kUh4@kafka-sebin-dev-sandbox.aivencloud.com:12696/schemas/ids/1 
{"schema":"{\"doc\":\"example\",\"fields\":[{\"default\":5,\"doc\":\"my test number\",\"name\":\"test\",\"namespace\":\"test\",\"type\":\"int\"}],\"name\":\"example\",\"namespace\":\"example\",\"type\":\"record\"}","subjects":["test"]}
```
```

Exception in thread "test_subject" org.apache.kafka.streams.errors.StreamsException: Deserialization exception handler is set to fail upon a deserialization error. If you would rather have the streaming pipeline continue after a deserialization error, please set the default.deserialization.exception.handler appropriately.
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "subjects" (class io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString), not marked as ignorable (4 known properties: "references", "schema", "schemaType", "maxId"])

```

