### PR TITLE
Resolve schema reference recursively during schema parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ venv
 .python-version
 .hypothesis/
 .DS_Store
+# ignoring protobuf generated files.
+runtime/

--- a/karapace/kafka_rest_apis/schema_cache.py
+++ b/karapace/kafka_rest_apis/schema_cache.py
@@ -61,7 +61,7 @@ class TopicSchemaCache:
 class SchemaCache(SchemaCacheProtocol):
     def __init__(self) -> None:
         self._schema_hash_str_to_id: Dict[str, SchemaId] = {}
-        self._id_to_schema_str: MutableMapping[SchemaId, TypedSchema] = TTLCache(maxsize=10000, ttl=600)
+        self._id_to_schema_str: MutableMapping[SchemaId, TypedSchema] = TTLCache(maxsize=100, ttl=600)
 
     def get_schema_id(self, schema: TypedSchema) -> Optional[SchemaId]:
         fingerprint = hashlib.sha1(str(schema).encode("utf8")).hexdigest()

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -131,7 +131,7 @@ class ProtobufSchema:
     def collect_dependencies(self, verifier: ProtobufDependencyVerifier) -> None:
         if self.dependencies:
             for key in self.dependencies:
-                self.dependencies[key].schema.schema.collect_dependencies(verifier)
+                self.dependencies[key].get_schema().schema.collect_dependencies(verifier)
 
         for i in self.proto_file_element.imports:
             verifier.add_import(i)

--- a/karapace/schema_references.py
+++ b/karapace/schema_references.py
@@ -8,11 +8,10 @@ See LICENSE for details
 from __future__ import annotations
 
 from karapace.dataclasses import default_dataclass
-from karapace.typing import JsonData, ResolvedVersion, SchemaId, Subject
-from typing import List, Mapping, NewType, TypeVar
+from karapace.typing import JsonData, JsonObject, ResolvedVersion, SchemaId, Subject
+from typing import cast, List, Mapping, NewType, TypeVar
 
 Referents = NewType("Referents", List[SchemaId])
-
 
 T = TypeVar("T")
 
@@ -63,6 +62,14 @@ class Reference:
             "subject": self.subject,
             "version": self.version,
         }
+
+    @staticmethod
+    def from_dict(data: JsonObject) -> Reference:
+        return Reference(
+            name=str(data["name"]),
+            subject=Subject(str(data["subject"])),
+            version=ResolvedVersion(cast(int, data["version"])),
+        )
 
 
 def reference_from_mapping(

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -5,17 +5,19 @@ See LICENSE for details
 from aiohttp import BasicAuth
 from avro.io import BinaryDecoder, BinaryEncoder, DatumReader, DatumWriter
 from cachetools import TTLCache
+from functools import lru_cache
 from google.protobuf.message import DecodeError
 from jsonschema import ValidationError
 from karapace.client import Client
+from karapace.dependency import Dependency
 from karapace.errors import InvalidReferences
 from karapace.protobuf.exception import ProtobufTypeException
 from karapace.protobuf.io import ProtobufDatumReader, ProtobufDatumWriter
 from karapace.schema_models import InvalidSchema, ParsedTypedSchema, SchemaType, TypedSchema, ValidatedTypedSchema
-from karapace.schema_references import Reference, reference_from_mapping
-from karapace.typing import SchemaId, Subject
+from karapace.schema_references import LatestVersionReference, Reference, reference_from_mapping
+from karapace.typing import ResolvedVersion, SchemaId, Subject
 from karapace.utils import json_decode, json_encode
-from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple
+from typing import Any, Callable, Dict, List, MutableMapping, Optional, Set, Tuple
 from urllib.parse import quote
 
 import asyncio
@@ -101,18 +103,78 @@ class SchemaRegistryClient:
             raise SchemaRetrievalError(result.json())
         return SchemaId(result.json()["id"])
 
-    async def get_latest_schema(self, subject: str) -> Tuple[SchemaId, ParsedTypedSchema]:
-        result = await self.client.get(f"subjects/{quote(subject)}/versions/latest")
+    async def _get_schema_r(
+        self,
+        subject: Subject,
+        explored_schemas: Set[Tuple[Subject, Optional[ResolvedVersion]]],
+        version: Optional[ResolvedVersion] = None,
+    ) -> Tuple[SchemaId, ValidatedTypedSchema, ResolvedVersion]:
+        if (subject, version) in explored_schemas:
+            raise InvalidSchema(
+                f"The schema has at least a cycle in dependencies, "
+                f"one path of the cycle is given by the following nodes: {explored_schemas}"
+            )
+
+        explored_schemas = explored_schemas | {(subject, version)}
+
+        version_str = str(version) if version is not None else "latest"
+        result = await self.client.get(f"subjects/{quote(subject)}/versions/{version_str}")
+
         if not result.ok:
             raise SchemaRetrievalError(result.json())
+
         json_result = result.json()
-        if "id" not in json_result or "schema" not in json_result:
+        if "id" not in json_result or "schema" not in json_result or "version" not in json_result:
             raise SchemaRetrievalError(f"Invalid result format: {json_result}")
+
+        if "references" in json_result:
+            references = [Reference.from_dict(data) for data in json_result["references"]]
+            dependencies = {}
+            for reference in references:
+                _, schema, version = await self._get_schema_r(reference.subject, explored_schemas, reference.version)
+                dependencies[reference.name] = Dependency(
+                    name=reference.name, subject=reference.subject, version=version, target_schema=schema
+                )
+        else:
+            references = None
+            dependencies = None
+
         try:
             schema_type = SchemaType(json_result.get("schemaType", "AVRO"))
-            return SchemaId(json_result["id"]), ParsedTypedSchema.parse(schema_type, json_result["schema"])
+            return (
+                SchemaId(json_result["id"]),
+                ValidatedTypedSchema.parse(
+                    schema_type,
+                    json_result["schema"],
+                    references=references,
+                    dependencies=dependencies,
+                ),
+                ResolvedVersion(json_result["version"]),
+            )
         except InvalidSchema as e:
             raise SchemaRetrievalError(f"Failed to parse schema string from response: {json_result}") from e
+
+    @lru_cache(maxsize=100)
+    async def get_schema(
+        self,
+        subject: Subject,
+        version: Optional[ResolvedVersion] = None,
+    ) -> Tuple[SchemaId, ValidatedTypedSchema, ResolvedVersion]:
+        """
+        Retrieves the schema and its dependencies for the specified subject.
+
+        Args:
+            subject (Subject): The subject for which to retrieve the schema.
+            version (Optional[ResolvedVersion]): The specific version of the schema to retrieve.
+                                                    If None, the latest available schema will be returned.
+
+        Returns:
+            Tuple[SchemaId, ValidatedTypedSchema, ResolvedVersion]: A tuple containing:
+                - SchemaId: The ID of the retrieved schema.
+                - ValidatedTypedSchema: The retrieved schema, validated and typed.
+                - ResolvedVersion: The version of the schema that was retrieved.
+        """
+        return await self._get_schema_r(subject, set(), version)
 
     async def get_schema_for_id(self, schema_id: SchemaId) -> Tuple[TypedSchema, List[Subject]]:
         result = await self.client.get(f"schemas/ids/{schema_id}", params={"includeSubjects": "True"})
@@ -138,15 +200,24 @@ class SchemaRegistryClient:
                         raise InvalidReferences from exc
                     parsed_references.append(reference)
             if parsed_references:
-                return (
-                    ParsedTypedSchema.parse(
-                        schema_type,
-                        json_result["schema"],
-                        references=parsed_references,
-                    ),
-                    subjects,
-                )
-            return ParsedTypedSchema.parse(schema_type, json_result["schema"]), subjects
+                dependencies = {}
+
+                for reference in parsed_references:
+                    if isinstance(reference, LatestVersionReference):
+                        _, schema, version = await self.get_schema(reference.subject)
+                    else:
+                        _, schema, version = await self.get_schema(reference.subject, reference.version)
+
+                    dependencies[reference.name] = Dependency(reference.name, reference.subject, version, schema)
+            else:
+                dependencies = None
+
+            return (
+                ParsedTypedSchema.parse(
+                    schema_type, json_result["schema"], references=parsed_references, dependencies=dependencies
+                ),
+                subjects,
+            )
         except InvalidSchema as e:
             raise SchemaRetrievalError(f"Failed to parse schema string from response: {json_result}") from e
 
@@ -204,9 +275,9 @@ class SchemaRegistrySerializer:
 
         return Subject(f"{self.subject_name_strategy(topic_name, namespace)}-{subject_type}")
 
-    async def get_schema_for_subject(self, subject: str) -> TypedSchema:
+    async def get_schema_for_subject(self, subject: Subject) -> TypedSchema:
         assert self.registry_client, "must not call this method after the object is closed."
-        schema_id, schema = await self.registry_client.get_latest_schema(subject)
+        schema_id, schema, _ = await self.registry_client.get_schema(subject)
         async with self.state_lock:
             schema_ser = str(schema)
             self.schemas_to_ids[schema_ser] = schema_id

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -17,7 +17,7 @@ async def test_remote_client(registry_async_client: Client) -> None:
     assert sc_id >= 0
     stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_avro, f"stored schema {stored_schema.to_dict()} is not {schema_avro.to_dict()}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    stored_id, stored_schema, _ = await reg_cli.get_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro
 
@@ -31,6 +31,6 @@ async def test_remote_client_tls(registry_async_client_tls: Client) -> None:
     assert sc_id >= 0
     stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_avro, f"stored schema {stored_schema.to_dict()} is not {schema_avro.to_dict()}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    stored_id, stored_schema = await reg_cli.get_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro

--- a/tests/integration/test_client_protobuf.py
+++ b/tests/integration/test_client_protobuf.py
@@ -18,7 +18,7 @@ async def test_remote_client_protobuf(registry_async_client):
     assert sc_id >= 0
     stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    stored_id, stored_schema, _ = await reg_cli.get_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_protobuf
 
@@ -33,6 +33,6 @@ async def test_remote_client_protobuf2(registry_async_client):
     assert sc_id >= 0
     stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    stored_id, stored_schema, _ = await reg_cli.get_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_protobuf_after

--- a/tests/integration/test_rest_consumer_protobuf.py
+++ b/tests/integration/test_rest_consumer_protobuf.py
@@ -2,13 +2,20 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
+
+from karapace.client import Client
+from karapace.kafka_rest_apis import KafkaRestAdminClient
+from karapace.protobuf.kotlin_wrapper import trim_margin
+from tests.integration.test_rest import NEW_TOPIC_TIMEOUT
 from tests.utils import (
     new_consumer,
+    new_random_name,
     new_topic,
     repeat_until_successful_request,
     REST_HEADERS,
     schema_data,
     schema_data_second,
+    wait_for_topics,
 )
 
 import pytest
@@ -74,3 +81,184 @@ async def test_publish_consume_protobuf_second(rest_async_client, admin_client, 
     data_values = [x["value"] for x in data]
     for expected, actual in zip(publish_payload, data_values):
         assert expected == actual, f"Expecting {actual} to be {expected}"
+
+
+async def test_publish_protobuf_with_references(
+    rest_async_client: Client,
+    admin_client: KafkaRestAdminClient,
+    registry_async_client: Client,
+):
+    topic_name = new_topic(admin_client)
+    subject_reference = "reference"
+    subject_topic = f"{topic_name}-value"
+
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    reference_schema = trim_margin(
+        """
+        |syntax = "proto3";
+        |message Reference {
+        |     string name = 1;
+        |}
+        |"""
+    )
+
+    topic_schema = trim_margin(
+        """
+        |syntax = "proto3";
+        |import "Reference.proto";
+        |message Example {
+        |     Reference example = 1;
+        |}
+        |"""
+    )
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_reference}/versions", json={"schemaType": "PROTOBUF", "schema": reference_schema}
+    )
+    assert "id" in res.json()
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_topic}/versions",
+        json={
+            "schemaType": "PROTOBUF",
+            "schema": topic_schema,
+            "references": [
+                {
+                    "name": "Reference.proto",
+                    "subject": subject_reference,
+                    "version": 1,
+                }
+            ],
+        },
+    )
+    topic_schema_id = res.json()["id"]
+
+    example_message = {"value_schema_id": topic_schema_id, "records": [{"value": {"example": {"name": "myname"}}}]}
+
+    res = await rest_async_client.post(
+        f"/topics/{topic_name}",
+        json=example_message,
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200
+
+
+async def test_publish_and_consume_protobuf_with_recursive_references(
+    rest_async_client: Client,
+    admin_client: KafkaRestAdminClient,
+    registry_async_client: Client,
+):
+    topic_name = new_topic(admin_client)
+    subject_meta_reference = "meta-reference"
+    subject_inner_reference = "inner-reference"
+    subject_topic = f"{topic_name}-value"
+
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    meta_reference = trim_margin(
+        """
+        |syntax = "proto3";
+        |message MetaReference {
+        |     string name = 1;
+        |}
+        |"""
+    )
+
+    inner_reference = trim_margin(
+        """
+        |syntax = "proto3";
+        |import "MetaReference.proto";
+        |message InnerReference {
+        |     MetaReference reference = 1;
+        }
+        |"""
+    )
+
+    topic_schema = trim_margin(
+        """
+        |syntax = "proto3";
+        |import "InnerReference.proto";
+        |message Example {
+        |     InnerReference example = 1;
+        |}
+        |"""
+    )
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_meta_reference}/versions", json={"schemaType": "PROTOBUF", "schema": meta_reference}
+    )
+    assert "id" in res.json()
+    res = await registry_async_client.post(
+        f"subjects/{subject_inner_reference}/versions",
+        json={
+            "schemaType": "PROTOBUF",
+            "schema": inner_reference,
+            "references": [
+                {
+                    "name": "MetaReference.proto",
+                    "subject": subject_meta_reference,
+                    "version": 1,
+                }
+            ],
+        },
+    )
+    assert "id" in res.json()
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_topic}/versions",
+        json={
+            "schemaType": "PROTOBUF",
+            "schema": topic_schema,
+            "references": [
+                {
+                    "name": "InnerReference.proto",
+                    "subject": subject_inner_reference,
+                    "version": 1,
+                }
+            ],
+        },
+    )
+    topic_schema_id = res.json()["id"]
+
+    produced_message = {"example": {"reference": {"name": "myname"}}}
+    example_message = {
+        "value_schema_id": topic_schema_id,
+        "records": [{"value": produced_message}],
+    }
+
+    res = await rest_async_client.post(
+        f"/topics/{topic_name}",
+        json=example_message,
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200
+
+    group = new_random_name("protobuf_recursive_reference_message")
+    instance_id = await new_consumer(rest_async_client, group)
+
+    subscribe_path = f"/consumers/{group}/instances/{instance_id}/subscription"
+
+    consume_path = f"/consumers/{group}/instances/{instance_id}/records?timeout=1000"
+
+    res = await rest_async_client.post(subscribe_path, json={"topics": [topic_name]}, headers=REST_HEADERS["binary"])
+    assert res.ok
+
+    resp = await rest_async_client.get(consume_path, headers=REST_HEADERS["avro"])
+    data = resp.json()
+
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+    msg = data[0]
+
+    assert "key" in msg
+    assert "offset" in msg
+    assert "topic" in msg
+    assert "value" in msg
+    assert "timestamp" in msg
+
+    assert msg["key"] is None, "no key defined in production"
+    assert msg["offset"] == 0 and msg["partition"] == 0, "first message of the only partition available"
+    assert msg["topic"] == topic_name
+    assert msg["value"] == produced_message


### PR DESCRIPTION
The previous implementation of the schema resolver wasn't resolving recursively the entities of a schema that was containing references. With that implementation the schema are recursively resolved and the references are sent to the parser.

Closes #679