### PR TITLE
fix: remove 'subjects' from the default schema reply

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -472,6 +472,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 status=HTTPStatus.NOT_FOUND,
             )
 
+        include_subjects = request.query.get("includeSubjects", "false").lower() == "true"
         fetch_max_id = request.query.get("fetchMaxId", "false").lower() == "true"
         schema = self.schema_registry.schemas_get(parsed_schema_id, fetch_max_id=fetch_max_id)
 
@@ -505,9 +506,11 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 status=HTTPStatus.NOT_FOUND,
             )
 
-        subjects = self.schema_registry.database.subjects_for_schema(parsed_schema_id)
+        response_body = {"schema": schema.schema_str}
 
-        response_body = {"schema": schema.schema_str, "subjects": subjects}
+        if include_subjects:
+            response_body["subjects"] = self.schema_registry.database.subjects_for_schema(parsed_schema_id)
+
         if schema.schema_type is not SchemaType.AVRO:
             response_body["schemaType"] = schema.schema_type
         if schema.references:

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -115,7 +115,7 @@ class SchemaRegistryClient:
             raise SchemaRetrievalError(f"Failed to parse schema string from response: {json_result}") from e
 
     async def get_schema_for_id(self, schema_id: SchemaId) -> Tuple[TypedSchema, List[Subject]]:
-        result = await self.client.get(f"schemas/ids/{schema_id}")
+        result = await self.client.get(f"schemas/ids/{schema_id}", params={"includeSubjects": "True"})
         if not result.ok:
             raise SchemaRetrievalError(result.json()["message"])
         json_result = result.json()


### PR DESCRIPTION
The default reply for a schema given it's ID contains the `subjects` field. The default implementation of Jackson it's strict and translate the missing of explicit description of the object in the Java class in an exception, to be precise a `com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "subjects"` exception.

This fix restore the previous design that enable the field only if the `includeSubjects` header with a `true` value it's provided.